### PR TITLE
test: tests trustify-cli help

### DIFF
--- a/backend/cli/Cargo.toml
+++ b/backend/cli/Cargo.toml
@@ -14,3 +14,6 @@ log = "0.4.19"
 serde_json = "1.0.104"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/backend/cli/tests/cli.rs
+++ b/backend/cli/tests/cli.rs
@@ -1,0 +1,28 @@
+use pretty_assertions::assert_eq;
+use std::env;
+use tokio::process::Command;
+
+const TRUSTIFY_CLI_HELP: &str = "huevos
+
+Usage: trustify-cli <COMMAND>
+
+Commands:
+  importer  
+  server    Run the API server
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+#[tokio::test]
+async fn trustify_cli_help() {
+    let output = Command::new(env!("CARGO_BIN_EXE_trustify-cli"))
+        .output()
+        .await
+        .expect("");
+
+    let output_str = String::from_utf8_lossy(&output.stderr).to_string();
+    assert_eq!(TRUSTIFY_CLI_HELP, output_str);
+}


### PR DESCRIPTION
* Adds pretty_assertions as dev-dependency for easy cli-diff-tests-results visualization

![2024-03-07_10-04](https://github.com/trustification/trustify/assets/6443576/cc81479a-8444-424e-981a-ec346e390347)
