### PR TITLE
build(fix): Enable feature to fix build within child workspace

### DIFF
--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -28,7 +28,7 @@ prometheus = "0.13.3"
 reqwest = "0.11"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-tokio = { version = "1", features = ["time", "signal"] }
+tokio = { version = "1", features = ["time", "signal", "macros"] }
 tracing-bunyan-formatter = "0.3.7"
 tracing-opentelemetry = "0.23"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "tracing-log"] }


### PR DESCRIPTION
Same situation as #64 

```
error[E0432]: unresolved import `tokio::select`
 --> common/infrastructure/src/health/checks/local.rs:9:5
  |
9 | use tokio::select;
  |     ^^^^^^^^^^^^^ no `select` in the root

error: cannot determine resolution for the macro `select`
   --> common/infrastructure/src/health/checks/local.rs:102:17
    |
102 |                 select! {
    |                 ^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports
```

