### PR TITLE
Convert fn's to take Purl's to simplify fallible string conversions

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,3 +22,5 @@ thiserror = "1"
 
 [dev-dependencies]
 serde_json = "1.0.104"
+test-log = { version = "0.2.15", features = ["env_logger", "trace"] }
+tokio = { version = "1.30.0", features = ["full"] }

--- a/common/src/package/mod.rs
+++ b/common/src/package/mod.rs
@@ -172,12 +172,12 @@ pub struct Claimant {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::package::{Assertion, Claimant, PackageVulnerabilityAssertions};
+    use test_log::test;
 
-    #[test]
-    fn not_affected() {
+    #[test(tokio::test)]
+    async fn not_affected() -> Result<(), anyhow::Error> {
         let assertions = PackageVulnerabilityAssertions {
             assertions: vec![
                 Assertion::Affected {
@@ -220,16 +220,14 @@ mod tests {
             ],
         };
 
-        let claimants = assertions
-            .not_affected_claimants_for_version("1.2")
-            .unwrap();
+        let claimants = assertions.not_affected_claimants_for_version("1.2")?;
 
         assert_eq!(2, claimants.len());
 
-        let claimants = assertions.affected_claimants_for_version("1.2").unwrap();
+        let claimants = assertions.affected_claimants_for_version("1.2")?;
         assert_eq!(0, claimants.len());
 
-        let claimants = assertions.affected_claimants_for_version("1.3").unwrap();
-        assert_eq!(1, claimants.len());
+        let claimants = assertions.affected_claimants_for_version("1.3")?;
+        Ok(assert_eq!(1, claimants.len()))
     }
 }

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -164,12 +164,12 @@ impl From<PackageUrl<'_>> for Purl {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::purl::Purl;
+    use test_log::test;
 
-    #[test]
-    fn purl_serde() {
+    #[test(tokio::test)]
+    async fn purl_serde() -> Result<(), anyhow::Error> {
         let purl: Purl = serde_json::from_str(
             r#"
             "pkg://maven/io.quarkus/quarkus-core@1.2.3?foo=bar"
@@ -185,14 +185,12 @@ mod tests {
 
         assert_eq!(purl.qualifiers.get("foo"), Some(&"bar".to_string()));
 
-        let purl: Purl = "pkg://maven/io.quarkus/quarkus-core@1.2.3?foo=bar"
-            .try_into()
-            .unwrap();
+        let purl: Purl = "pkg://maven/io.quarkus/quarkus-core@1.2.3?foo=bar".try_into()?;
         let json = serde_json::to_string(&purl).unwrap();
 
-        assert_eq!(
+        Ok(assert_eq!(
             json,
             r#""pkg://maven/io.quarkus/quarkus-core@1.2.3?foo=bar""#
-        );
+        ))
     }
 }

--- a/graph/src/graph/advisory/advisory_vulnerability.rs
+++ b/graph/src/graph/advisory/advisory_vulnerability.rs
@@ -28,13 +28,11 @@ impl<'g> From<(&AdvisoryContext<'g>, entity::advisory_vulnerability::Model)>
 }
 
 impl<'g> AdvisoryVulnerabilityContext<'g> {
-    pub async fn get_fixed_package_version<P: Into<Purl>>(
+    pub async fn get_fixed_package_version(
         &self,
-        pkg: P,
+        purl: Purl,
         tx: Transactional<'_>,
     ) -> Result<Option<FixedPackageVersionContext>, Error> {
-        let purl = pkg.into();
-
         if let Some(package_version) = self.advisory.graph.get_package_version(purl, tx).await? {
             Ok(entity::fixed_package_version::Entity::find()
                 .filter(
@@ -52,13 +50,11 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn get_not_affected_package_version<P: Into<Purl>>(
+    pub async fn get_not_affected_package_version(
         &self,
-        pkg: P,
+        purl: Purl,
         tx: Transactional<'_>,
     ) -> Result<Option<NotAffectedPackageVersionContext>, Error> {
-        let purl = pkg.into();
-
         if let Some(package_version) = self.advisory.graph.get_package_version(purl, tx).await? {
             Ok(entity::not_affected_package_version::Entity::find()
                 .filter(
@@ -109,12 +105,11 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn ingest_not_affected_package_version<P: Into<Purl>>(
+    pub async fn ingest_not_affected_package_version(
         &self,
-        pkg: P,
+        purl: Purl,
         tx: Transactional<'_>,
     ) -> Result<NotAffectedPackageVersionContext, Error> {
-        let purl = pkg.into();
         if let Some(found) = self
             .get_not_affected_package_version(purl.clone(), tx)
             .await?
@@ -137,12 +132,11 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .into())
     }
 
-    pub async fn ingest_fixed_package_version<P: Into<Purl>>(
+    pub async fn ingest_fixed_package_version(
         &self,
-        pkg: P,
+        purl: Purl,
         tx: Transactional<'_>,
     ) -> Result<FixedPackageVersionContext, Error> {
-        let purl = pkg.into();
         if let Some(found) = self.get_fixed_package_version(purl.clone(), tx).await? {
             return Ok(found);
         }
@@ -162,14 +156,13 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .into())
     }
 
-    pub async fn ingest_affected_package_range<P: Into<Purl>>(
+    pub async fn ingest_affected_package_range(
         &self,
-        pkg: P,
+        purl: Purl,
         start: &str,
         end: &str,
         tx: Transactional<'_>,
     ) -> Result<AffectedPackageVersionRangeContext, Error> {
-        let purl = pkg.into();
         if let Some(found) = self
             .get_affected_package_range(purl.clone(), start, end, tx)
             .await?

--- a/graph/src/graph/advisory/mod.rs
+++ b/graph/src/graph/advisory/mod.rs
@@ -474,7 +474,7 @@ mod test {
 
         let affected1 = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -483,7 +483,7 @@ mod test {
 
         let affected2 = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -492,7 +492,7 @@ mod test {
 
         let affected3 = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-addons",
+                "pkg://maven/io.quarkus/quarkus-addons".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -530,7 +530,7 @@ mod test {
 
         let affected = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -539,21 +539,21 @@ mod test {
 
         let fixed1 = advisory_vulnerability
             .ingest_fixed_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.2.0",
+                "pkg://maven/io.quarkus/quarkus-core@1.2.0".try_into()?,
                 Transactional::None,
             )
             .await?;
 
         let fixed2 = advisory_vulnerability
             .ingest_fixed_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.2.0",
+                "pkg://maven/io.quarkus/quarkus-core@1.2.0".try_into()?,
                 Transactional::None,
             )
             .await?;
 
         let fixed3 = advisory_vulnerability
             .ingest_fixed_package_version(
-                "pkg://maven/io.quarkus/quarkus-addons@1.2.0",
+                "pkg://maven/io.quarkus/quarkus-addons@1.2.0".try_into()?,
                 Transactional::None,
             )
             .await?;
@@ -615,7 +615,7 @@ mod test {
 
         advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -624,7 +624,7 @@ mod test {
 
         advisory_vulnerability
             .ingest_not_affected_package_version(
-                "pkg://maven/.io.quarkus/quarkus-core@1.1.9",
+                "pkg://maven/.io.quarkus/quarkus-core@1.1.9".try_into()?,
                 Transactional::None,
             )
             .await?;
@@ -655,7 +655,7 @@ mod test {
 
         advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -664,7 +664,7 @@ mod test {
 
         advisory_vulnerability
             .ingest_not_affected_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.1.9",
+                "pkg://maven/io.quarkus/quarkus-core@1.1.9".try_into()?,
                 Transactional::None,
             )
             .await?;

--- a/graph/src/graph/package/package_version.rs
+++ b/graph/src/graph/package/package_version.rs
@@ -233,7 +233,7 @@ mod tests {
 
         redhat_advisory_vulnerability
             .ingest_not_affected_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.2",
+                "pkg://maven/io.quarkus/quarkus-core@1.2".try_into()?,
                 Transactional::None,
             )
             .await?;
@@ -248,14 +248,14 @@ mod tests {
 
         ghsa_advisory_vulnerability
             .ingest_not_affected_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.2.2",
+                "pkg://maven/io.quarkus/quarkus-core@1.2.2".try_into()?,
                 Transactional::None,
             )
             .await?;
 
         let pkg_version = system
             .get_package_version(
-                "pkg://maven/io.quarkus/quarkus-core@1.2.2",
+                "pkg://maven/io.quarkus/quarkus-core@1.2.2".try_into()?,
                 Transactional::None,
             )
             .await?

--- a/graph/src/graph/package/qualified_package.rs
+++ b/graph/src/graph/package/qualified_package.rs
@@ -153,7 +153,7 @@ mod tests {
 
         let affected_core = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-core",
+                "pkg://maven/io.quarkus/quarkus-core".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -162,7 +162,7 @@ mod tests {
 
         let affected_addons = advisory_vulnerability
             .ingest_affected_package_range(
-                "pkg://maven/io.quarkus/quarkus-addons",
+                "pkg://maven/io.quarkus/quarkus-addons".try_into()?,
                 "1.0.2",
                 "1.2.0",
                 Transactional::None,
@@ -171,7 +171,7 @@ mod tests {
 
         let pkg_core = system
             .ingest_qualified_package(
-                "pkg://maven/io.quarkus/quarkus-core@1.0.4",
+                "pkg://maven/io.quarkus/quarkus-core@1.0.4".try_into()?,
                 Transactional::None,
             )
             .await?;
@@ -182,7 +182,7 @@ mod tests {
 
         let pkg_addons = system
             .ingest_qualified_package(
-                "pkg://maven/io.quarkus/quarkus-core@1.0.4",
+                "pkg://maven/io.quarkus/quarkus-core@1.0.4".try_into()?,
                 Transactional::None,
             )
             .await?;

--- a/graph/src/graph/sbom/spdx.rs
+++ b/graph/src/graph/sbom/spdx.rs
@@ -40,7 +40,7 @@ impl SbomContext {
                                 if reference.reference_type == "purl" {
                                     //log::debug!("describes pkg {}", reference.reference_locator);
                                     sbom.ingest_describes_package(
-                                        reference.reference_locator.clone(),
+                                        reference.reference_locator.as_str().try_into()?,
                                         tx,
                                     )
                                         .await?;
@@ -88,9 +88,9 @@ impl SbomContext {
                                                                 &relationship.relationship_type,
                                                                 &package_b).try_into() {
                                                                 sbom.ingest_package_relates_to_package(
-                                                                    left,
+                                                                    left.try_into()?,
                                                                     rel,
-                                                                    right,
+                                                                    right.try_into()?,
                                                                     tx,
                                                                 ).await?
                                                             }
@@ -114,9 +114,9 @@ impl SbomContext {
     }
 }
 
-pub struct SpdxRelationship<'spdx>(&'spdx String, &'spdx RelationshipType, &'spdx String);
+pub struct SpdxRelationship<'spdx>(&'spdx str, &'spdx RelationshipType, &'spdx str);
 
-impl<'spdx> TryFrom<SpdxRelationship<'spdx>> for (&'spdx String, Relationship, &'spdx String) {
+impl<'spdx> TryFrom<SpdxRelationship<'spdx>> for (&'spdx str, Relationship, &'spdx str) {
     type Error = ();
 
     fn try_from(
@@ -213,7 +213,7 @@ mod tests {
         let contains = sbom
             .related_packages(
                 Relationship::ContainedBy,
-                described_packages[0].clone(),
+                described_packages[0].clone().into(),
                 Transactional::None,
             )
             .await?;
@@ -266,7 +266,7 @@ mod tests {
         let contains = sbom
             .related_packages(
                 Relationship::ContainedBy,
-                described_packages[0].clone(),
+                described_packages[0].clone().into(),
                 Transactional::None,
             )
             .await?;
@@ -316,7 +316,7 @@ mod tests {
         let contains = sbom
             .related_packages(
                 Relationship::ContainedBy,
-                described[0].clone(),
+                described[0].clone().into(),
                 Transactional::None,
             )
             .await?;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = "1.0.72"
 clap = { version = "4", features = ["derive"] }
 log = "0.4.19"
 once_cell = "1.19.0"
-packageurl = "0.3"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.68", features = [ "raw_value" ] }

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -4,6 +4,7 @@ use actix_web::{HttpResponse, ResponseError};
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use trustify_common::error::ErrorInformation;
+use trustify_common::purl::PurlErr;
 use trustify_graph::graph;
 
 pub mod importer;
@@ -15,7 +16,7 @@ pub enum Error {
     #[error(transparent)]
     System(graph::error::Error),
     #[error(transparent)]
-    Purl(#[from] packageurl::Error),
+    Purl(#[from] PurlErr),
     #[error(transparent)]
     Actix(#[from] actix_web::Error),
     #[error("Invalid request {msg}")]

--- a/server/src/server/read/package.rs
+++ b/server/src/server/read/package.rs
@@ -31,7 +31,7 @@ pub async fn dependencies(
 ) -> actix_web::Result<impl Responder> {
     authorizer.require(&user, Permission::ReadSbom)?;
 
-    let purl: Purl = Purl::from(&*purl);
+    let purl: Purl = Purl::from_str(&purl).map_err(Error::Purl)?;
 
     /*
     if matches!(params.transitive, Some(true)) {


### PR DESCRIPTION
Resolves #6 

Converting strings to purl's is fallible, so we need to implement `TryFrom` instead of `From`. Changing the fn args to `TryFrom<Purl, Error=...>` became verbose, so this PR changes them to `Purl`, forcing callers to try the conversion beforehand. 