### PR TITLE
chore: enable readable debug log

### DIFF
--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 trustify-entity = { path = "../entity"}
 trustify-common = { path = "../common" }
 trustify-migration = { path = "../migration" }
-sea-orm = { version = "0.12", features = [ "sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros" ] }
+sea-orm = { version = "0.12", features = [ "sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros", "debug-print" ] }
 sea-query = "0.30.0"
 sea-orm-migration = "0.12.2"
 tokio = { version = "1.30.0", features = ["full"] }


### PR DESCRIPTION
When using the `trustify-cli` command and enabling `RUST_LOG` we get unreadable `sqlx` debug logs:

```console
INFO  sqlx::query] summary="SELECT \"package\".\"id\", \"package\".\"type\", \"package\".\"namespace\", …" db.statement="\n\nSELECT\n  \"package\".\"id\",\n  \"package\".\"type\",\n  \"package\".\"namespace\",\n  \"package\".\"name\"\nFROM\n  \"package\"\nWHERE\n  \"package\".\"type\" = $1\n  AND \"package\".\"namespace\" = $2\n  AND \"package\".\"name\" = $3\nLIMIT\n
```

With this change we can see:

```console
DEBUG sea_orm::driver::sqlx_postgres] SELECT "package"."id", "package"."type", "package"."namespace", "package"."name" FROM "package" WHERE "package"."type" = 'maven' AND "package"."namespace" = 'com.fasterxml.jackson.dataformat' AND "package"."name" = 'jackson-dataformat-yaml' LIMIT 1
```