### PR TITLE
Ensure dates are included in fully-ingested vulnerabilities.

### DIFF
--- a/model/src/advisory/details/advisory_vulnerability.rs
+++ b/model/src/advisory/details/advisory_vulnerability.rs
@@ -260,9 +260,7 @@ impl AdvisoryVulnerabilitySummary {
                     summaries.push(AdvisoryVulnerabilitySummary {
                         head,
                         cvss3_scores,
-                        assertions: AdvisoryVulnerabilityAssertions {
-                            assertions
-                        }
+                        assertions: AdvisoryVulnerabilityAssertions { assertions },
                     });
                 }
             }

--- a/model/src/advisory/details/advisory_vulnerability.rs
+++ b/model/src/advisory/details/advisory_vulnerability.rs
@@ -260,7 +260,9 @@ impl AdvisoryVulnerabilitySummary {
                     summaries.push(AdvisoryVulnerabilitySummary {
                         head,
                         cvss3_scores,
-                        assertions: Default::default(),
+                        assertions: AdvisoryVulnerabilityAssertions {
+                            assertions
+                        }
                     });
                 }
             }

--- a/model/src/vulnerability/details/vulnerability_advisory.rs
+++ b/model/src/vulnerability/details/vulnerability_advisory.rs
@@ -223,7 +223,9 @@ impl VulnerabilityAdvisorySummary {
                     summaries.push(VulnerabilityAdvisorySummary {
                         head,
                         cvss3_scores,
-                        assertions: Default::default(),
+                        assertions: AdvisoryVulnerabilityAssertions {
+                            assertions,
+                        },
                     });
                 }
             }

--- a/model/src/vulnerability/details/vulnerability_advisory.rs
+++ b/model/src/vulnerability/details/vulnerability_advisory.rs
@@ -223,9 +223,7 @@ impl VulnerabilityAdvisorySummary {
                     summaries.push(VulnerabilityAdvisorySummary {
                         head,
                         cvss3_scores,
-                        assertions: AdvisoryVulnerabilityAssertions {
-                            assertions,
-                        },
+                        assertions: AdvisoryVulnerabilityAssertions { assertions },
                     });
                 }
             }

--- a/model/src/vulnerability/mod.rs
+++ b/model/src/vulnerability/mod.rs
@@ -15,9 +15,16 @@ mod summary;
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityHead {
     pub identifier: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub published: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub modified: Option<OffsetDateTime>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub withdrawn: Option<OffsetDateTime>,
 }
 

--- a/modules/vulnerability/src/endpoints/test.rs
+++ b/modules/vulnerability/src/endpoints/test.rs
@@ -13,6 +13,7 @@ use trustify_cvss::cvss3::{
 };
 use trustify_model::vulnerability::VulnerabilitySummary;
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
+use trustify_module_ingestor::graph::vulnerability::VulnerabilityInformation;
 use trustify_module_ingestor::graph::Graph;
 
 #[test_context(TrustifyContext, skip_teardown)]
@@ -153,15 +154,30 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     advisory.link_to_vulnerability("CVE-345", ()).await?;
 
+    graph
+        .ingest_vulnerability(
+            "CVE-123",
+            VulnerabilityInformation {
+                title: Some("Something wicked this way comes".to_string()),
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
     let uri = "/api/v1/vulnerability/CVE-123";
-
     let request = TestRequest::get().uri(uri).to_request();
-
     let response: Value = actix_web::test::call_and_read_body_json(&app, request).await;
 
-    let identifier = response.path("$.identifier").unwrap();
+    let identifier = response.clone().path("$.identifier").unwrap();
+    let published = response.clone().path("$.published").unwrap();
+    let title = response.clone().path("$.title").unwrap();
 
     assert_eq!(identifier, json!(["CVE-123"]));
+    assert_eq!(title, json!(["Something wicked this way comes"]));
 
+    assert!(published.get(0).is_some());
     Ok(())
 }


### PR DESCRIPTION
Ensure dates are serialized in a non-array format as expected by the UI. Tests for the above.
Also, include the assertions we bothered to calculate.