### PR TITLE
ci: disable npm lint, as we don't make use of its results right now

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,8 +29,8 @@ jobs:
         run: ./scripts/verify_lock.mjs
       - name: Install
         run: npm clean-install --ignore-scripts
-      - name: Lint sources
-        run: npm run lint
+#      - name: Lint sources
+#        run: npm run lint
       - name: Build
         run: npm run build
       - name: Test


### PR DESCRIPTION
As mentioned in #19 I find it pretty hard to work with PRs because of those unrelated warnings, which show up on every PR. Even though no changes have been made on those files.

My proposal here is to either merge this PR and disable this step for now, until we find some time to fix those warnigns. Or find a switch for "warnings as errors" and fail the build in the case of violations.

Spamming PRs and not using the outcome to improve the code seems counterproductive.