### PR TITLE
chore: proper log level in trustd-cli

### DIFF
--- a/trustd/src/main.rs
+++ b/trustd/src/main.rs
@@ -26,12 +26,12 @@ impl Trustd {
         match self.run_command().await {
             Ok(code) => code,
             Err(err) => {
-                log::info!("Error: {err}");
+                log::error!("Error: {err}");
                 for (n, err) in err.chain().skip(1).enumerate() {
                     if n == 0 {
-                        log::info!("Caused by:");
+                        log::error!("Caused by:");
                     }
-                    log::info!("\t{err}");
+                    log::error!("\t{err}");
                 }
 
                 ExitCode::FAILURE


### PR DESCRIPTION
With this we can see the `caused by` without `RUST_LOG=debug`

I found here:

`No output prints when running this code. By default, the log level is error, and any lower levels are dropped.`
https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/log.html#log-a-debug-message-to-the-console

![2024-03-19_10-09](https://github.com/trustification/trustify/assets/6443576/8e8c19b8-7847-4508-a870-a3069a0f578b)




