### PR TITLE
fix: add test for optimistic locking and fix it

### DIFF
--- a/common/auth/src/client/inject.rs
+++ b/common/auth/src/client/inject.rs
@@ -1,15 +1,16 @@
 use super::{error::Error, Credentials, TokenProvider};
-use async_trait::async_trait;
+use std::future::Future;
 use tracing::instrument;
 
 /// Allows injecting tokens.
-#[async_trait]
 pub trait TokenInjector: Sized + Send + Sync {
-    async fn inject_token(self, token_provider: &dyn TokenProvider) -> Result<Self, Error>;
+    fn inject_token(
+        self,
+        token_provider: &dyn TokenProvider,
+    ) -> impl Future<Output = Result<Self, Error>> + Send;
 }
 
 /// Injects tokens into a request by setting the authorization header to a "bearer" token.
-#[async_trait]
 impl TokenInjector for reqwest::RequestBuilder {
     #[instrument(level = "debug", skip(token_provider), err)]
     async fn inject_token(self, token_provider: &dyn TokenProvider) -> Result<Self, Error> {

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -1,14 +1,16 @@
 #![cfg(test)]
 
 use super::model::ImportConfiguration;
-use actix_web::http::StatusCode;
-use actix_web::{test, App};
+use actix_web::{
+    http::{header, StatusCode},
+    test, App,
+};
 use serde_json::json;
 use trustify_common::db::Database;
 
 #[actix_web::test]
 async fn test_default() {
-    env_logger::init();
+    let _ = env_logger::try_init();
 
     let db = Database::for_test("test_default").await.unwrap();
     let app =
@@ -74,6 +76,179 @@ async fn test_default() {
 
     let req = test::TestRequest::delete()
         .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // get none
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[actix_web::test]
+async fn test_oplock() {
+    let _ = env_logger::try_init();
+
+    let db = Database::for_test("test_oplock").await.unwrap();
+    let app =
+        test::init_service(App::new().configure(|svc| super::endpoints::configure(svc, db))).await;
+
+    // create one
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/importer/foo")
+        .set_json(json!({"foo":"bar"}))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // update it (no lock)
+
+    let req = test::TestRequest::put()
+        .uri("/api/v1/importer/foo")
+        .set_json(json!({"foo":"baz"}))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // get it
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let etag = resp.headers().get(header::ETAG);
+    assert!(etag.is_some());
+    let etag = etag.cloned().unwrap();
+
+    let result: ImportConfiguration = test::read_body_json(resp).await;
+    assert_eq!(
+        result,
+        ImportConfiguration {
+            name: "foo".into(),
+            configuration: json!({"foo":"baz"})
+        }
+    );
+
+    // update it (with lock)
+
+    let req = test::TestRequest::put()
+        .uri("/api/v1/importer/foo")
+        .set_json(json!({"foo":"buz"}))
+        .append_header((header::IF_MATCH, etag.clone()))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // get it
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: ImportConfiguration = test::read_body_json(resp).await;
+    assert_eq!(
+        result,
+        ImportConfiguration {
+            name: "foo".into(),
+            configuration: json!({"foo":"buz"})
+        }
+    );
+
+    // update it (with broken lock)
+
+    let req = test::TestRequest::put()
+        .uri("/api/v1/importer/foo")
+        .set_json(json!({"foo":"boz"}))
+        .append_header((header::IF_MATCH, etag.clone()))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::PRECONDITION_FAILED);
+
+    // update it (with wrong name)
+
+    let req = test::TestRequest::put()
+        .uri("/api/v1/importer/foo2")
+        .set_json(json!({"foo":"boz"}))
+        .append_header((header::IF_MATCH, etag.clone()))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // get it (must not change)
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let old_etag = etag;
+    let etag = resp.headers().get(header::ETAG);
+    assert!(etag.is_some());
+    let etag = etag.cloned().unwrap();
+    assert_ne!(old_etag, etag);
+
+    let result: ImportConfiguration = test::read_body_json(resp).await;
+    assert_eq!(
+        result,
+        ImportConfiguration {
+            name: "foo".into(),
+            configuration: json!({"foo":"buz"})
+        }
+    );
+
+    // delete it (wrong lock)
+
+    let req = test::TestRequest::delete()
+        .uri("/api/v1/importer/foo")
+        .append_header((header::IF_MATCH, old_etag.clone()))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // get it (must still be there)
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/importer/foo")
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let result: ImportConfiguration = test::read_body_json(resp).await;
+    assert_eq!(
+        result,
+        ImportConfiguration {
+            name: "foo".into(),
+            configuration: json!({"foo":"buz"})
+        }
+    );
+
+    // delete it (correct lock)
+
+    let req = test::TestRequest::delete()
+        .uri("/api/v1/importer/foo")
+        .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
 
     let resp = test::call_service(&app, req).await;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
The reason for updating to Rust 1.76.0 was the introduction of `inspect_err`, which I find super helpful (also in this case):

```rust
operation().
    .inspect_err(|err| {
        log::info!("err: {err:?}");
    })
```