### PR TITLE
Add `title` and `description` to Vulnerability models and entities.

### DIFF
--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -16,3 +16,4 @@ pub mod sbom;
 pub mod sbom_describes_cpe22;
 pub mod sbom_describes_package;
 pub mod vulnerability;
+pub mod vulnerability_description;

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -7,6 +7,8 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     pub identifier: String,
+    pub title: Option<String>,
+    pub description_en: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -1,4 +1,4 @@
-use crate::advisory_vulnerability;
+use crate::{advisory_vulnerability, vulnerability_description};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -8,18 +8,25 @@ pub struct Model {
     pub id: i32,
     pub identifier: String,
     pub title: Option<String>,
-    pub description_en: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
     #[sea_orm(has_many = "super::advisory_vulnerability::Entity")]
     AdvisoryVulnerabilities,
+    #[sea_orm(has_many = "super::vulnerability_description::Entity")]
+    Descriptions,
 }
 
 impl Related<advisory_vulnerability::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::AdvisoryVulnerabilities.def()
+    }
+}
+
+impl Related<vulnerability_description::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Descriptions.def()
     }
 }
 

--- a/entity/src/vulnerability_description.rs
+++ b/entity/src/vulnerability_description.rs
@@ -1,0 +1,29 @@
+use crate::vulnerability;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "vulnerability_description")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub vulnerability_id: i32,
+    pub lang: String,
+    pub description: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+    belongs_to = "super::vulnerability::Entity",
+    from = "super::vulnerability_description::Column::VulnerabilityId"
+    to = "super::vulnerability::Column::Id")]
+    Vulnerability,
+}
+
+impl Related<vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Vulnerability.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/graph/src/graph/advisory/mod.rs
+++ b/graph/src/graph/advisory/mod.rs
@@ -130,7 +130,7 @@ impl<'g> AdvisoryContext<'g> {
 
         let entity = entity::advisory_vulnerability::ActiveModel {
             advisory_id: Set(self.advisory.id),
-            vulnerability_id: Set(cve.cve.id),
+            vulnerability_id: Set(cve.vulnerability.id),
         };
 
         Ok((self, entity.insert(&self.graph.connection(tx)).await?).into())

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -3,7 +3,10 @@ use log::debug;
 use migration::Migrator;
 use postgresql_embedded;
 use postgresql_embedded::PostgreSQL;
-use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbErr, Statement};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DatabaseTransaction, DbErr,
+    Statement, TransactionTrait,
+};
 use sea_orm_migration::MigratorTrait;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
@@ -57,6 +60,10 @@ impl<E: Send + Display> std::error::Error for Error<E> {}
 impl Graph {
     pub fn new(db: trustify_common::db::Database) -> Self {
         Self { db }
+    }
+
+    pub async fn transaction(&self) -> Result<DatabaseTransaction, error::Error> {
+        Ok(self.db.begin().await?)
     }
 
     pub(crate) fn connection<'db>(

--- a/graph/src/graph/vulnerability.rs
+++ b/graph/src/graph/vulnerability.rs
@@ -5,13 +5,15 @@ use crate::graph::error::Error;
 use crate::graph::Graph;
 use sea_orm::ActiveValue::{Set, Unchanged};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, NotSet, QueryFilter, QuerySelect, RelationTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, NotSet, QueryFilter, QuerySelect,
+    RelationTrait,
 };
 use sea_query::JoinType;
 use std::fmt::{Debug, Formatter};
 use trustify_common::db::Transactional;
+use trustify_entity as entity;
 use trustify_entity::vulnerability::Model;
