### PR TITLE
Automate labeling and CI conditional execution

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,14 @@
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - frontend/**
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - backend/**

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,13 +7,16 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/**"
 
 env:
   CI: true
 
 jobs:
-  test:
-    name: test
+  ci:
+    name: ci
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "pull request labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yaml


### PR DESCRIPTION
Not sure if you guys consider this PR adds any value or just add lines of code for a problem that might not exist. Feel free to not merge the PR or require changes 

- Add `ci`, `frontend`, or `backend` labels to each PR depending on the directories touched by the PR. Just to add some classification of PRs
- Execute backend/frontend unit tests only when the appropriate directory was touched.
  - If a file in the backend folder has been touched, there is no reason to execute the UI tests. It only slows down the total execution time of the set of GH actions.