### PR TITLE
chore: markdown lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ cargo run --bin trustd --no-default-features
 ```
 
 That will create its own database on your local filesystem.
-The first command also contains **UI** so point your browser at <http://localhost:8080>.
-The second runs without **UI** then you can go at <http://localhost:8080/swagger-ui/> to view the API.
+
+* The first command also contains **UI** so point your browser at <http://localhost:8080>.
+* The second runs without **UI** then you can go at <http://localhost:8080/swagger-ui/> to view the API.
 
 ### Running containerized UI
 

--- a/docs/design/fetch-service.md
+++ b/docs/design/fetch-service.md
@@ -1,20 +1,21 @@
 # Fetch Service
 
 ## Purpose
-The fetch service is used to fetch, without much analysis or calcuation, a variety of entities for the REST API.
+
+The fetch service is used to fetch, without much analysis or calculation, a variety of entities for the REST API.
 Some traversal does occur, as top-level entities may include relevant joined entities.
 
 ## Types of DTOs
 
-There are currently 3 varieties of DTOs in play. 
+There are currently 3 varieties of DTOs in play.
 To demonstrate, we will use the intersection of *Advisory* and the *Vulnerabilities* it may reference.
 
 The various types will be described below, but generally-speaking:
 
 * Summary DTOs contains the head of the object.
-  * Summary DTOs may link to heads of _related_ objects.
+  * Summary DTOs may link to heads of *related* objects.
 * Detail DTOs contains the object of the object.
-  *  Detail DTOs may link to summaries of _related_ objects.
+  * Detail DTOs may link to summaries of *related* objects.
 
 ### Head
 
@@ -22,7 +23,7 @@ The various types will be described below, but generally-speaking:
 
 The "head" of an Advisory contains very top-level aspects of the Entity, such as:
 
-* Identifer
+* Identifier
 * Hashes/digests to address it
 * Dates relevant to the publication, modification and withdrawal.
 * It's title
@@ -41,19 +42,19 @@ The summary of this join includes:
 * The vulnerability's "head"
 * Verbatim CVSS3 scores
 * Fixed/NotAffected/Affected assertions
- 
+
 ### Vulnerability
- 
+
 The "head" of a Vulnerability contains very top-level aspects also, such as
 
-* Identifer
+* Identifier
 * Title
 
 Neither of these head DTOs are directly fetchable from the REST API.
 
 #### VulnerabilityAdvisory
 
-Sitting between Vulnerabilitly and Advisory (in that particular direction) is another DTO referred to as a "vulnerability-advisory join", which also can have a "head" and "summary" variant.
+Sitting between Vulnerability and Advisory (in that particular direction) is another DTO referred to as a "vulnerability-advisory join", which also can have a "head" and "summary" variant.
 
 The head of this join includes:
 
@@ -69,10 +70,9 @@ The summary of a vulnerability includes the "head" as described above, plus a li
 
 The summary of an advisory includes the "head" as described above, plus a list of associated advisory-vulnerability joins.
 
-
 ### Details
 
-Details objects contain _all_ required information, and may link to _summaries_ of related objects (which may then link to _heads_ of their second-order related objects).
+Details objects contain *all* required information, and may link to *summaries* of related objects (which may then link to *heads* of their second-order related objects).
 
 ```mermaid
 ---