-use trustify_entity::{advisory, advisory_vulnerability, vulnerability};
+use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 
 impl Graph {
     pub async fn ingest_vulnerability(
@@ -26,7 +28,6 @@ impl Graph {
                 id: Default::default(),
                 identifier: Set(identifier.to_string()),
                 title: NotSet,
-                description_en: NotSet,
             };
 
             Ok((self, entity.insert(&self.connection(tx)).await?).into())
@@ -95,17 +96,38 @@ impl VulnerabilityContext {
         Ok(())
     }
 
-    pub async fn set_description_en(
+    pub async fn add_description(
         &self,
-        description_en: Option<String>,
+        lang: String,
+        description: String,
         tx: Transactional<'_>,
     ) -> Result<(), Error> {
-        let mut entity: vulnerability::ActiveModel = self.vulnerability.clone().into();
-        entity.description_en = Set(description_en);
+        let model = vulnerability_description::ActiveModel {
+            id: Default::default(),
+            vulnerability_id: Set(self.vulnerability.id),
+            lang: Set(lang),
+            description: Set(description),
+        };
 
-        entity.save(&self.graph.connection(tx)).await?;
+        model.save(&self.graph.connection(tx)).await?;
 
         Ok(())
+    }
+
+    pub async fn descriptions(
+        &self,
+        lang: &str,
+        tx: Transactional<'_>,
+    ) -> Result<Vec<String>, Error> {
+        Ok(self
+            .vulnerability
+            .find_related(entity::vulnerability_description::Entity)
+            .filter(vulnerability_description::Column::Lang.eq(lang))
+            .all(&self.graph.connection(tx))
+            .await?
+            .drain(..)
+            .map(|e| e.description)
+            .collect())
     }
 }
 

--- a/graph/src/graph/vulnerability.rs
+++ b/graph/src/graph/vulnerability.rs
@@ -3,9 +3,9 @@
 use crate::graph::advisory::AdvisoryContext;
 use crate::graph::error::Error;
 use crate::graph::Graph;
-use sea_orm::ActiveValue::Set;
+use sea_orm::ActiveValue::{Set, Unchanged};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QuerySelect, RelationTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, NotSet, QueryFilter, QuerySelect, RelationTrait,
 };
 use sea_query::JoinType;
 use std::fmt::{Debug, Formatter};
@@ -25,6 +25,8 @@ impl Graph {
             let entity = vulnerability::ActiveModel {
                 id: Default::default(),
                 identifier: Set(identifier.to_string()),
+                title: NotSet,
+                description_en: NotSet,
             };
 
             Ok((self, entity.insert(&self.connection(tx)).await?).into())
@@ -46,21 +48,21 @@ impl Graph {
 
 #[derive(Clone)]
 pub struct VulnerabilityContext {
-    pub(crate) system: Graph,
-    pub(crate) cve: vulnerability::Model,
+    pub(crate) graph: Graph,
+    pub(crate) vulnerability: vulnerability::Model,
 }
 
 impl Debug for VulnerabilityContext {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.cve.fmt(f)
+        self.vulnerability.fmt(f)
     }
 }
 
 impl From<(&Graph, vulnerability::Model)> for VulnerabilityContext {
     fn from((system, cve): (&Graph, Model)) -> Self {
         Self {
-            system: system.clone(),
-            cve,
+            graph: system.clone(),
+            vulnerability: cve,
         }
     }
 }
@@ -72,12 +74,38 @@ impl VulnerabilityContext {
                 JoinType::Join,
                 advisory_vulnerability::Relation::Advisory.def().rev(),
             )
-            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(self.cve.id))
-            .all(&self.system.connection(tx))
+            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(self.vulnerability.id))
+            .all(&self.graph.connection(tx))
             .await?
             .drain(0..)
-            .map(|advisory| (&self.system, advisory).into())
+            .map(|advisory| (&self.graph, advisory).into())
             .collect())
+    }
+
+    pub async fn set_title(
+        &self,
+        title: Option<String>,
+        tx: Transactional<'_>,
+    ) -> Result<(), Error> {
+        let mut entity: vulnerability::ActiveModel = self.vulnerability.clone().into();
+        entity.title = Set(title);
+
+        entity.save(&self.graph.connection(tx)).await?;
+
+        Ok(())
+    }
+
+    pub async fn set_description_en(
+        &self,
+        description_en: Option<String>,
+        tx: Transactional<'_>,
+    ) -> Result<(), Error> {
+        let mut entity: vulnerability::ActiveModel = self.vulnerability.clone().into();
+        entity.description_en = Set(description_en);
+
+        entity.save(&self.graph.connection(tx)).await?;
+
+        Ok(())
     }
 }
 
