### PR TITLE
Move CVSS scoring from `Advisory` down to `AdvisoryVulnerability`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5730,7 +5730,6 @@ dependencies = [
  "trustify-module-graph",
  "url-escape",
  "utoipa",
- "walker-common",
 ]
 
 [[package]]

--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -1,4 +1,4 @@
-use crate::advisory;
+use crate::{advisory, vulnerability};
 use sea_orm::entity::prelude::*;
 use trustify_cvss::cvss3::Cvss3Base;
 
@@ -7,6 +7,9 @@ use trustify_cvss::cvss3::Cvss3Base;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub advisory_id: i32,
+
+    #[sea_orm(primary_key)]
+    pub vulnerability_id: i32,
 
     #[sea_orm(primary_key)]
     pub minor_version: i32,
@@ -44,11 +47,23 @@ pub enum Relation {
     from = "super::cvss3::Column::AdvisoryId"
     to = "super::advisory::Column::Id")]
     Advisory,
+
+    #[sea_orm(
+    belongs_to = "super::advisory::Entity",
+    from = "super::cvss3::Column::VulnerabilityId"
+    to = "super::advisory::Column::Id")]
+    Vulnerability,
 }
 
 impl Related<advisory::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Advisory.def()
+    }
+}
+
+impl Related<vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Vulnerability.def()
     }
 }
 

--- a/migration/src/m0000033_create_cvss3.rs
+++ b/migration/src/m0000033_create_cvss3.rs
@@ -17,17 +17,23 @@ impl MigrationTrait for Migration {
                     .table(Cvss3::Table)
                     .if_not_exists()
                     .col(ColumnDef::new(Cvss3::AdvisoryId).integer().not_null())
+                    .col(ColumnDef::new(Cvss3::VulnerabilityId).integer().not_null())
                     .col(ColumnDef::new(Cvss3::MinorVersion).integer().not_null())
                     .primary_key(
                         Index::create()
+                            .col(Cvss3::VulnerabilityId)
                             .col(Cvss3::AdvisoryId)
                             .col(Cvss3::MinorVersion),
                     )
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(Cvss3::AdvisoryId)
-                            .to(Advisory::Table, Advisory::Id)
-                            .on_delete(ForeignKeyAction::Cascade),
+                            .to(Advisory::Table, Advisory::Id),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from_col(Cvss3::VulnerabilityId)
+                            .to(Advisory::Table, Advisory::Id),
                     )
                     .col(
                         ColumnDef::new(Cvss3::AV)
@@ -88,6 +94,7 @@ impl MigrationTrait for Migration {
 pub enum Cvss3 {
     Table,
     AdvisoryId,
+    VulnerabilityId,
     MinorVersion,
     AV,
     AC,

--- a/modules/graph/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/graph/src/graph/advisory/advisory_vulnerability.rs
@@ -6,12 +6,13 @@ use crate::graph::error::Error;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use trustify_common::db::Transactional;
 use trustify_common::purl::Purl;
+use trustify_cvss::cvss3::Cvss3Base;
 use trustify_entity as entity;
 
 #[derive(Clone, Debug)]
 pub struct AdvisoryVulnerabilityContext<'g> {
     pub advisory: AdvisoryContext<'g>,
-    pub vulnerability: entity::advisory_vulnerability::Model,
+    pub advisory_vulnerability: entity::advisory_vulnerability::Model,
 }
 
 impl<'g> From<(&AdvisoryContext<'g>, entity::advisory_vulnerability::Model)>
@@ -22,7 +23,7 @@ impl<'g> From<(&AdvisoryContext<'g>, entity::advisory_vulnerability::Model)>
     ) -> Self {
         Self {
             advisory: advisory.clone(),
-            vulnerability,
+            advisory_vulnerability: vulnerability,
         }
     }
 }
@@ -193,5 +194,64 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             entity.insert(&self.advisory.graph.connection(&tx)).await?,
         )
             .into())
+    }
+
+    pub async fn cvss3_scores<TX: AsRef<Transactional>>(
+        &self,
+        tx: TX,
+    ) -> Result<Vec<Cvss3Base>, Error> {
+        Ok(entity::cvss3::Entity::find()
+            .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
+            .filter(
+                entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.vulnerability_id),
+            )
+            .all(&self.advisory.graph.connection(&tx))
+            .await?
+            .drain(..)
+            .map(|e| e.into())
+            .collect())
+    }
+
+    pub async fn get_cvss3_score<TX: AsRef<Transactional>>(
+        &self,
+        minor_version: u8,
+        tx: TX,
+    ) -> Result<Option<Cvss3Base>, Error> {
+        Ok(entity::cvss3::Entity::find()
+            .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
+            .filter(
+                entity::cvss3::Column::VulnerabilityId
+                    .eq(self.advisory_vulnerability.vulnerability_id),
+            )
+            .filter(entity::cvss3::Column::MinorVersion.eq(minor_version as i32))
+            .one(&self.advisory.graph.connection(&tx))
+            .await?
+            .map(|cvss| cvss.into()))
+    }
+
+    pub async fn ingest_cvss3_score<TX: AsRef<Transactional>>(
+        &self,
+        cvss3: Cvss3Base,
+        tx: TX,
+    ) -> Result<Cvss3Base, Error> {
+        if let Some(found) = self.get_cvss3_score(cvss3.minor_version, &tx).await? {
+            return Ok(found);
+        }
+
+        let model = entity::cvss3::ActiveModel {
+            advisory_id: Set(self.advisory_vulnerability.advisory_id),
+            vulnerability_id: Set(self.advisory_vulnerability.vulnerability_id),
+            minor_version: sea_orm::ActiveValue::Set(cvss3.minor_version as i32),
+            av: Set(cvss3.av.into()),
+            ac: Set(cvss3.ac.into()),
+            pr: Set(cvss3.pr.into()),
+            ui: Set(cvss3.ui.into()),
+            s: Set(cvss3.s.into()),
+            c: Set(cvss3.c.into()),
+            i: Set(cvss3.i.into()),
+            a: Set(cvss3.a.into()),
+        };
+
+        Ok(model.insert(&self.advisory.graph.db).await?.into())
     }
 }


### PR DESCRIPTION
Given that a single advisory can speak towards multiple vulnerabilities, the severity should be associated with the join of the two two entities.