### PR TITLE
Replace a few more Into<Purl>'s hither and yon.

### DIFF
--- a/graph/src/graph/advisory/advisory_vulnerability.rs
+++ b/graph/src/graph/advisory/advisory_vulnerability.rs
@@ -28,12 +28,17 @@ impl<'g> From<(&AdvisoryContext<'g>, entity::advisory_vulnerability::Model)>
 }
 
 impl<'g> AdvisoryVulnerabilityContext<'g> {
-    pub async fn get_fixed_package_version(
+    pub async fn get_fixed_package_version<TX: AsRef<Transactional>>(
         &self,
         purl: Purl,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<Option<FixedPackageVersionContext>, Error> {
-        if let Some(package_version) = self.advisory.graph.get_package_version(purl, tx).await? {
+        if let Some(package_version) = self
+            .advisory
+            .graph
+            .get_package_version(purl, tx.as_ref())
+            .await?
+        {
             Ok(entity::fixed_package_version::Entity::find()
                 .filter(
                     entity::fixed_package_version::Column::AdvisoryId.eq(self.advisory.advisory.id),
@@ -42,7 +47,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::fixed_package_version::Column::PackageVersionId
                         .eq(package_version.package_version.id),
                 )
-                .one(&self.advisory.graph.connection(tx))
+                .one(&self.advisory.graph.connection(tx.as_ref()))
                 .await?
                 .map(|affected| (self, affected).into()))
         } else {
@@ -50,12 +55,17 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn get_not_affected_package_version(
+    pub async fn get_not_affected_package_version<TX: AsRef<Transactional>>(
         &self,
         purl: Purl,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<Option<NotAffectedPackageVersionContext>, Error> {
-        if let Some(package_version) = self.advisory.graph.get_package_version(purl, tx).await? {
+        if let Some(package_version) = self
+            .advisory
+            .graph
+            .get_package_version(purl, tx.as_ref())
+            .await?
+        {
             Ok(entity::not_affected_package_version::Entity::find()
                 .filter(
                     entity::not_affected_package_version::Column::AdvisoryId
@@ -65,7 +75,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::not_affected_package_version::Column::PackageVersionId
                         .eq(package_version.package_version.id),
                 )
-                .one(&self.advisory.graph.connection(tx))
+                .one(&self.advisory.graph.connection(tx.as_ref()))
                 .await?
                 .map(|not_affected_package_version| (self, not_affected_package_version).into()))
         } else {
@@ -73,19 +83,17 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn get_affected_package_range<P: Into<Purl>>(
+    pub async fn get_affected_package_range<TX: AsRef<Transactional>>(
         &self,
-        pkg: P,
+        purl: Purl,
         start: &str,
         end: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<Option<AffectedPackageVersionRangeContext>, Error> {
-        let purl = pkg.into();
-
         if let Some(package_version_range) = self
             .advisory
             .graph
-            .get_package_version_range(purl.clone(), start, end, tx)
+            .get_package_version_range(purl.clone(), start, end, tx.as_ref())
             .await?
         {
             Ok(entity::affected_package_version_range::Entity::find()
@@ -97,7 +105,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::affected_package_version_range::Column::PackageVersionRangeId
                         .eq(package_version_range.package_version_range.id),
                 )
-                .one(&self.advisory.graph.connection(tx))
+                .one(&self.advisory.graph.connection(tx.as_ref()))
                 .await?
                 .map(|affected| (self, affected).into()))
         } else {
@@ -105,19 +113,23 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn ingest_not_affected_package_version(
+    pub async fn ingest_not_affected_package_version<TX: AsRef<Transactional>>(
         &self,
         purl: Purl,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<NotAffectedPackageVersionContext, Error> {
         if let Some(found) = self
-            .get_not_affected_package_version(purl.clone(), tx)
+            .get_not_affected_package_version(purl.clone(), tx.as_ref())
             .await?
         {
             return Ok(found);
         }
 
-        let package_version = self.advisory.graph.ingest_package_version(purl, tx).await?;
+        let package_version = self
+            .advisory
+            .graph
+            .ingest_package_version(purl, tx.as_ref())
+            .await?;
 
         let entity = entity::not_affected_package_version::ActiveModel {
             id: Default::default(),
@@ -127,21 +139,30 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok((
             self,
-            entity.insert(&self.advisory.graph.connection(tx)).await?,
+            entity
+                .insert(&self.advisory.graph.connection(tx.as_ref()))
+                .await?,
         )
             .into())
     }
 
-    pub async fn ingest_fixed_package_version(
+    pub async fn ingest_fixed_package_version<TX: AsRef<Transactional>>(
         &self,
         purl: Purl,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<FixedPackageVersionContext, Error> {
-        if let Some(found) = self.get_fixed_package_version(purl.clone(), tx).await? {
+        if let Some(found) = self
+            .get_fixed_package_version(purl.clone(), tx.as_ref())
+            .await?
+        {
             return Ok(found);
         }
 
-        let package_version = self.advisory.graph.ingest_package_version(purl, tx).await?;
+        let package_version = self
+            .advisory
+            .graph
+            .ingest_package_version(purl, tx.as_ref())
+            .await?;
 
         let entity = entity::fixed_package_version::ActiveModel {
             id: Default::default(),
@@ -151,20 +172,22 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok((
             self,
-            entity.insert(&self.advisory.graph.connection(tx)).await?,
+            entity
+                .insert(&self.advisory.graph.connection(tx.as_ref()))
+                .await?,
         )
             .into())
     }
 
-    pub async fn ingest_affected_package_range(
+    pub async fn ingest_affected_package_range<TX: AsRef<Transactional>>(
         &self,
         purl: Purl,
         start: &str,
         end: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<AffectedPackageVersionRangeContext, Error> {
         if let Some(found) = self
-            .get_affected_package_range(purl.clone(), start, end, tx)
+            .get_affected_package_range(purl.clone(), start, end, tx.as_ref())
             .await?
         {
             return Ok(found);
@@ -173,7 +196,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         let package_version_range = self
             .advisory
             .graph
-            .ingest_package_version_range(purl, start, end, tx)
+            .ingest_package_version_range(purl, start, end, tx.as_ref())
             .await?;
 
         let entity = entity::affected_package_version_range::ActiveModel {
@@ -184,7 +207,9 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok((
             self,
-            entity.insert(&self.advisory.graph.connection(tx)).await?,
+            entity
+                .insert(&self.advisory.graph.connection(tx.as_ref()))
+                .await?,
         )
             .into())
     }

--- a/graph/src/graph/advisory/csaf/mod.rs
+++ b/graph/src/graph/advisory/csaf/mod.rs
@@ -18,7 +18,7 @@ impl<'g> AdvisoryContext<'g> {
         let mut entity: entity::advisory::ActiveModel = self.advisory.clone().into();
         entity.title = Set(Some(csaf.document.title.clone().to_string()));
         entity
-            .update(&self.graph.connection(Transactional::None))
+            .update(&self.graph.connection(&Transactional::None))
             .await?;
 
         // Ingest vulnerabilities

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -62,14 +62,14 @@ impl Graph {
         Self { db }
     }
 
-    pub async fn transaction(&self) -> Result<DatabaseTransaction, error::Error> {
-        Ok(self.db.begin().await?)
+    //pub async fn transaction(&self) -> Result<DatabaseTransaction, error::Error> {
+    //Ok(self.db.begin().await?)
+    //}
+    pub async fn transaction(&self) -> Result<Transactional, error::Error> {
+        Ok(Transactional::Some(self.db.begin().await?))
     }
 
-    pub(crate) fn connection<'db>(
-        &'db self,
-        tx: Transactional<'db>,
-    ) -> ConnectionOrTransaction<'db> {
+    pub(crate) fn connection<'db>(&'db self, tx: &'db Transactional) -> ConnectionOrTransaction {
         match tx {
             Transactional::None => ConnectionOrTransaction::Connection(&self.db),
             Transactional::Some(tx) => ConnectionOrTransaction::Transaction(tx),

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -62,9 +62,10 @@ impl Graph {
         Self { db }
     }
 
-    //pub async fn transaction(&self) -> Result<DatabaseTransaction, error::Error> {
-    //Ok(self.db.begin().await?)
-    //}
+    /// Create a `Transactional::Some(_)` with a new transaction.
+    ///
+    /// The transaction will be rolled-back unless explicitly `commit()`'d before
+    /// it drops.
     pub async fn transaction(&self) -> Result<Transactional, error::Error> {
         Ok(Transactional::Some(self.db.begin().await?))
     }

--- a/graph/src/graph/package/qualified_package.rs
+++ b/graph/src/graph/package/qualified_package.rs
@@ -74,7 +74,10 @@ impl<'g> From<QualifiedPackageContext<'g>> for Purl {
 }
 
 impl<'g> QualifiedPackageContext<'g> {
-    pub async fn sboms_containing(&self, tx: Transactional<'_>) -> Result<Vec<SbomContext>, Error> {
+    pub async fn sboms_containing<TX: AsRef<Transactional>>(
+        &self,
+        tx: TX,
+    ) -> Result<Vec<SbomContext>, Error> {
         /*
         Ok(entity::sbom::Entity::find()
             .join(
@@ -95,12 +98,12 @@ impl<'g> QualifiedPackageContext<'g> {
         todo!()
     }
 
-    pub async fn vulnerability_assertions(
+    pub async fn vulnerability_assertions<TX: AsRef<Transactional>>(
         &self,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<PackageVulnerabilityAssertions, Error> {
-        let affected = self.affected_assertions(tx).await?;
-        let not_affected = self.not_affected_assertions(tx).await?;
+        let affected = self.affected_assertions(tx.as_ref()).await?;
+        let not_affected = self.not_affected_assertions(tx.as_ref()).await?;
 
         let mut merged = PackageVulnerabilityAssertions::default();
 
@@ -113,16 +116,16 @@ impl<'g> QualifiedPackageContext<'g> {
         Ok(merged)
     }
 
-    pub async fn affected_assertions(
+    pub async fn affected_assertions<TX: AsRef<Transactional>>(
         &self,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<PackageVulnerabilityAssertions, Error> {
         self.package_version.affected_assertions(tx).await
     }
 
-    pub async fn not_affected_assertions(
+    pub async fn not_affected_assertions<TX: AsRef<Transactional>>(
         &self,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<PackageVulnerabilityAssertions, Error> {
         self.package_version.not_affected_assertions(tx).await
     }

--- a/graph/src/graph/vulnerability.rs
+++ b/graph/src/graph/vulnerability.rs
@@ -16,12 +16,12 @@ use trustify_entity::vulnerability::Model;
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 
 impl Graph {
-    pub async fn ingest_vulnerability(
+    pub async fn ingest_vulnerability<TX: AsRef<Transactional>>(
         &self,
         identifier: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<VulnerabilityContext, Error> {
-        if let Some(found) = self.get_vulnerability(identifier, tx).await? {
+        if let Some(found) = self.get_vulnerability(identifier, tx.as_ref()).await? {
             Ok(found)
         } else {
             let entity = vulnerability::ActiveModel {
@@ -30,18 +30,18 @@ impl Graph {
                 title: NotSet,
             };
 
-            Ok((self, entity.insert(&self.connection(tx)).await?).into())
+            Ok((self, entity.insert(&self.connection(tx.as_ref())).await?).into())
         }
     }
 
-    pub async fn get_vulnerability(
+    pub async fn get_vulnerability<TX: AsRef<Transactional>>(
         &self,
         identifier: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<Option<VulnerabilityContext>, Error> {
         Ok(vulnerability::Entity::find()
             .filter(vulnerability::Column::Identifier.eq(identifier))
-            .one(&self.connection(tx))
+            .one(&self.connection(tx.as_ref()))
             .await?
             .map(|cve| (self, cve).into()))
     }
@@ -69,38 +69,41 @@ impl From<(&Graph, vulnerability::Model)> for VulnerabilityContext {
 }
 
 impl VulnerabilityContext {
-    pub async fn advisories(&self, tx: Transactional<'_>) -> Result<Vec<AdvisoryContext>, Error> {
+    pub async fn advisories<TX: AsRef<Transactional>>(
+        &self,
+        tx: TX,
+    ) -> Result<Vec<AdvisoryContext>, Error> {
         Ok(advisory::Entity::find()
             .join(
                 JoinType::Join,
                 advisory_vulnerability::Relation::Advisory.def().rev(),
             )
             .filter(advisory_vulnerability::Column::VulnerabilityId.eq(self.vulnerability.id))
-            .all(&self.graph.connection(tx))
+            .all(&self.graph.connection(tx.as_ref()))
             .await?
             .drain(0..)
             .map(|advisory| (&self.graph, advisory).into())
             .collect())
     }
 
-    pub async fn set_title(
+    pub async fn set_title<TX: AsRef<Transactional>>(
         &self,
         title: Option<String>,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<(), Error> {
         let mut entity: vulnerability::ActiveModel = self.vulnerability.clone().into();
         entity.title = Set(title);
 
-        entity.save(&self.graph.connection(tx)).await?;
+        entity.save(&self.graph.connection(tx.as_ref())).await?;
 
         Ok(())
     }
 
-    pub async fn add_description(
+    pub async fn add_description<TX: AsRef<Transactional>>(
         &self,
         lang: &str,
         description: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<(), Error> {
         let model = vulnerability_description::ActiveModel {
             id: Default::default(),
@@ -109,21 +112,21 @@ impl VulnerabilityContext {
             description: Set(description.to_string()),
         };
 
-        model.save(&self.graph.connection(tx)).await?;
+        model.save(&self.graph.connection(tx.as_ref())).await?;
 
         Ok(())
     }
 
-    pub async fn descriptions(
+    pub async fn descriptions<TX: AsRef<Transactional>>(
         &self,
         lang: &str,
-        tx: Transactional<'_>,
+        tx: TX,
     ) -> Result<Vec<String>, Error> {
         Ok(self
             .vulnerability
             .find_related(entity::vulnerability_description::Entity)
             .filter(vulnerability_description::Column::Lang.eq(lang))
-            .all(&self.graph.connection(tx))
+            .all(&self.graph.connection(tx.as_ref()))
             .await?
             .drain(..)
             .map(|e| e.description)

--- a/ingestors/src/advisory/osv/loader.rs
+++ b/ingestors/src/advisory/osv/loader.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
 
-use trustify_common::db::Transactional;
 use trustify_graph::graph::Graph;
 
 use crate::advisory::osv::schema::Vulnerability;
@@ -35,16 +34,11 @@ impl<'g> OsvLoader<'g> {
         }) {
             for cve_id in cve_ids {
                 println!("INGEST VULN {}", cve_id);
-                let vuln = self
-                    .graph
-                    .ingest_vulnerability(cve_id, Transactional::Some(&tx))
-                    .await?;
+                let vuln = self.graph.ingest_vulnerability(cve_id, &tx).await?;
 
-                vuln.set_title(osv.summary.clone(), Transactional::Some(&tx))
-                    .await?;
+                vuln.set_title(osv.summary.clone(), &tx).await?;
                 if let Some(details) = &osv.details {
-                    vuln.add_description("en", details, Transactional::Some(&tx))
-                        .await?
+                    vuln.add_description("en", details, &tx).await?
                 }
             }
 
@@ -52,7 +46,7 @@ impl<'g> OsvLoader<'g> {
             let sha256 = hex::encode(hashes.sha256.as_ref());
 
             self.graph
-                .ingest_advisory(osv.id, location, sha256, Transactional::Some(&tx))
+                .ingest_advisory(osv.id, location, sha256, &tx)
                 .await?;
         }
 

--- a/ingestors/src/cve/loader.rs
+++ b/ingestors/src/cve/loader.rs
@@ -68,7 +68,6 @@ mod test {
     use std::str::FromStr;
 
     use test_log::test;
-
     use trustify_common::db::Database;
     use trustify_graph::graph::Graph;
 


### PR DESCRIPTION
Add type constraints to make using transactions a bit easier. A `Transactional::Some(_)` owns its transaction, reducing the things you need to hang onto.
A `Transactional::Some(_)` is provided ready-to-eat from Graph::transaction(). A `()` can be used for non-transactional as shorthand for `Transactional::None`.