@@ -103,8 +131,8 @@ mod tests {
             .ingest_vulnerability("CVE-456", Transactional::None)
             .await?;
 
-        assert_eq!(cve1.cve.id, cve2.cve.id);
-        assert_ne!(cve1.cve.id, cve3.cve.id);
+        assert_eq!(cve1.vulnerability.id, cve2.vulnerability.id);
+        assert_ne!(cve1.vulnerability.id, cve3.vulnerability.id);
 
         let not_found = system
             .get_vulnerability("CVE-NOT_FOUND", Transactional::None)

--- a/ingestors/Cargo.toml
+++ b/ingestors/Cargo.toml
@@ -22,6 +22,7 @@ ring = "0.17.8"
 hex = "0.4.3"
 csaf = "0.5.0"
 sha2 = "0.10.8"
+sea-orm = "*"
 
 [dev-dependencies]
 test-log = { version = "0.2.15", features = ["env_logger", "trace"] }

--- a/ingestors/src/cve/cve_record/v5.rs
+++ b/ingestors/src/cve/cve_record/v5.rs
@@ -63,6 +63,7 @@ pub struct Containers {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CnaContainer {
+    pub title: Option<String>,
     pub descriptions: Vec<Description>,
     pub problem_types: Vec<ProblemType>,
 }

--- a/ingestors/src/lib.rs
+++ b/ingestors/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod advisory;
 pub mod cve;
+
 pub mod hashing;
+
+use sea_orm::error::DbErr;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -8,6 +11,8 @@ pub enum Error {
     Json(serde_json::Error),
     #[error(transparent)]
     Graph(trustify_graph::graph::error::Error),
+    #[error(transparent)]
+    Db(DbErr),
 }
 
 impl From<serde_json::Error> for Error {
@@ -19,5 +24,11 @@ impl From<serde_json::Error> for Error {
 impl From<trustify_graph::graph::error::Error> for Error {
     fn from(value: trustify_graph::graph::error::Error) -> Self {
         Self::Graph(value)
+    }
+}
+
+impl From<DbErr> for Error {
+    fn from(value: DbErr) -> Self {
+        Self::Db(value)
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -18,6 +18,7 @@ mod m0000190_sbom_describes_package;
 mod m0000200_create_relationship;
 mod m0000210_create_package_relates_to_package;
 
+mod m0000012_create_vulnerability_description;
 mod m0000035_create_cpe22;
 mod m0000220_create_qualified_package_transitive_function;
 mod m0000230_create_importer;
@@ -30,6 +31,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m0000010_create_sbom::Migration),
             Box::new(m0000011_create_vulnerability::Migration),
+            Box::new(m0000012_create_vulnerability_description::Migration),
             Box::new(m0000030_create_advisory::Migration),
             Box::new(m0000032_create_advisory_vulnerability::Migration),
             Box::new(m0000040_create_package::Migration),

--- a/migration/src/m0000011_create_vulnerability.rs
+++ b/migration/src/m0000011_create_vulnerability.rs
@@ -31,6 +31,8 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
+                    .col(ColumnDef::new(Vulnerability::Title).string())
+                    .col(ColumnDef::new(Vulnerability::DescriptionEn).string())
                     .to_owned(),
             )
             .await
@@ -50,4 +52,6 @@ pub enum Vulnerability {
     Timestamp,
     // --
     Identifier,
+    Title,
+    DescriptionEn,
 }

--- a/migration/src/m0000011_create_vulnerability.rs
+++ b/migration/src/m0000011_create_vulnerability.rs
@@ -32,7 +32,6 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(Vulnerability::Title).string())
-                    .col(ColumnDef::new(Vulnerability::DescriptionEn).string())
                     .to_owned(),
             )
             .await
@@ -53,5 +52,4 @@ pub enum Vulnerability {
     // --
     Identifier,
     Title,
-    DescriptionEn,
 }

--- a/migration/src/m0000012_create_vulnerability_description.rs
+++ b/migration/src/m0000012_create_vulnerability_description.rs
@@ -1,0 +1,77 @@
+use crate::m0000011_create_vulnerability::Vulnerability;
+use crate::m0000032_create_advisory_vulnerability::AdvisoryVulnerability;
+use sea_orm_migration::prelude::*;
+
+use crate::Now;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .create_table(
+                Table::create()
+                    .table(VulnerabilityDescription::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(VulnerabilityDescription::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AdvisoryVulnerability::VulnerabilityId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from_col(VulnerabilityDescription::VulnerabilityId)
+                            .to(Vulnerability::Table, Vulnerability::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .col(
+                        ColumnDef::new(VulnerabilityDescription::Timestamp)
+                            .timestamp_with_time_zone()
+                            .default(Func::cust(Now)),
+                    )
+                    .col(
+                        ColumnDef::new(VulnerabilityDescription::Lang)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(VulnerabilityDescription::Description)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(VulnerabilityDescription::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum VulnerabilityDescription {
+    Table,
+    Id,
+    Timestamp,
+    // --
+    VulnerabilityId,
+    Lang,
+    Description,
+}


### PR DESCRIPTION
Provide a handy method for getting a new db transaction. CVE record importer uses transactions and sets title/description. A few small renames of system->graph.