### PR TITLE
Thicken up the Vulnerability DTOs.

### DIFF
--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -3,6 +3,7 @@ use crate::{
     not_affected_package_version, vulnerability_description,
 };
 use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "vulnerability")]
@@ -11,6 +12,9 @@ pub struct Model {
     pub id: i32,
     pub identifier: String,
     pub title: Option<String>,
+    pub published: Option<OffsetDateTime>,
+    pub modified: Option<OffsetDateTime>,
+    pub withdrawn: Option<OffsetDateTime>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/migration/src/m0000040_create_vulnerability.rs
+++ b/migration/src/m0000040_create_vulnerability.rs
@@ -34,11 +34,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Vulnerability::Title).string())
                     .col(ColumnDef::new(Vulnerability::Published).timestamp_with_time_zone())
                     .col(ColumnDef::new(Vulnerability::Modified).timestamp_with_time_zone())
-                    .col(
-                        ColumnDef::new(Vulnerability::Withdrawn)
-                            .timestamp_with_time_zone()
-                            .default(Func::cust(Now)),
-                    )
+                    .col(ColumnDef::new(Vulnerability::Withdrawn).timestamp_with_time_zone())
                     .to_owned(),
             )
             .await

--- a/migration/src/m0000040_create_vulnerability.rs
+++ b/migration/src/m0000040_create_vulnerability.rs
@@ -32,6 +32,13 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(Vulnerability::Title).string())
+                    .col(ColumnDef::new(Vulnerability::Published).timestamp_with_time_zone())
+                    .col(ColumnDef::new(Vulnerability::Modified).timestamp_with_time_zone())
+                    .col(
+                        ColumnDef::new(Vulnerability::Withdrawn)
+                            .timestamp_with_time_zone()
+                            .default(Func::cust(Now)),
+                    )
                     .to_owned(),
             )
             .await
@@ -52,4 +59,7 @@ pub enum Vulnerability {
     // --
     Identifier,
     Title,
+    Published,
+    Modified,
+    Withdrawn,
 }

--- a/modules/fetch/src/endpoints/advisory.rs
+++ b/modules/fetch/src/endpoints/advisory.rs
@@ -120,6 +120,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -152,6 +153,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -203,6 +205,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -217,6 +220,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )

--- a/modules/fetch/src/endpoints/vulnerability.rs
+++ b/modules/fetch/src/endpoints/vulnerability.rs
@@ -238,6 +238,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -270,6 +271,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -309,6 +311,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -341,6 +344,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )

