### PR TITLE
fix: properly define primary key

### DIFF
--- a/entity/src/package_relates_to_package.rs
+++ b/entity/src/package_relates_to_package.rs
@@ -6,8 +6,11 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub left_package_id: i32,
+    #[sea_orm(primary_key)]
     pub relationship: Relationship,
+    #[sea_orm(primary_key)]
     pub right_package_id: i32,
+    #[sea_orm(primary_key)]
     pub sbom_id: i32,
 }
 


### PR DESCRIPTION
To my understanding that should be a composite primary key:

https://github.com/trustification/trustify/blob/3f0719b4bcae5f10561a27256bff80abb9466a2e/migration/src/m0000220_create_package_relates_to_package.rs#L58-L64

And the docs seem to require the attribute for all fields of that key:

https://www.sea-ql.org/SeaORM/docs/generate-entity/entity-structure/#composite-key

