### PR TITLE
chore: enable metrics endpoint

### DIFF
--- a/common/infrastructure/src/app/http.rs
+++ b/common/infrastructure/src/app/http.rs
@@ -392,6 +392,7 @@ impl HttpServerBuilder {
 
     pub fn metrics(mut self, registry: impl Into<Registry>, namespace: impl AsRef<str>) -> Self {
         let metrics = PrometheusMetricsBuilder::new(namespace.as_ref())
+            .endpoint("/metrics")
             .registry(registry.into())
             .build();
 


### PR DESCRIPTION
Related to https://github.com/trustification/trustify/discussions/262
Sort of related to #261 

```sh
➜  ~ curl http://localhost:8080/metrics
# HELP trustify_http_requests_duration_seconds HTTP request duration in seconds for all requests
# TYPE trustify_http_requests_duration_seconds histogram
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.005"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.01"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.025"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.05"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.1"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.25"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.5"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="1"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="2.5"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="5"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="10"} 1
trustify_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="+Inf"} 1
trustify_http_requests_duration_seconds_sum{endpoint="/metrics",method="GET",status="200"} 0.000127021
trustify_http_requests_duration_seconds_count{endpoint="/metrics",method="GET",status="200"} 1
# HELP trustify_http_requests_total Total number of HTTP requests
# TYPE trustify_http_requests_total counter
trustify_http_requests_total{endpoint="/metrics",method="GET",status="200"} 1
```
