### PR TITLE
fix: swagger-ui by pulling in utoipa upstream fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6235,9 +6235,8 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+version = "4.2.2"
+source = "git+https://github.com/juhaku/utoipa?rev=09eb5abcac98c98d501f0ea4c760d3bf491a965e#09eb5abcac98c98d501f0ea4c760d3bf491a965e"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -6247,9 +6246,8 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+version = "4.3.0"
+source = "git+https://github.com/juhaku/utoipa?rev=09eb5abcac98c98d501f0ea4c760d3bf491a965e#09eb5abcac98c98d501f0ea4c760d3bf491a965e"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,5 @@ trustify-server = { path = "server"}
 #sbom-walker = { path = "../csaf-walker/sbom" }
 #walker-common = { path = "../csaf-walker/common" }
 #walker-extras = { path = "../csaf-walker/extras" }
+
+utoipa = { git = "https://github.com/juhaku/utoipa", rev = "09eb5abcac98c98d501f0ea4c760d3bf491a965e" }

--- a/modules/fetch/src/endpoints/package.rs
+++ b/modules/fetch/src/endpoints/package.rs
@@ -21,7 +21,7 @@ pub struct PackageParams {
         (status = 200, description = "Dependencies"),
     ),
 )]
-#[get("/package/{purl}/dependencies")]
+#[get("/api/v1/package/{purl}/dependencies")]
 pub async fn dependencies(
     //state: web::Data<Graph>,
     purl: web::Path<String>,
@@ -63,7 +63,7 @@ pub async fn dependencies(
         (status = 200, description = "Affected packages"),
     ),
 )]
-#[get("/package/{purl}/dependents")]
+#[get("/api/v1/package/{purl}/dependents")]
 pub async fn dependents(
     //state: web::Data<Graph>,
     purl: web::Path<String>,
@@ -79,7 +79,7 @@ pub async fn dependents(
         (status = 200, description = "Affected packages"),
     ),
 )]
-#[get("/package/{purl}/variants")]
+#[get("/api/v1/package/{purl}/variants")]
 pub async fn variants(
     //state: web::Data<Graph>,
     purl: web::Path<String>,
@@ -106,7 +106,7 @@ pub async fn variants(
         (status = 200, description = "Affected packages"),
     ),
 )]
-#[get("/package/{purl}/vulnerabilities")]
+#[get("/api/v1/package/{purl}/vulnerabilities")]
 pub async fn vulnerabilities(
     //state: web::Data<Graph>,
     purl: web::Path<String>,

--- a/modules/ingestor/src/endpoints/advisory.rs
+++ b/modules/ingestor/src/endpoints/advisory.rs
@@ -3,14 +3,14 @@ use actix_web::{get, post, web, HttpResponse, Responder};
 use tokio_util::io::ReaderStream;
 
 #[utoipa::path(
-    tag = "ingestor",
+    tag = "advisory",
     request_body = Vec <u8>,
     responses(
         (status = 201, description = "Upload a file"),
         (status = 400, description = "The file could not be parsed as an advisory"),
     )
 )]
-#[post("/advisories")]
+#[post("/api/v1/advisory")]
 /// Upload a new advisory
 pub async fn upload_advisory(
     service: web::Data<IngestorService>,
@@ -23,13 +23,13 @@ pub async fn upload_advisory(
 }
 
 #[utoipa::path(
-    tag = "ingestor",
+    tag = "advisory",
     responses(
         (status = 200, description = "Download a an advisory", body = Vec<u8>),
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/advisories/{id}")]
+#[get("/api/v1/advisory/{id}")]
 /// Download an advisory
 pub async fn download_advisory(
     // TODO: Do we use this?!?!?!
@@ -61,7 +61,7 @@ mod tests {
         let app = test::init_service(App::new().configure(|svc| configure(svc, db, storage))).await;
         let payload = include_str!("../../../../etc/test-data/cve-2023-33201.json");
 
-        let uri = "/advisories?location=test-csaf";
+        let uri = "/api/v1/advisory";
         let request = TestRequest::post()
             .uri(uri)
             .set_payload(payload)
@@ -83,7 +83,7 @@ mod tests {
         let app = test::init_service(App::new().configure(|svc| configure(svc, db, storage))).await;
         let payload = include_str!("../../../../etc/test-data/osv/RUSTSEC-2021-0079.json");
 
-        let uri = "/advisories?location=test-osv&format=osv";
+        let uri = "/api/v1/advisory";
         let request = TestRequest::post()
             .uri(uri)
             .set_payload(payload)
@@ -104,7 +104,7 @@ mod tests {
         let (storage, _temp) = FileSystemBackend::for_test().await?;
         let app = test::init_service(App::new().configure(|svc| configure(svc, db, storage))).await;
 
-        let uri = "/advisories?location=testless&format=XYZ42";
+        let uri = "/api/v1/advisory";
         let request = TestRequest::post().uri(uri).to_request();
 
         let response = test::call_service(&app, request).await;

--- a/modules/ingestor/src/endpoints/sbom.rs
+++ b/modules/ingestor/src/endpoints/sbom.rs
@@ -10,7 +10,7 @@ pub struct UploadSbomQuery {
 }
 
 #[utoipa::path(
-    tag = "ingestor",
+    tag = "sbom",
     request_body = Vec <u8>,
     params(
         ("location" = String, Query, description = "Source the document came from"),
@@ -20,7 +20,7 @@ pub struct UploadSbomQuery {
         (status = 400, description = "The file could not be parsed as an advisory"),
     )
 )]
-#[post("/sboms")]
+#[post("/api/v1/sbom")]
 /// Upload a new advisory
 pub async fn upload_sbom(
     service: web::Data<IngestorService>,
@@ -32,13 +32,13 @@ pub async fn upload_sbom(
 }
 
 #[utoipa::path(
-    tag = "ingestor",
+    tag = "sbom",
     responses(
         (status = 200, description = "Download a an SBOM", body = Vec<u8>),
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/sboms/{id}")]
+#[get("/api/v1/sbom/{id}")]
 /// Download an SBOM
 pub async fn download_sbom(
     service: web::Data<IngestorService>,


### PR DESCRIPTION
Fixes: #235

This allows us to keep our OpenApi docs modular, i.e. merge now honors http methods.