### PR TITLE
GET /advisories

### DIFF
--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = "0.1.74"
 lenient_semver = "0.4.2"
 cpe = "0.1.3"
 postgresql_embedded = { version = "0.6.2", features = ["blocking", "bundled", "tokio" ] }
+serde = { version = "1.0.197", features = ["derive"] }
 
 
 [dev-dependencies]

--- a/backend/api/src/db.rs
+++ b/backend/api/src/db.rs
@@ -5,6 +5,7 @@ use sea_orm::{
     ExecResult, FromQueryResult, ModelTrait, PaginatorTrait, QueryResult, Select, Statement,
 };
 use sea_query::Iden;
+use serde::Deserialize;
 use std::fmt::Write;
 use std::marker::PhantomData;
 use std::process::Output;
@@ -65,20 +66,25 @@ impl ConnectionTrait for ConnectionOrTransaction<'_> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
 pub struct Paginated {
     pub page_size: u64,
     pub page: u64,
 }
 
+impl Default for Paginated {
+    fn default() -> Self {
+        Paginated {
+            page: 1,
+            page_size: 10,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PaginatedResults<R> {
     pub results: Vec<R>,
-    pub page: u64,
     pub num_items: u64,
-    pub num_pages: u64,
-    pub prev_page: Option<Paginated>,
-    pub next_page: Option<Paginated>,
 }
 
 pub struct QualifiedPackageTransitive;

--- a/backend/api/src/system/package/mod.rs
+++ b/backend/api/src/system/package/mod.rs
@@ -432,25 +432,7 @@ impl PackageContext {
                 .drain(0..)
                 .map(|each| (self, each).into())
                 .collect(),
-            page: paginated.page_size,
             num_items,
-            num_pages,
-            prev_page: if paginated.page > 0 {
-                Some(Paginated {
-                    page_size: paginated.page_size,
-                    page: paginated.page - 1,
-                })
-            } else {
-                None
-            },
-            next_page: if paginated.page + 1 < num_pages {
-                Some(Paginated {
-                    page_size: paginated.page_size,
-                    page: paginated.page + 1,
-                })
-            } else {
-                None
-            },
         })
     }
 
@@ -753,29 +735,6 @@ mod tests {
             )
             .await?;
 
-        assert!(paginated.prev_page.is_none());
-        assert_eq!(
-            paginated.next_page,
-            Some(Paginated {
-                page_size: 50,
-                page: 1,
-            })
-        );
-        assert_eq!(50, paginated.results.len());
-
-        let next_paginated = pkg
-            .get_versions_paginated(paginated.next_page.unwrap(), Transactional::None)
-            .await?;
-
-        assert_eq!(
-            next_paginated.prev_page,
-            Some(Paginated {
-                page_size: 50,
-                page: 0,
-            })
-        );
-
-        assert!(next_paginated.next_page.is_some());
         assert_eq!(50, paginated.results.len());
 
         Ok(())

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 trustify-api = { path = "../api"}
 trustify-common = { path = "../common"}
+trustify-entity = { path = "../entity"}
 
 actix-web = "4"
 anyhow = "1.0.72"

--- a/backend/server/src/dto.rs
+++ b/backend/server/src/dto.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+use trustify_entity as entity;
+
+#[derive(Serialize, Deserialize)]
+pub struct AdvisoryDto {
+    pub id: i32,
+    // pub aggregated_severity: String,
+    // pub revision_date: String,
+}
+
+impl From<entity::advisory::Model> for AdvisoryDto {
+    fn from(value: entity::advisory::Model) -> Self {
+        Self { id: value.id }
+    }
+}

--- a/backend/server/src/lib.rs
+++ b/backend/server/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use trustify_api::system::{DbStrategy, InnerSystem};
 use trustify_common::config::Database;
 
+pub mod dto;
 pub mod server;
 
 /// Run the API server

--- a/backend/server/src/server/read/advisory.rs
+++ b/backend/server/src/server/read/advisory.rs
@@ -1,0 +1,28 @@
+use crate::dto::AdvisoryDto;
+use crate::server::Error;
+use crate::AppState;
+use actix_web::{get, post, web, HttpResponse, Responder};
+use trustify_api::db::{Paginated, Transactional};
+
+#[utoipa::path(responses((status = 200, description = "List advisories")), )]
+#[get("/advisories")]
+pub async fn list_advisories(
+    state: web::Data<AppState>,
+    paginated: web::Query<Paginated>,
+) -> Result<impl Responder, Error> {
+    let advisories = state
+        .system
+        .list_advisories(paginated.into_inner(), Transactional::None)
+        .await
+        .map_err(Error::System)?;
+
+    Ok(HttpResponse::Ok()
+        .append_header(("x-total", advisories.num_items))
+        .json(
+            advisories
+                .results
+                .into_iter()
+                .map(|ctx| AdvisoryDto::from(ctx.advisory))
+                .collect::<Vec<_>>(),
+        ))
+}

--- a/backend/server/src/server/read/mod.rs
+++ b/backend/server/src/server/read/mod.rs
@@ -1,2 +1,3 @@
+pub mod advisory;
 pub mod package;
 pub mod vulnerability;


### PR DESCRIPTION
Hi tried to put my hands into generating REST endpoints for the advisories. Some questions came to my mind:

- Do we really need the following data inside the Paginated Object?

```rust
pub num_pages: u64,
pub prev_page: Option<Paginated>,
pub next_page: Option<Paginated>, 
```
From the REST point of view, whoever is making a request can infer all those 3 fields based on data being send and the first response of the server.

- At the moment, we save (in the DB) limited data about `Advisory` . We will definitely need to extract more fields out of the CSAF files. I could not find any code where we are extracting data from CSAF files and then map them to the DB or object. Is something like that already existing somewhere or it needs to be implemented? 

```rust
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: i32,
    pub identifier: String,
    pub location: String,
    pub sha256: String,
}
```

I'm not expecting this PR to be merged as it does not contain the fields I expect to expose through the REST endpoints, but I just wanted to open this PR for my questions to make more sense.