@@ -99,13 +99,10 @@ erDiagram
     AdvisoryVulnerabilityHead ||--|| VulnerabilityHead : includes
     AdvisoryDetails ||--o{ AdvisoryVulnerabilitySummary : references
     AdvisoryVulnerabilitySummary ||--|| VulnerabilityHead : includes
-    
+
     VulnerabilitySummary ||--|| VulnerabilityHead : contains
     VulnerabilitySummary ||--o{ VulnerabilityAdvisoryHead : references
     VulnerabilityAdvisoryHead ||--|| AdvisoryHead : includes
-    VulnerabliityDetails ||--o{ VulnerbaililyAdvisorySummary: references
+    VulnerabilityDetails ||--o{ VulnerabilityAdvisorySummary: references
     VulnerabilityAdvisorySummary ||--|| AdvisoryHead: includes
-        
-        
-
 ```

--- a/docs/design/importer.md
+++ b/docs/design/importer.md
@@ -42,13 +42,13 @@ class IngestorService {
 class Importer {
     +string name
     +uuid revision
-    
+
     +state state
     +timestamp? last_change
     +timestamp? last_run
     +timestamp? last_success
     +string? last_error
-    
+
     +ImporterConfiguration configuration
 }
 
@@ -85,4 +85,3 @@ loop
     ImporterService ->> ImporterReport: store report
 end
 ```
-

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,7 +9,7 @@ Generally, to this point, most vulnerabilities come from the CVE Project, with t
 
 Within the database, generally a vulnerability is added as a side effect of an advisory mentioning it.
 
-A _CVE Record_ from NIST/NVD is a low-value advisory that is generally the first discovered advisory that mentions a vulnerability.
+A *CVE Record* from NIST/NVD is a low-value advisory that is generally the first discovered advisory that mentions a vulnerability.
 
 ### Advisory
 
@@ -18,25 +18,25 @@ An advisory is an opinion about a vulnerability.
 These opinions include the context to which the opinions apply.
 These opinions include evaluation of the severity and scoring of a vulnerability within that context, such as CVSS scores.
 
-As mentioned above, a _CVE Record_ from the CVE Project is a low-value advisory that mentions the vulnerability and provide a base opinion about it.
+As mentioned above, a *CVE Record* from the CVE Project is a low-value advisory that mentions the vulnerability and provide a base opinion about it.
 It may include CVSS scores, within the context of the abstract origin containing the vulnerability.
-This may be simply in reference to the vulnerability _as it exists in source-code form_.
+This may be simply in reference to the vulnerability *as it exists in source-code form*.
 
 Other, more-involved stakeholders (product vendors, upstream project owners) may issue *additional* advisories.
-These opinions may be in reference to _concrete_ shipped products, contextualized to how the vulnerable code is _actually used_.
+These opinions may be in reference to *concrete* shipped products, contextualized to how the vulnerable code is *actually used*.
 
 ### Package
 
 A package is an atomic artifact or component.
 Packages may be addressed using pURLs.
-A package may be described by an SBOM describing how it is created and its contents. 
+A package may be described by an SBOM describing how it is created and its contents.
 A package may certainly contain other packages (e.g. shading one Java jar into another).
 A package may also be the sole member of a Product (`UBI-8.0.13-x86.oci` may be the singular package within the "UBI 8.0.13-x86" product).
-A package is one step more abstract than an _artifact_.
+A package is one step more abstract than an *artifact*.
 
 #### pURL
 
-Package URLs (pURLs) are possibly ambiguous names applied to packages. 
+Package URLs (pURLs) are possibly ambiguous names applied to packages.
 A simple pURL such as `pkg:maven/org.apache/log4j@1.2.3` may or may not refer to a unique artifact.
 With additional qualifiers, it is possible to produce a URI that asserts uniqueness, such as `pkg:maven/org.apache/log4j@1.2.3?repository_url=repo.jboss.com`.
 Without additional qualifiers, the implicit aspects (such as `repository_url`) must be taken into account.
@@ -44,16 +44,16 @@ For instance, an unqualified `pkg:maven` pURL *implies* "the jar from Maven Cent
 
 ### Product
 
-A product is a _named collection of 1 or more packages_ for a concrete shippable thing.
+A product is a *named collection of 1 or more packages* for a concrete shippable thing.
 
 Products may be addressed using CPEs or some other future identification method.
 A product may be described by an SBOM describing its components, which may be other products or packages, or their SBOMs.
 
-> **NOTE**
+> [!NOTE]
 > Given ProdSec definitions, grouping of Products may need to occur within some sense of Product Versions, or Product Streams.
 
-`RHEL8` may be a _product stream_.
-`RHEL 8.2.03 PowerPC` may be a concrete _product_ distinct from `RHEL 8.2.03 AArch64`.
+`RHEL8` may be a *product stream*.
+`RHEL 8.2.03 PowerPC` may be a concrete *product* distinct from `RHEL 8.2.03 AArch64`.
 
 #### CPE
 
@@ -63,19 +63,14 @@ CPEs describe the vendor, the product, the version, target architecture, etc.
 CPEs may also be non-fully specified, to use as pattern-matching.
 For instance, "All versions of RHEL 8.2.013, regardless of platform", or if more fully-specified, could imply "All versions of RHEL 8.x on AArch64".
 
-> **NOTE** 
+> [!NOTE]
 > CPEs are somewhat contentious, and used enough for us to not ignore, but not used enough to be a pivotal definition of "product" for any users of Trustify.
 
-### Artifact.
+### Artifact
 
-For a given _package_, there may be zero or more instances of that package.
+For a given *package*, there may be zero or more instances of that package.
 Given `log4j-1.2.3.jar`, seventeen different people could compile the same source with the same arguments, and still end up with 17 distinct Java jars (due to non-reproducible builds).
-Each is an artifact of the _same_ package.
+Each is an artifact of the *same* package.
 Each may (will probably) have its own SHA-256 related to it.
 
 Consider an *artifact* to be a concrete *instance* of a package.
-
-
-
-
-

--- a/modules/README.md
+++ b/modules/README.md
@@ -6,7 +6,7 @@ Currently, we have:
 
 * `graph` – The core graph model, correlation between the different SBOM and advisory entities.
 * `ingestor` – Data ingestion functionality.
-* `importer` – Scheduled data import management and execution. Uses `ingestor` for ingesting data. 
+* `importer` – Scheduled data import management and execution. Uses `ingestor` for ingesting data.
 
 There's an ideal (not enforced) layout of modules:
 

--- a/modules/fetch/README.md
+++ b/modules/fetch/README.md
@@ -1,30 +1,30 @@
-Find SBOMs:
+# Find SBOMs
 
-```bash
+```shell
 http GET localhost:8080/api/v1/sbom limit==5 offset==0
 ```
 
 Retrieve SBOM:
 
-```bash
+```shell
 http GET localhost:8080/sboms/1
 ```
 
 Get SBOM packages:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/sbom/1/packages limit==5 offset==0
 ```
 
 Get SBOM top-level packages:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/sbom/1/packages limit==5 offset==0 root==true
 ```
 
 Get related packages:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/sbom/1/related limit==5 offset==0 reference==<purl>
 ```
 
@@ -34,6 +34,6 @@ It also is possible to limit the search to a specific relationship type by provi
 
 For example:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/sbom/1/related limit==5 offset==0 reference==pkg://maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=pom which==right
 ```

--- a/modules/importer/README.md
+++ b/modules/importer/README.md
@@ -1,6 +1,6 @@
-Create a new CSAF importer:
+# Create a new CSAF importer
 
-```bash
+```shell
 http POST localhost:8080/api/v1/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[onlyPatterns][]="^cve-2023-" csaf[period]=30s csaf[v3Signatures]:=true
 ```
 
@@ -8,33 +8,33 @@ Create a new SBOM importer:
 
 Quarkus & RHEL 9 data:
 
-```bash
+```shell
 http POST localhost:8080/api/v1/importer/redhat-sbom sbom[source]=https://access.redhat.com/security/data/sbom/beta/ sbom[keys][]=https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
 ```
 
 Get all importers:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/importer
 ```
 
 Get a specific importer:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/importer/redhat-csaf
 http GET localhost:8080/api/v1/importer/redhat-sbom
 ```
 
 Get reports:
 
-```bash
+```shell
 http GET localhost:8080/api/v1/importer/redhat-csaf/report
 http GET localhost:8080/api/v1/importer/redhat-sbom/report
 ```
 
 Delete an importer:
 
-```bash
+```shell
 http DELETE localhost:8080/api/v1/importer/redhat-csaf
 http DELETE localhost:8080/api/v1/importer/redhat-sbom
 ```


### PR DESCRIPTION
* Fixes some typos
* Standardizing shell usage for command code blocks (as in readme) instead of bash
* changed _ to * for emphasis (weirdo md lint says _ is bad)