--- a/modules/fetch/src/model/vulnerability.rs
+++ b/modules/fetch/src/model/vulnerability.rs
@@ -10,13 +10,16 @@ use utoipa::ToSchema;
 pub struct VulnerabilityHead {
     pub identifier: String,
     pub title: Option<String>,
+    pub published: Option<OffsetDateTime>,
+    pub modified: Option<OffsetDateTime>,
+    pub withdrawn: Option<OffsetDateTime>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilitySummary {
     #[serde(flatten)]
     pub head: VulnerabilityHead,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub advisories: Vec<VulnerabilityAdvisoryHead>,
 }
 

--- a/modules/fetch/src/service/advisory.rs
+++ b/modules/fetch/src/service/advisory.rs
@@ -420,6 +420,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -452,6 +453,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -480,6 +482,7 @@ mod test {
                     title: Some("RHSA-1".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )
@@ -519,6 +522,7 @@ mod test {
                     title: Some("RHSA-2".to_string()),
                     published: Some(OffsetDateTime::now_utc()),
                     modified: None,
+                    withdrawn: None,
                 },
                 (),
             )

--- a/modules/fetch/src/service/vulnerability.rs
+++ b/modules/fetch/src/service/vulnerability.rs
@@ -249,6 +249,9 @@ impl super::FetchService {
                 head: VulnerabilityHead {
                     identifier: vuln.identifier.clone(),
                     title: vuln.title.clone(),
+                    published: vuln.published,
+                    modified: vuln.modified,
+                    withdrawn: vuln.withdrawn,
                 },
                 advisories: self
                     .vulnerability_advisory_heads(vuln.id, advisories, &tx)
@@ -269,6 +272,9 @@ impl super::FetchService {
             .map(|vuln| VulnerabilityHead {
                 identifier: vuln.identifier.clone(),
                 title: vuln.title.clone(),
+                published: vuln.published,
+                modified: vuln.modified,
+                withdrawn: vuln.withdrawn,
             })
             .collect())
     }
@@ -509,6 +515,9 @@ impl super::FetchService {
                 head: VulnerabilityHead {
                     identifier: vuln.identifier,
                     title: vuln.title,
+                    published: vuln.published,
+                    modified: vuln.modified,
+                    withdrawn: vuln.withdrawn,
                 },
                 advisories: self
                     .vulnerability_advisory_heads(vuln.id, &advisories, &tx)
@@ -544,6 +553,9 @@ impl super::FetchService {
             head: VulnerabilityHead {
                 identifier: vuln.identifier.clone(),
                 title: vuln.title.clone(),
+                published: vuln.published,
+                modified: vuln.modified,
+                withdrawn: vuln.withdrawn,
             },
             advisories,
         }))

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -24,6 +24,7 @@ pub struct AdvisoryInformation {
     pub title: Option<String>,
     pub published: Option<OffsetDateTime>,
     pub modified: Option<OffsetDateTime>,
+    pub withdrawn: Option<OffsetDateTime>,
 }
 
 impl From<()> for AdvisoryInformation {
@@ -76,6 +77,7 @@ impl Graph {
             title,
             published,
             modified,
+            ..
         } = information.into();
 
         let model = entity::advisory::ActiveModel {
@@ -186,7 +188,7 @@ impl<'g> AdvisoryContext<'g> {
             return Ok(found);
         }
 
-        let vulnerability = self.graph.ingest_vulnerability(identifier, &tx).await?;
+        let vulnerability = self.graph.ingest_vulnerability(identifier, (), &tx).await?;
 
         let entity = entity::advisory_vulnerability::ActiveModel {
             advisory_id: Set(self.advisory.id),

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -5,28 +5,71 @@ use crate::graph::error::Error;
 use crate::graph::Graph;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, NotSet, QueryFilter, QuerySelect,
-    RelationTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
 };
 use sea_query::JoinType;
 use std::fmt::{Debug, Formatter};
+use time::OffsetDateTime;
 use trustify_common::db::Transactional;
 use trustify_entity as entity;
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 
+#[derive(Clone, Default)]
+pub struct VulnerabilityInformation {
+    pub title: Option<String>,
+    pub published: Option<OffsetDateTime>,
+    pub modified: Option<OffsetDateTime>,
+    pub withdrawn: Option<OffsetDateTime>,
+}
+
+impl VulnerabilityInformation {
+    pub fn has_data(&self) -> bool {
+        self.title.is_some()
+            || self.published.is_some()
+            || self.modified.is_some()
+            || self.withdrawn.is_some()
+    }
+}
+
+impl From<()> for VulnerabilityInformation {
+    fn from(_: ()) -> Self {
+        Self {
+            title: None,
+            published: None,
+            modified: None,
+            withdrawn: None,
+        }
+    }
+}
+
 impl Graph {
-    pub async fn ingest_vulnerability<TX: AsRef<Transactional>>(
+    pub async fn ingest_vulnerability<
+        I: Into<VulnerabilityInformation>,
+        TX: AsRef<Transactional>,
+    >(
         &self,
         identifier: &str,
+        information: I,
         tx: TX,
     ) -> Result<VulnerabilityContext, Error> {
+        let information = information.into();
         if let Some(found) = self.get_vulnerability(identifier, &tx).await? {
-            Ok(found)
+            if information.has_data() {
+                // we should update with the details.
+                let entity = vulnerability::ActiveModel::from(found.vulnerability);
+                let model = entity.update(&self.connection(&tx)).await?;
+                Ok(VulnerabilityContext::new(&found.graph, model))
+            } else {
+                Ok(found)
+            }
         } else {
             let entity = vulnerability::ActiveModel {
                 id: Default::default(),
                 identifier: Set(identifier.to_string()),
-                title: NotSet,
+                title: Set(information.title),
+                published: Set(information.published),
+                modified: Set(information.modified),
+                withdrawn: Set(information.withdrawn),
             };
 
             Ok(VulnerabilityContext::new(
@@ -86,17 +129,6 @@ impl VulnerabilityContext {
             .collect())
     }
 
-    pub async fn set_title<TX: AsRef<Transactional>>(
-        &self,
-        title: Option<String>,
-        tx: TX,
-    ) -> Result<(), Error> {
-        let mut entity: vulnerability::ActiveModel = self.vulnerability.clone().into();
-        entity.title = Set(title);
-        entity.save(&self.graph.connection(&tx)).await?;
-        Ok(())
-    }
-
     pub async fn add_description<TX: AsRef<Transactional>>(
         &self,
         lang: &str,
@@ -147,13 +179,13 @@ mod tests {
         let system = Graph::new(db);
 
         let cve1 = system
-            .ingest_vulnerability("CVE-123", Transactional::None)
+            .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
         let cve2 = system
-            .ingest_vulnerability("CVE-123", Transactional::None)
+            .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
         let cve3 = system
-            .ingest_vulnerability("CVE-456", Transactional::None)
+            .ingest_vulnerability("CVE-456", (), Transactional::None)
             .await?;
 
         assert_eq!(cve1.vulnerability.id, cve2.vulnerability.id);

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -26,6 +26,7 @@ impl<'a> From<Information<'a>> for AdvisoryInformation {
                 value.document.tracking.current_release_date.timestamp(),
             )
             .ok(),
+            withdrawn: None,
         }
     }
 }

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -51,6 +51,7 @@ impl<'g> OsvLoader<'g> {
                 title: osv.summary.clone(),
                 published: Some(osv.published),
                 modified: Some(osv.modified),
+                withdrawn: osv.withdrawn,
             };
             let advisory = self
                 .graph

--- a/modules/ingestor/src/service/cve/cve_record/v5.rs
+++ b/modules/ingestor/src/service/cve/cve_record/v5.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -24,6 +24,34 @@ impl CveMetadata {
             CveMetadata::Rejected(inner) => &inner.cve_id,
         }
     }
+
+    pub fn date_reserved(&self) -> Option<OffsetDateTime> {
+        match self {
+            CveMetadata::Published(inner) => inner.date_reserved,
+            CveMetadata::Rejected(inner) => inner.date_reserved,
+        }
+    }
+
+    pub fn date_published(&self) -> Option<OffsetDateTime> {
+        match self {
+            CveMetadata::Published(inner) => inner.date_published,
+            CveMetadata::Rejected(inner) => inner.date_published,
+        }
+    }
+
+    pub fn date_updated(&self) -> Option<OffsetDateTime> {
+        match self {
+            CveMetadata::Published(inner) => inner.date_updated,
+            CveMetadata::Rejected(inner) => inner.date_updated,
+        }
+    }
+
+    pub fn date_rejected(&self) -> Option<OffsetDateTime> {
+        match self {
+            CveMetadata::Published(_) => None,
+            CveMetadata::Rejected(inner) => inner.date_rejected,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -33,10 +61,13 @@ pub struct MetadataPublished {
     pub assigner_org_id: String,
     pub assigner_short_name: Option<String>,
     pub requester_user_id: Option<String>,
-    pub date_updated: Option<DateTime<Utc>>,
     pub serial: Option<u64>,
-    pub date_reserved: Option<DateTime<Utc>>,
-    pub date_published: Option<DateTime<Utc>>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_updated: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_reserved: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_published: Option<OffsetDateTime>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -46,11 +77,15 @@ pub struct MetadataRejected {
     pub assigner_org_id: String,
     pub assigner_short_name: Option<String>,
     pub requester_user_id: Option<String>,
-    pub date_updated: Option<DateTime<Utc>>,
     pub serial: Option<u64>,
-    pub date_reserved: Option<DateTime<Utc>>,
-    pub date_published: Option<DateTime<Utc>>,
-    pub date_rejected: Option<DateTime<Utc>>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_updated: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_reserved: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_published: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub date_rejected: Option<OffsetDateTime>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Hydrate details into a Vulnerability even if ingested after first light reference. Add some error-reporting if format auto-detection doesn't. Ensure `vulnerabilities` field is included, even if an empty array.