### PR TITLE
Add instructions for running UI using the container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,19 @@ cargo run --bin trustd
 ```
 That will create its own database on your local filesystem. Point your browser at http://localhost:8080/swagger-ui/ to view the API.
 
-You can then fire up the [trustify-ui](https://github.com/trustification/trustify-ui).
+You can fire up the UI using:
+
+```shell
+podman run --network="host" \
+-e TRUSTIFICATION_API_URL=http://localhost:8080 \
+-e AUTH_REQUIRED=false \
+-e ANALYTICS_ENABLED=false \
+-e PORT=3000 \
+-p 3000:3000 \
+ghcr.io/trustification/trustify-ui:latest
+```
+
+Open the UI at http://localhost:3000
 
 ## Repository Organization
 


### PR DESCRIPTION
I acknowledge the need to see the current status of the UI in relation to the backend and since https://github.com/trustification/trustify/pull/176 is taking some time to order things, I decided to add instruction to the Readme.md file so anyone can start the UI container image and play with it.

I will continue working on https://github.com/trustification/trustify/pull/176 though