### PR TITLE
Enable feature to fix build within child workspace

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.19"
 native-tls = "0.2"
 packageurl = "0.3.0"
 pem = "3"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["native-tls"] }
 sea-orm = { version = "0.12", features = ["sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"


### PR DESCRIPTION
Build works fine from root, but fails from beneath `graph` and `common` workspaces without enabling the `native-tls` feature for `reqwest` crate.