### PR TITLE
Add `aggregated_severity` + `current_release_date` to Advisory entity

### DIFF
--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 sea-orm = { version = "0.12", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-json" ] }
 serde_json = "1"
 tokio = { version = "1.30.0", features = ["full"] }
+chrono = "0.4.35"
 
 [dev-dependencies]
 anyhow = "1.0.72"

--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -9,6 +10,10 @@ pub struct Model {
     pub location: String,
     pub sha256: String,
     pub title: Option<String>,
+    pub aggregate_severity: Option<String>,
+
+    /// Holds the date when the current revision of this document was released.
+    pub current_release_date: Option<DateTime<Utc>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -10,10 +10,10 @@ pub struct Model {
     pub location: String,
     pub sha256: String,
     pub title: Option<String>,
-    pub aggregate_severity: Option<String>,
+    pub severity: Option<String>,
 
     /// Holds the date when the current revision of this document was released.
-    pub current_release_date: Option<DateTime<Utc>>,
+    pub release_date: Option<DateTime<Utc>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -28,6 +28,7 @@ lenient_semver = "0.4.2"
 cpe = "0.1.3"
 postgresql_embedded = { version = "0.6.2", features = ["blocking", "bundled", "tokio" ] }
 tempfile = "3"
+chrono = "0.4.35"
 
 
 [dev-dependencies]

--- a/graph/src/graph/advisory/csaf/mod.rs
+++ b/graph/src/graph/advisory/csaf/mod.rs
@@ -6,7 +6,6 @@ use crate::graph::error::Error;
 use csaf::{document::Category, Csaf};
 use sea_orm::ActiveValue::Set;
 use sea_orm::{ActiveModelTrait, TransactionTrait};
-use std::rc::Rc;
 use trustify_common::db::Transactional;
 use trustify_common::purl::Purl;
 use trustify_entity as entity;

--- a/graph/src/graph/advisory/csaf/mod.rs
+++ b/graph/src/graph/advisory/csaf/mod.rs
@@ -14,9 +14,19 @@ impl<'g> AdvisoryContext<'g> {
     pub async fn ingest_csaf(&self, csaf: Csaf) -> Result<(), Error> {
         let advisory = self.clone();
 
+        let csaf_title = csaf.document.title.clone();
+        let csaf_aggregate_severity = csaf
+            .document
+            .aggregate_severity
+            .as_ref()
+            .map(|e| e.text.clone());
+        let current_release_date = csaf.document.tracking.current_release_date;
+
         // Ingest metadata
         let mut entity: entity::advisory::ActiveModel = self.advisory.clone().into();
-        entity.title = Set(Some(csaf.document.title.clone().to_string()));
+        entity.title = Set(Some(csaf_title));
+        entity.aggregate_severity = Set(csaf_aggregate_severity);
+        entity.current_release_date = Set(Some(current_release_date));
         entity
             .update(&self.graph.connection(&Transactional::None))
             .await?;

--- a/graph/src/graph/package/mod.rs
+++ b/graph/src/graph/package/mod.rs
@@ -625,6 +625,7 @@ impl<'g> PackageContext<'g> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use crate::db::Paginated;
+    use crate::graph::advisory::AdvisoryMetadata;
     use crate::graph::error::Error;
     use crate::graph::Graph;
     use sea_orm::TransactionTrait;
@@ -947,6 +948,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/rhsa-1",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;
@@ -974,7 +976,13 @@ mod tests {
             .await?;
 
         let ghsa_advisory = system
-            .ingest_advisory("GHSA-1", "http://ghsa.com/ghsa-1", "2", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.com/ghsa-1",
+                "2",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let ghsa_advisory_vulnerability = ghsa_advisory
@@ -1040,6 +1048,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/rhsa-1",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;
@@ -1056,7 +1065,13 @@ mod tests {
             .await?;
 
         let ghsa_advisory = system
-            .ingest_advisory("GHSA-1", "http://ghsa.com/ghsa-1", "2", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.com/ghsa-1",
+                "2",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let ghsa_advisory_vulnerability = ghsa_advisory
@@ -1095,6 +1110,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/rhsa-1",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;
@@ -1120,7 +1136,13 @@ mod tests {
             .await?;
 
         let ghsa_advisory = system
-            .ingest_advisory("GHSA-1", "http://ghsa.com/ghsa-1", "2", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.com/ghsa-1",
+                "2",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let ghsa_advisory_vulnerability = ghsa_advisory
@@ -1159,6 +1181,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/rhsa-1",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;
@@ -1177,7 +1200,13 @@ mod tests {
             .await?;
 
         let ghsa_advisory = system
-            .ingest_advisory("GHSA-1", "http://ghsa.gov/GHSA-1", "3", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.gov/GHSA-1",
+                "3",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let ghsa_advisory_vulnerability = ghsa_advisory
@@ -1196,6 +1225,7 @@ mod tests {
                 "RHSA-299",
                 "http://redhat.com/rhsa-299",
                 "17",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;

--- a/graph/src/graph/package/package_version.rs
+++ b/graph/src/graph/package/package_version.rs
@@ -210,6 +210,7 @@ impl<'g> PackageVersionContext<'g> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use crate::graph::advisory::AdvisoryMetadata;
     use crate::graph::Graph;
     use trustify_common::db::{Database, Transactional};
 
@@ -223,6 +224,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/rhsa-1",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;
@@ -239,7 +241,13 @@ mod tests {
             .await?;
 
         let ghsa_advisory = system
-            .ingest_advisory("GHSA-1", "http://ghsa.com/ghsa-1", "2", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.com/ghsa-1",
+                "2",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let ghsa_advisory_vulnerability = ghsa_advisory

--- a/graph/src/graph/package/qualified_package.rs
+++ b/graph/src/graph/package/qualified_package.rs
@@ -133,6 +133,7 @@ impl<'g> QualifiedPackageContext<'g> {
 
 #[cfg(test)]
 mod tests {
+    use crate::graph::advisory::AdvisoryMetadata;
     use crate::graph::Graph;
     use trustify_common::db::{Database, Transactional};
 
@@ -147,6 +148,7 @@ mod tests {
                 "RHSA-GHSA-1",
                 "http://db.com/rhsa-ghsa-2",
                 "2",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;

--- a/graph/src/graph/sbom/mod.rs
+++ b/graph/src/graph/sbom/mod.rs
@@ -663,6 +663,7 @@ impl SbomContext {
 
 #[cfg(test)]
 mod tests {
+    use crate::graph::advisory::AdvisoryMetadata;
     use crate::graph::Graph;
     use test_log::test;
     use trustify_common::db::{Database, Transactional};
@@ -988,6 +989,7 @@ mod tests {
                 "RHSA-1",
                 "http://redhat.com/secdata/RHSA-1",
                 "7",
+                AdvisoryMetadata::default(),
                 Transactional::None,
             )
             .await?;

--- a/graph/src/graph/vulnerability/mod.rs
+++ b/graph/src/graph/vulnerability/mod.rs
@@ -137,6 +137,7 @@ impl VulnerabilityContext {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use crate::graph::advisory::AdvisoryMetadata;
     use crate::graph::Graph;
     use test_log::test;
     use trustify_common::db::{Database, Transactional};
@@ -174,15 +175,33 @@ mod tests {
         let system = Graph::new(db);
 
         let advisory1 = system
-            .ingest_advisory("GHSA-1", "http://ghsa.io/GHSA-1", "7", Transactional::None)
+            .ingest_advisory(
+                "GHSA-1",
+                "http://ghsa.io/GHSA-1",
+                "7",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let advisory2 = system
-            .ingest_advisory("RHSA-1", "http://rhsa.io/RHSA-1", "8", Transactional::None)
+            .ingest_advisory(
+                "RHSA-1",
+                "http://rhsa.io/RHSA-1",
+                "8",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         let advisory3 = system
-            .ingest_advisory("SNYK-1", "http://snyk.io/SNYK-1", "9", Transactional::None)
+            .ingest_advisory(
+                "SNYK-1",
+                "http://snyk.io/SNYK-1",
+                "9",
+                AdvisoryMetadata::default(),
+                Transactional::None,
+            )
             .await?;
 
         advisory1

--- a/ingestors/src/advisory/csaf.rs
+++ b/ingestors/src/advisory/csaf.rs
@@ -10,7 +10,7 @@ pub async fn ingest(
     sha256: &str,
     location: &str,
 ) -> anyhow::Result<i32> {
-    let identifier = csaf.document.tracking.id.clone();
+    let identifier = &csaf.document.tracking.id;
 
     log::info!("Ingesting: {} from {}", identifier, location);
 

--- a/ingestors/src/advisory/osv/loader.rs
+++ b/ingestors/src/advisory/osv/loader.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 use std::str::FromStr;
 use trustify_common::purl::Purl;
+use trustify_graph::graph::advisory::AdvisoryMetadata;
 
 use trustify_graph::graph::Graph;
 
@@ -39,7 +40,7 @@ impl<'g> OsvLoader<'g> {
 
             let advisory = self
                 .graph
-                .ingest_advisory(osv.id, location, sha256, &tx)
+                .ingest_advisory(osv.id, location, sha256, AdvisoryMetadata::default(), &tx)
                 .await?;
 
             for cve_id in cve_ids {

--- a/ingestors/src/cve/loader.rs
+++ b/ingestors/src/cve/loader.rs
@@ -1,4 +1,5 @@
 use std::io::Read;
+use trustify_graph::graph::advisory::AdvisoryMetadata;
 
 use trustify_graph::graph::Graph;
 
@@ -53,7 +54,13 @@ impl<'g> CveLoader<'g> {
 
         let advisory = self
             .graph
-            .ingest_advisory(cve.cve_metadata.cve_id(), location, sha256, &tx)
+            .ingest_advisory(
+                cve.cve_metadata.cve_id(),
+                location,
+                sha256,
+                AdvisoryMetadata::default(),
+                &tx,
+            )
             .await?;
 
         // Link the advisory to the backing vulnerability

--- a/migration/src/m0000030_create_advisory.rs
+++ b/migration/src/m0000030_create_advisory.rs
@@ -23,6 +23,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Advisory::Location).string().not_null())
                     .col(ColumnDef::new(Advisory::Sha256).string().not_null())
                     .col(ColumnDef::new(Advisory::Title).string())
+                    .col(ColumnDef::new(Advisory::AggregateSeverity).string())
+                    .col(ColumnDef::new(Advisory::CurrentReleaseDate).timestamp_with_time_zone())
                     .to_owned(),
             )
             .await
@@ -43,4 +45,6 @@ pub enum Advisory {
     Location,
     Sha256,
     Title,
+    AggregateSeverity,
+    CurrentReleaseDate,
 }

--- a/migration/src/m0000030_create_advisory.rs
+++ b/migration/src/m0000030_create_advisory.rs
@@ -23,8 +23,8 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Advisory::Location).string().not_null())
                     .col(ColumnDef::new(Advisory::Sha256).string().not_null())
                     .col(ColumnDef::new(Advisory::Title).string())
-                    .col(ColumnDef::new(Advisory::AggregateSeverity).string())
-                    .col(ColumnDef::new(Advisory::CurrentReleaseDate).timestamp_with_time_zone())
+                    .col(ColumnDef::new(Advisory::Severity).string())
+                    .col(ColumnDef::new(Advisory::ReleaseDate).timestamp_with_time_zone())
                     .to_owned(),
             )
             .await
@@ -45,6 +45,6 @@ pub enum Advisory {
     Location,
     Sha256,
     Title,
-    AggregateSeverity,
-    CurrentReleaseDate,
+    Severity,
+    ReleaseDate,
 }

--- a/server/src/server/write/advisory.rs
+++ b/server/src/server/write/advisory.rs
@@ -4,6 +4,7 @@ use actix_web::{http, post, web, HttpRequest, HttpResponse, Responder};
 use anyhow::anyhow;
 use csaf::Csaf;
 use std::fs;
+use std::rc::Rc;
 
 use crate::server::Error;
 use crate::AppState;

--- a/server/src/server/write/advisory.rs
+++ b/server/src/server/write/advisory.rs
@@ -4,7 +4,6 @@ use actix_web::{http, post, web, HttpRequest, HttpResponse, Responder};
 use anyhow::anyhow;
 use csaf::Csaf;
 use std::fs;
-use std::rc::Rc;
 
 use crate::server::Error;
 use crate::AppState;


### PR DESCRIPTION
Adding some metadata to the Advisory entity
- Purpose: those fields are part of the the main table that list advisories in the UI.
