### PR TITLE
PostgreSQL embedded: tests use system temp dir for installation

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -41,6 +41,6 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used
     - name: Test
-      run: cargo test -- --test-threads=1 --nocapture
+      run: cargo test -- --nocapture
       env:
         RUST_LOG: debug

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = "0.1.74"
 lenient_semver = "0.4.2"
 cpe = "0.1.3"
 postgresql_embedded = { version = "0.6.2", features = ["blocking", "bundled", "tokio" ] }
+tempfile = "3"
 
 
 [dev-dependencies]

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -99,6 +99,7 @@ impl Graph {
             username: "postgres".to_string(),
             password: "trustify".to_string(),
             temporary: true,
+            installation_dir: tempfile::tempdir()?.into_path(),
             ..Default::default()
         };
 


### PR DESCRIPTION
Investigating the failure in https://github.com/trustification/trustify/actions/runs/8234967143/job/22517985508?pr=40#step:9:33, it turned out it was related to multi tests concurrently extracting PostgreSQL to the same folder.

Installing tests to extract PostgreSQL in folder within the system temporary directory enables tests to be executed concurrently.

The drawback with this implementation is that `into_path` consumes `TempDir` hence it won't be automatically deleted at the end of the test but considering the installation directory is within the system temporary directory, I think this could be considered acceptable in the context of tests execution.