### PR TITLE
feat: allow preventing a reset of the database

### DIFF
--- a/common/src/test_util.rs
+++ b/common/src/test_util.rs
@@ -1,5 +1,7 @@
-use crate::config::{Database, DbStrategy};
-use crate::db;
+use crate::{
+    config::{Database, DbStrategy},
+    db,
+};
 use std::sync::Arc;
 
 pub async fn bootstrap_system(name: &str) -> Result<db::Database, anyhow::Error> {
@@ -12,7 +14,7 @@ pub async fn bootstrap_system(name: &str) -> Result<db::Database, anyhow::Error>
             port: 5432,
             name: name.to_string(),
         },
-        true,
+        db::CreationMode::Bootstrap,
     )
     .await
 }

--- a/importer/src/csaf/mod.rs
+++ b/importer/src/csaf/mod.rs
@@ -69,7 +69,8 @@ impl ImportCsafCommand {
     pub async fn run_once(self, progress: Progress) -> Result<Report, ScannerError> {
         let report = Arc::new(Mutex::new(ReportBuilder::new()));
 
-        let db = db::Database::with_external_config(&self.database, false).await?;
+        let db =
+            db::Database::with_external_config(&self.database, db::CreationMode::Default).await?;
         let system = Graph::new(db);
 
         let source: DispatchSource = match Url::parse(&self.source) {

--- a/importer/src/sbom/mod.rs
+++ b/importer/src/sbom/mod.rs
@@ -55,7 +55,8 @@ impl ImportSbomCommand {
     async fn run_once(self, progress: Progress) -> Result<Report, ScannerError> {
         let report = Arc::new(Mutex::new(ReportBuilder::new()));
 
-        let db = db::Database::with_external_config(&self.database, false).await?;
+        let db =
+            db::Database::with_external_config(&self.database, db::CreationMode::Default).await?;
         let system = Graph::new(db);
 
         let source: DispatchSource = match Url::parse(&self.source) {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -41,8 +41,9 @@ pub struct Run {
     #[command(flatten)]
     pub database: Database,
 
-    #[arg(long, env)]
-    pub bootstrap: bool,
+    /// The database creation mode
+    #[arg(long, env, value_enum, default_value_t = db::CreationMode::Default)]
+    pub creation: db::CreationMode,
 
     #[arg(long, env)]
     pub devmode: bool,
@@ -108,7 +109,7 @@ impl InitData {
                 .await?
                 .map(Arc::new);
 
-        let db = db::Database::with_external_config(&run.database, run.bootstrap).await?;
+        let db = db::Database::with_external_config(&run.database, run.creation).await?;
         let graph = Graph::new(db.clone());
 
         let check = Local::spawn_periodic("no database connection", Duration::from_secs(1), {


### PR DESCRIPTION
This adds the ability to keep the database structure (and with that the data) during restarts.

I understand it makes sense for tests to use ephemeral databases. But when testing locally, IMHO restarting the server process should not drop all the data.

This happens as we "refresh" all migrations, which removes all tables, and thus the data.

One can choose now between:

* bootstrap: re-create database
* refresh: re-create schema
* default: simply run missing migrations

That changes the default and if you're modifying (not adding) you would need to provide `--creation refresh` when starting. But I think that's the exception case.