### PR TITLE
feat(ingestor): default to sha384 hashing and allow for algorithm customization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,6 +5671,7 @@ dependencies = [
  "humantime",
  "log",
  "packageurl",
+ "rand",
  "reqwest",
  "ring 0.17.8",
  "sbom-walker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ walker-common = "=0.6.0-alpha.8"
 walker-extras = "=0.6.0-alpha.8"
 bytes = "1.5"
 tokio-util = "0.7"
+rand = "0.8.5" # for testing
 
 trustify-server = { path = "server"}
 trustify-importer = { path = "importer"}

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -36,3 +36,4 @@ utoipa = { workspace = true, features = ["actix_extras"] }
 [dev-dependencies]
 test-log = { workspace = true, features = ["env_logger", "trace"] }
 url-escape = { workspace = true }
+rand = { workspace = true }

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -51,9 +51,9 @@ impl<'g> CsafLoader<'g> {
 
         let tx = self.graph.transaction().await?;
 
-        let hashes = reader.hashes();
-        let sha256 = hex::encode(hashes.sha256.as_ref());
-        if checksum != sha256 {
+        let hash = reader.finish();
+        let enc_hash = hex::encode(hash);
+        if checksum != enc_hash {
             return Err(Error::Storage(anyhow::Error::msg(
                 "document integrity check failed",
             )));
@@ -63,7 +63,7 @@ impl<'g> CsafLoader<'g> {
 
         let advisory = self
             .graph
-            .ingest_advisory(&advisory_id, location, sha256, Information(&csaf), &tx)
+            .ingest_advisory(&advisory_id, location, enc_hash, Information(&csaf), &tx)
             .await?;
 
         for vuln in csaf.vulnerabilities.iter().flatten() {

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -51,7 +51,7 @@ impl<'g> CsafLoader<'g> {
 
         let tx = self.graph.transaction().await?;
 
-        let hash = reader.finish();
+        let hash = reader.finish().map_err(|e| Error::Generic(e.into()))?;
         let enc_hash = hex::encode(hash);
         if checksum != enc_hash {
             return Err(Error::Storage(anyhow::Error::msg(

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -39,9 +39,9 @@ impl<'g> OsvLoader<'g> {
                 .cloned()
                 .collect::<Vec<_>>()
         }) {
-            let hashes = reader.hashes();
-            let sha256 = hex::encode(hashes.sha256.as_ref());
-            if checksum != sha256 {
+            let hash = reader.finish();
+            let enc_hash = hex::encode(hash);
+            if checksum != enc_hash {
                 return Err(Error::Storage(anyhow::Error::msg(
                     "document integrity check failed",
                 )));
@@ -54,7 +54,7 @@ impl<'g> OsvLoader<'g> {
             };
             let advisory = self
                 .graph
-                .ingest_advisory(&osv.id, location, sha256, information, &tx)
+                .ingest_advisory(&osv.id, location, enc_hash, information, &tx)
                 .await?;
 
             if let Some(withdrawn) = osv.withdrawn {

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -39,9 +39,9 @@ impl<'g> OsvLoader<'g> {
                 .cloned()
                 .collect::<Vec<_>>()
         }) {
-            let hash = reader.finish().map_err(|e| Error::Generic(e.into()))?;
-            let enc_hash = hex::encode(hash);
-            if checksum != enc_hash {
+            let digests = reader.finish().map_err(|e| Error::Generic(e.into()))?;
+            let encoded_sha256 = hex::encode(digests.sha256);
+            if checksum != encoded_sha256 {
                 return Err(Error::Storage(anyhow::Error::msg(
                     "document integrity check failed",
                 )));
@@ -54,7 +54,7 @@ impl<'g> OsvLoader<'g> {
             };
             let advisory = self
                 .graph
-                .ingest_advisory(&osv.id, location, enc_hash, information, &tx)
+                .ingest_advisory(&osv.id, location, encoded_sha256, information, &tx)
                 .await?;
 
             if let Some(withdrawn) = osv.withdrawn {

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -39,7 +39,7 @@ impl<'g> OsvLoader<'g> {
                 .cloned()
                 .collect::<Vec<_>>()
         }) {
-            let hash = reader.finish();
+            let hash = reader.finish().map_err(|e| Error::Generic(e.into()))?;
             let enc_hash = hex::encode(hash);
             if checksum != enc_hash {
                 return Err(Error::Storage(anyhow::Error::msg(

--- a/modules/ingestor/src/service/cve/loader.rs
+++ b/modules/ingestor/src/service/cve/loader.rs
@@ -44,12 +44,12 @@ impl<'g> CveLoader<'g> {
                 .await?;
         }
 
-        let hashes = reader.hashes();
-        let sha256 = hex::encode(hashes.sha256.as_ref());
+        let hash = reader.finish();
+        let enc_hash = hex::encode(hash);
 
         let advisory = self
             .graph
-            .ingest_advisory(cve.cve_metadata.cve_id(), location, sha256, (), &tx)
+            .ingest_advisory(cve.cve_metadata.cve_id(), location, enc_hash, (), &tx)
             .await?;
 
         // Link the advisory to the backing vulnerability

--- a/modules/ingestor/src/service/cve/loader.rs
+++ b/modules/ingestor/src/service/cve/loader.rs
@@ -44,12 +44,12 @@ impl<'g> CveLoader<'g> {
                 .await?;
         }
 
-        let hash = reader.finish().map_err(|e| Error::Generic(e.into()))?;
-        let enc_hash = hex::encode(hash);
+        let digests = reader.finish().map_err(|e| Error::Generic(e.into()))?;
+        let encoded_sha256 = hex::encode(digests.sha256);
 
         let advisory = self
             .graph
-            .ingest_advisory(cve.cve_metadata.cve_id(), location, enc_hash, (), &tx)
+            .ingest_advisory(cve.cve_metadata.cve_id(), location, encoded_sha256, (), &tx)
             .await?;
 
         // Link the advisory to the backing vulnerability

--- a/modules/ingestor/src/service/cve/loader.rs
+++ b/modules/ingestor/src/service/cve/loader.rs
@@ -44,7 +44,7 @@ impl<'g> CveLoader<'g> {
                 .await?;
         }
 
-        let hash = reader.finish();
+        let hash = reader.finish().map_err(|e| Error::Generic(e.into()))?;
         let enc_hash = hex::encode(hash);
 
         let advisory = self

--- a/modules/ingestor/src/service/hashing.rs
+++ b/modules/ingestor/src/service/hashing.rs
@@ -27,8 +27,8 @@ impl<R: Read> HashingRead<R> {
     }
 
     /// Finishes reading all data from the inner reader and returns the hash digest
-    pub fn finish(mut self) -> Digest {
-        (&mut self).read_to_end(&mut Vec::new()).unwrap();
+    pub fn finish(mut self) -> std::io::Result<Digest> {
+        self.read_to_end(&mut Vec::new())?;
         self.ctx.finish()
     }
 }

--- a/modules/ingestor/src/service/hashing.rs
+++ b/modules/ingestor/src/service/hashing.rs
@@ -29,7 +29,7 @@ impl<R: Read> HashingRead<R> {
     /// Finishes reading all data from the inner reader and returns the hash digest
     pub fn finish(mut self) -> std::io::Result<Digest> {
         self.read_to_end(&mut Vec::new())?;
-        self.ctx.finish()
+        Ok(self.ctx.finish())
     }
 }
 
@@ -69,7 +69,7 @@ mod test {
     fn default_hash() {
         let data = rand_bytes();
         let reader = HashingRead::new(data.as_slice());
-        let digest_res = reader.finish();
+        let digest_res = reader.finish().unwrap();
         let digest_bytes = digest_res.as_ref();
 
         let expected_digest = digest(&SHA384, &data);
@@ -82,7 +82,7 @@ mod test {
     fn finish_hash() {
         let data = rand_bytes();
         let reader = HashingRead::new(data.as_slice());
-        let digest_res = reader.finish(); // This should !!! consume the reader entirely !!! and return the digest
+        let digest_res = reader.finish().unwrap(); // This should !!! consume the reader entirely !!! and return the digest
         let digest_bytes = digest_res.as_ref();
 
         let expected_digest = digest(&SHA384, &data);


### PR DESCRIPTION
## Changes

- Added the option to use any `ring::digest::Algorithm` for `trustify_module_ingestor::service::hashing::HashingRead` - defaulting to SHA384 (previously SHA256, see #161)

- Changed associated functions to match `ring::digest::Digest` behavior - mainly `.finish()`, that takes ownership of main to prevent any misuse.

- Added tests for hashing / reading.