### PR TITLE
docs: first try for some design docs

### DIFF
--- a/docs/design/importer.md
+++ b/docs/design/importer.md
@@ -1,0 +1,88 @@
+# Importer
+
+The importer is responsible for importing documents into the system.
+
+Module level documentation: [modules/importer/README.md](../../modules/importer/README.md)
+
+## Entities
+
+```mermaid
+erDiagram
+
+IMPORTER only one to zero or more IMPORTER_REPORT : owns
+
+IMPORTER {
+    string name PK
+    uuid revision
+
+    state state
+    json configuration
+}
+
+IMPORTER_REPORT {
+    uuid id PK
+    string importer FK
+    string error
+    json report
+}
+```
+
+## Services
+
+```mermaid
+classDiagram
+
+IngestorService <|-- ImporterService
+
+class IngestorService {
+    +ingest_sbom(SBOM)
+    +ingest_advisory(SBOM)
+}
+
+class Importer {
+    +string name
+    +uuid revision
+    
+    +state state
+    +timestamp? last_change
+    +timestamp? last_run
+    +timestamp? last_success
+    +string? last_error
+    
+    +ImporterConfiguration configuration
+}
+
+class ImporterConfiguration {
+    +json value
+}
+
+class ImporterService {
+    +create(name, ImporterConfiguration)
+    +Importer read(name)
+    +delete(name, revision?)
+
+    +update_configuration(name, ImporterConfiguration, revision?)
+    +update_start(name)
+    +update_finish(name, report)
+
+    +Vec~Importer~ list()
+    +Vec~ImporterReport~ get_reports(name)
+}
+```
+
+```mermaid
+sequenceDiagram
+
+loop
+    ImporterService ->> ImporterConfig: wait for next pending job
+    ImporterConfig -->> ImporterService: next job
+    loop
+        ImporterService ->> Source: fetch next document
+        Source -->> ImporterService: next document
+        ImporterService ->>+ IngestorService: store document
+        IngestorService -->>- ImporterService: finished
+    end
+    ImporterService ->> ImporterReport: store report
+end
+```
+


### PR DESCRIPTION
This is a first test on how we could do design docs as part of the code. At least, closer to the code.

I think it works reasonably well. My expectation would be that the docs might not be fleshed out, might have some gaps in less relevant areas, but must be correct!

 I am not sure about the file system structure. Those docs could also go into their respective modules folders.

Rendered version: https://github.com/ctron/trustify/blob/feature/design_docs_1/docs/design/importer.md