### PR TITLE
Add support for Organization-related endpoints.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,6 +6378,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustify-module-organization"
+version = "0.1.0"
+dependencies = [
+ "actix-web",
+ "anyhow",
+ "async-trait",
+ "jsonpath-rust",
+ "log",
+ "sea-orm",
+ "sea-orm-migration",
+ "sea-query",
+ "serde",
+ "serde_json",
+ "test-context",
+ "test-log",
+ "thiserror",
+ "tracing",
+ "trustify-auth",
+ "trustify-common",
+ "trustify-cvss",
+ "trustify-entity",
+ "trustify-migration",
+ "trustify-model",
+ "trustify-module-ingestor",
+ "trustify-module-storage",
+ "utoipa",
+]
+
+[[package]]
 name = "trustify-module-storage"
 version = "0.1.0"
 dependencies = [
@@ -6488,6 +6517,7 @@ dependencies = [
  "trustify-module-fetch",
  "trustify-module-importer",
  "trustify-module-ingestor",
+ "trustify-module-organization",
  "trustify-module-storage",
  "trustify-module-ui",
  "trustify-module-vulnerability",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "modules/storage",
   "modules/ui",
   "modules/advisory",
+  "modules/organization",
   "modules/vulnerability",
   "server",
   "trustd",
@@ -122,6 +123,7 @@ trustify-module-search = { path = "modules/search" }
 trustify-module-storage = { path = "modules/storage" }
 trustify-module-ui = { path = "modules/ui", default-features = false }
 trustify-module-advisory = { path = "modules/advisory" }
+trustify-module-organization = { path = "modules/organization" }
 trustify-module-vulnerability = { path = "modules/vulnerability" }
 trustify-server = { path = "server", default-features = false }
 trustify-ui = { git = "https://github.com/trustification/trustify-ui.git" }

--- a/entity/src/organization.rs
+++ b/entity/src/organization.rs
@@ -1,3 +1,4 @@
+use crate::advisory;
 use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
@@ -12,5 +13,11 @@ pub struct Model {
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
+
+impl Related<advisory::Entity> for Entity {
+    fn to() -> RelationDef {
+        super::advisory::Relation::Issuer.def().rev()
+    }
+}
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/model/src/advisory/details/advisory_vulnerability.rs
+++ b/model/src/advisory/details/advisory_vulnerability.rs
@@ -27,16 +27,34 @@ pub struct AdvisoryVulnerabilityHead {
 
 impl AdvisoryVulnerabilityHead {
     pub async fn from_entity(
+        advisory: &advisory::Model,
         vulnerability: &vulnerability::Model,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Option<Self>, Error> {
-        Ok(VulnerabilityHead::from_entity(vulnerability, tx)
-            .await?
-            .map(|head| AdvisoryVulnerabilityHead {
-                head,
-                severity: "".to_string(),
-                score: 0.0,
-            }))
+    ) -> Result<Self, Error> {
+        let cvss3 = cvss3::Entity::find()
+            .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
+            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .all(tx)
+            .await?;
+
+        let score = if let Some(average) = cvss3
+            .iter()
+            .map(|e| {
+                let base = Cvss3Base::from(e.clone());
+                base.score().value()
+            })
+            .reduce(|accum, e| accum + e)
+        {
+            Score::new(average / cvss3.len() as f64)
+        } else {
+            Score::new(0.0)
+        };
+
+        Ok(AdvisoryVulnerabilityHead {
+            head: VulnerabilityHead::from_entity(vulnerability, tx).await?,
+            severity: score.severity().to_string(),
+            score: score.value(),
+        })
     }
 
     pub async fn from_entities(
@@ -66,13 +84,11 @@ impl AdvisoryVulnerabilityHead {
             } else {
                 Score::new(0.0)
             };
-            if let Some(head) = VulnerabilityHead::from_entity(vuln, tx).await? {
-                heads.push(AdvisoryVulnerabilityHead {
-                    head,
-                    severity: score.severity().to_string(),
-                    score: score.value(),
-                });
-            }
+            heads.push(AdvisoryVulnerabilityHead {
+                head: VulnerabilityHead::from_entity(vuln, tx).await?,
+                severity: score.severity().to_string(),
+                score: score.value(),
+            });
         }
 
         Ok(heads)
@@ -256,13 +272,11 @@ impl AdvisoryVulnerabilitySummary {
                     .map(|e| Cvss3Base::from(e).to_string())
                     .collect();
 
-                if let Some(head) = AdvisoryVulnerabilityHead::from_entity(vuln, tx).await? {
-                    summaries.push(AdvisoryVulnerabilitySummary {
-                        head,
-                        cvss3_scores,
-                        assertions: AdvisoryVulnerabilityAssertions { assertions },
-                    });
-                }
+                summaries.push(AdvisoryVulnerabilitySummary {
+                    head: AdvisoryVulnerabilityHead::from_entity(advisory, vuln, tx).await?,
+                    cvss3_scores,
+                    assertions: AdvisoryVulnerabilityAssertions { assertions },
+                });
             }
         }
 

--- a/model/src/advisory/mod.rs
+++ b/model/src/advisory/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use utoipa::ToSchema;
 
+use crate::organization::OrganizationSummary;
 use crate::Error;
 pub use details::advisory_vulnerability::*;
 pub use details::*;
@@ -17,7 +18,7 @@ mod summary;
 pub struct AdvisoryHead {
     pub identifier: String,
     pub sha256: String,
-    pub issuer: Option<String>,
+    pub issuer: Option<OrganizationSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(with = "time::serde::rfc3339::option")]
     pub published: Option<OffsetDateTime>,
@@ -33,19 +34,26 @@ pub struct AdvisoryHead {
 impl AdvisoryHead {
     pub async fn from_entity(
         entity: &advisory::Model,
+        issuer: Option<organization::Model>,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Option<Self>, Error> {
-        let issuer = entity.find_related(organization::Entity).one(tx).await?;
+    ) -> Result<Self, Error> {
+        let issuer = if let Some(issuer) = issuer {
+            Some(OrganizationSummary::from_entity(&issuer, tx).await?)
+        } else if let Some(issuer) = entity.find_related(organization::Entity).one(tx).await? {
+            Some(OrganizationSummary::from_entity(&issuer, tx).await?)
+        } else {
+            None
+        };
 
-        Ok(Some(Self {
+        Ok(Self {
             identifier: entity.identifier.clone(),
             sha256: entity.sha256.clone(),
-            issuer: issuer.map(|inner| inner.name),
+            issuer,
             published: entity.published,
             modified: entity.modified,
             withdrawn: entity.withdrawn,
             title: entity.title.clone(),
-        }))
+        })
     }
 
     pub async fn from_entities(
@@ -57,10 +65,16 @@ impl AdvisoryHead {
         let issuers = entities.load_one(organization::Entity, tx).await?;
 
         for (advisory, issuer) in entities.iter().zip(issuers) {
+            let issuer = if let Some(issuer) = issuer {
+                Some(OrganizationSummary::from_entity(&issuer, tx).await?)
+            } else {
+                None
+            };
+
             heads.push(Self {
                 identifier: advisory.identifier.clone(),
                 sha256: advisory.sha256.clone(),
-                issuer: issuer.map(|inner| inner.name),
+                issuer,
                 published: advisory.published,
                 modified: advisory.modified,
                 withdrawn: advisory.withdrawn,

--- a/model/src/advisory/summary.rs
+++ b/model/src/advisory/summary.rs
@@ -30,7 +30,7 @@ impl AdvisorySummary {
 
         let mut summaries = Vec::new();
 
-        for ((advisory, vulnerabilities), issuser) in entities
+        for ((advisory, vulnerabilities), issuer) in entities
             .iter()
             .zip(vulnerabilities.drain(..))
             .zip(issuers.drain(..))
@@ -39,15 +39,7 @@ impl AdvisorySummary {
                 AdvisoryVulnerabilityHead::from_entities(advisory, &vulnerabilities, tx).await?;
 
             summaries.push(AdvisorySummary {
-                head: AdvisoryHead {
-                    identifier: advisory.identifier.clone(),
-                    sha256: advisory.sha256.clone(),
-                    issuer: issuser.map(|inner| inner.name),
-                    published: advisory.published,
-                    modified: advisory.modified,
-                    withdrawn: advisory.withdrawn,
-                    title: advisory.title.clone(),
-                },
+                head: AdvisoryHead::from_entity(advisory, issuer, tx).await?,
                 vulnerabilities,
             })
         }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,6 +1,7 @@
 use sea_orm::DbErr;
 
 pub mod advisory;
+pub mod organization;
 pub mod vulnerability;
 
 #[derive(Debug, thiserror::Error)]

--- a/model/src/organization/details/mod.rs
+++ b/model/src/organization/details/mod.rs
@@ -1,0 +1,30 @@
+use sea_orm::ModelTrait;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use trustify_common::db::ConnectionOrTransaction;
+use trustify_entity::{advisory, organization};
+
+use crate::advisory::AdvisoryHead;
+use crate::organization::OrganizationHead;
+use crate::Error;
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+pub struct OrganizationDetails {
+    #[serde(flatten)]
+    head: OrganizationHead,
+    advisories: Vec<AdvisoryHead>,
+}
+
+impl OrganizationDetails {
+    pub async fn from_entity(
+        org: &organization::Model,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        let advisories = org.find_related(advisory::Entity).all(tx).await?;
+        Ok(OrganizationDetails {
+            head: OrganizationHead::from_entity(org, tx).await?,
+            advisories: AdvisoryHead::from_entities(&advisories, tx).await?,
+        })
+    }
+}

--- a/model/src/organization/mod.rs
+++ b/model/src/organization/mod.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+mod details;
+mod summary;
+
+use crate::Error;
+pub use details::*;
+pub use summary::*;
+use trustify_common::db::ConnectionOrTransaction;
+use trustify_entity::organization;
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct OrganizationHead {
+    pub id: i32,
+    pub name: String,
+    pub cpe_key: Option<String>,
+    pub website: Option<String>,
+}
+
+impl OrganizationHead {
+    pub async fn from_entity(
+        organization: &organization::Model,
+        _tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        Ok(OrganizationHead {
+            id: organization.id,
+            name: organization.name.clone(),
+            cpe_key: organization.cpe_key.clone(),
+            website: organization.website.clone(),
+        })
+    }
+}

--- a/model/src/organization/summary.rs
+++ b/model/src/organization/summary.rs
@@ -1,0 +1,41 @@
+use crate::organization::OrganizationHead;
+use crate::Error;
+use serde::{Deserialize, Serialize};
+use trustify_common::db::ConnectionOrTransaction;
+use trustify_common::paginated;
+use trustify_entity::organization;
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+pub struct OrganizationSummary {
+    #[serde(flatten)]
+    pub head: OrganizationHead,
+}
+
+paginated!(OrganizationSummary);
+
+impl OrganizationSummary {
+    pub async fn from_entity(
+        organization: &organization::Model,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        Ok(OrganizationSummary {
+            head: OrganizationHead::from_entity(organization, tx).await?,
+        })
+    }
+
+    pub async fn from_entities(
+        organizations: &[organization::Model],
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Vec<Self>, Error> {
+        let mut summaries = Vec::new();
+
+        for org in organizations {
+            summaries.push(OrganizationSummary {
+                head: OrganizationHead::from_entity(org, tx).await?,
+            });
+        }
+
+        Ok(summaries)
+    }
+}

--- a/model/src/vulnerability/details/mod.rs
+++ b/model/src/vulnerability/details/mod.rs
@@ -3,50 +3,95 @@ pub use vulnerability_advisory::*;
 
 use crate::vulnerability::VulnerabilityHead;
 use crate::Error;
-use sea_orm::{EntityTrait, LoaderTrait, ModelTrait};
+use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use trustify_common::db::ConnectionOrTransaction;
-use trustify_entity::{advisory, vulnerability};
+use trustify_cvss::cvss3::score::Score;
+use trustify_cvss::cvss3::Cvss3Base;
+use trustify_entity::{advisory, cvss3, vulnerability};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityDetails {
     #[serde(flatten)]
     pub head: VulnerabilityHead,
+    /// Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.
+    pub average_severity: Option<String>,
+    /// Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
+    pub average_score: Option<f64>,
     pub advisories: Vec<VulnerabilityAdvisorySummary>,
 }
 
 impl VulnerabilityDetails {
     pub async fn from_entity(
-        entity: &vulnerability::Model,
+        vulnerability: &vulnerability::Model,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Option<Self>, Error> {
-        let advisories = entity.find_related(advisory::Entity).all(tx).await?;
+    ) -> Result<Self, Error> {
+        let advisories = vulnerability.find_related(advisory::Entity).all(tx).await?;
 
         let advisories =
-            VulnerabilityAdvisorySummary::from_entities(entity, &advisories, tx).await?;
+            VulnerabilityAdvisorySummary::from_entities(vulnerability, &advisories, tx).await?;
 
-        Ok(VulnerabilityHead::from_entity(entity, tx)
-            .await?
-            .map(|head| VulnerabilityDetails { head, advisories }))
+        let cvss3 = cvss3::Entity::find()
+            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .all(tx)
+            .await?;
+
+        let total_score = cvss3
+            .iter()
+            .map(|e| {
+                let base = Cvss3Base::from(e.clone());
+                base.score().value()
+            })
+            .reduce(|accum, e| accum + e);
+
+        let average_score = total_score.map(|total| Score::new(total / cvss3.len() as f64));
+
+        Ok(VulnerabilityDetails {
+            head: VulnerabilityHead::from_entity(vulnerability, tx).await?,
+            average_severity: average_score.map(|score| score.severity().to_string()),
+            average_score: average_score.map(|score| score.value()),
+            advisories,
+        })
     }
 
     pub async fn from_entities(
-        entities: &[vulnerability::Model],
+        vulnerabilities: &[vulnerability::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let advisories = entities.load_many(advisory::Entity::find(), tx).await?;
+        let advisories = vulnerabilities
+            .load_many(advisory::Entity::find(), tx)
+            .await?;
 
         let mut details = Vec::new();
 
-        for (vuln, advisories) in entities.iter().zip(advisories.iter()) {
-            if let Some(head) = VulnerabilityHead::from_entity(vuln, tx).await? {
-                details.push(VulnerabilityDetails {
-                    head,
-                    advisories: VulnerabilityAdvisorySummary::from_entities(vuln, advisories, tx)
-                        .await?,
+        for (vulnerability, advisories) in vulnerabilities.iter().zip(advisories.iter()) {
+            let cvss3 = cvss3::Entity::find()
+                .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+                .all(tx)
+                .await?;
+
+            let total_score = cvss3
+                .iter()
+                .map(|e| {
+                    let base = Cvss3Base::from(e.clone());
+                    base.score().value()
                 })
-            }
+                .reduce(|accum, e| accum + e);
+
+            let average_score = total_score.map(|total| Score::new(total / cvss3.len() as f64));
+
+            details.push(VulnerabilityDetails {
+                head: VulnerabilityHead::from_entity(vulnerability, tx).await?,
+                average_severity: average_score.map(|score| score.severity().to_string()),
+                average_score: average_score.map(|score| score.value()),
+                advisories: VulnerabilityAdvisorySummary::from_entities(
+                    vulnerability,
+                    advisories,
+                    tx,
+                )
+                .await?,
+            })
         }
 
         Ok(details)

--- a/model/src/vulnerability/details/vulnerability_advisory.rs
+++ b/model/src/vulnerability/details/vulnerability_advisory.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use trustify_common::advisory::{AdvisoryVulnerabilityAssertions, Assertion};
 use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::purl::Purl;
+use trustify_cvss::cvss3::score::Score;
 use trustify_cvss::cvss3::Cvss3Base;
 use trustify_entity::{
     advisory, affected_package_version_range, cvss3, fixed_package_version,
@@ -17,26 +18,71 @@ use utoipa::ToSchema;
 pub struct VulnerabilityAdvisoryHead {
     #[serde(flatten)]
     pub head: AdvisoryHead,
+    pub severity: Option<String>,
+    pub score: Option<f64>,
 }
 
 impl VulnerabilityAdvisoryHead {
     pub async fn from_entity(
+        vulnerability: &vulnerability::Model,
         advisory: &advisory::Model,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Option<Self>, Error> {
-        Ok(AdvisoryHead::from_entity(advisory, tx)
-            .await?
-            .map(|head| VulnerabilityAdvisoryHead { head }))
+    ) -> Result<Self, Error> {
+        let cvss3 = cvss3::Entity::find()
+            .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
+            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .all(tx)
+            .await?;
+
+        let total_score = cvss3
+            .iter()
+            .map(|e| {
+                let base = Cvss3Base::from(e.clone());
+                base.score().value()
+            })
+            .reduce(|accum, e| accum + e);
+
+        let score = total_score.map(|score| Score::new(score / cvss3.len() as f64));
+
+        Ok(VulnerabilityAdvisoryHead {
+            head: AdvisoryHead::from_entity(advisory, None, tx).await?,
+            severity: score.map(|score| score.severity().to_string()),
+            score: score.map(|score| score.value()),
+        })
     }
     pub async fn from_entities(
-        entities: &[advisory::Model],
+        vulnerability: &vulnerability::Model,
+        advisories: &[advisory::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        Ok(AdvisoryHead::from_entities(entities, tx)
-            .await?
-            .drain(..)
-            .map(|head| VulnerabilityAdvisoryHead { head })
-            .collect())
+        let cvss3s = advisories
+            .load_many(
+                cvss3::Entity::find().filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id)),
+                tx,
+            )
+            .await?;
+
+        let mut heads = Vec::new();
+
+        for (advisory, cvss3) in advisories.iter().zip(cvss3s.iter()) {
+            let total_score = cvss3
+                .iter()
+                .map(|e| {
+                    let base = Cvss3Base::from(e.clone());
+                    base.score().value()
+                })
+                .reduce(|accum, e| accum + e);
+
+            let score = total_score.map(|score| Score::new(score / cvss3.len() as f64));
+
+            heads.push(VulnerabilityAdvisoryHead {
+                head: AdvisoryHead::from_entity(advisory, None, tx).await?,
+                severity: score.map(|score| score.severity().to_string()),
+                score: score.map(|score| score.value()),
+            });
+        }
+
+        Ok(heads)
     }
 }
 
@@ -219,13 +265,12 @@ impl VulnerabilityAdvisorySummary {
                     .map(|e| Cvss3Base::from(e).to_string())
                     .collect();
 
-                if let Some(head) = VulnerabilityAdvisoryHead::from_entity(advisory, tx).await? {
-                    summaries.push(VulnerabilityAdvisorySummary {
-                        head,
-                        cvss3_scores,
-                        assertions: AdvisoryVulnerabilityAssertions { assertions },
-                    });
-                }
+                summaries.push(VulnerabilityAdvisorySummary {
+                    head: VulnerabilityAdvisoryHead::from_entity(vulnerability, advisory, tx)
+                        .await?,
+                    cvss3_scores,
+                    assertions: AdvisoryVulnerabilityAssertions { assertions },
+                });
             }
         }
 

--- a/model/src/vulnerability/mod.rs
+++ b/model/src/vulnerability/mod.rs
@@ -32,14 +32,14 @@ impl VulnerabilityHead {
     pub async fn from_entity(
         entity: &vulnerability::Model,
         _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Option<Self>, Error> {
-        Ok(Some(Self {
+    ) -> Result<Self, Error> {
+        Ok(Self {
             identifier: entity.identifier.clone(),
             title: entity.title.clone(),
             published: entity.published,
             modified: entity.modified,
             withdrawn: entity.withdrawn,
-        }))
+        })
     }
 
     pub async fn from_entities(

--- a/model/src/vulnerability/summary.rs
+++ b/model/src/vulnerability/summary.rs
@@ -1,17 +1,24 @@
 use crate::vulnerability::details::VulnerabilityAdvisoryHead;
 use crate::vulnerability::VulnerabilityHead;
 use crate::Error;
-use sea_orm::{EntityTrait, LoaderTrait};
+use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::paginated;
-use trustify_entity::{advisory, advisory_vulnerability, vulnerability};
+use trustify_cvss::cvss3::score::Score;
+use trustify_cvss::cvss3::Cvss3Base;
+use trustify_entity::{advisory, advisory_vulnerability, cvss3, vulnerability};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilitySummary {
     #[serde(flatten)]
     pub head: VulnerabilityHead,
+    /// Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.
+    pub average_severity: Option<String>,
+    /// Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
+    pub average_score: Option<f64>,
+    // All advisories related to this vulnerability
     #[serde(default)]
     pub advisories: Vec<VulnerabilityAdvisoryHead>,
 }
@@ -30,15 +37,26 @@ impl VulnerabilitySummary {
         let mut summaries = Vec::new();
 
         for (vuln, advisories) in vulnerabilities.iter().zip(advisories.iter()) {
+            let cvss3 = cvss3::Entity::find()
+                .filter(cvss3::Column::VulnerabilityId.eq(vuln.id))
+                .all(tx)
+                .await?;
+
+            let total_score = cvss3
+                .iter()
+                .map(|e| {
+                    let base = Cvss3Base::from(e.clone());
+                    base.score().value()
+                })
+                .reduce(|accum, e| accum + e);
+
+            let average_score = total_score.map(|total| Score::new(total / cvss3.len() as f64));
+
             summaries.push(VulnerabilitySummary {
-                head: VulnerabilityHead {
-                    identifier: vuln.identifier.clone(),
-                    title: vuln.title.clone(),
-                    published: vuln.published,
-                    modified: vuln.modified,
-                    withdrawn: vuln.withdrawn,
-                },
-                advisories: VulnerabilityAdvisoryHead::from_entities(advisories, tx).await?,
+                head: VulnerabilityHead::from_entity(vuln, tx).await?,
+                average_severity: average_score.map(|score| score.severity().to_string()),
+                average_score: average_score.map(|score| score.value()),
+                advisories: VulnerabilityAdvisoryHead::from_entities(vuln, advisories, tx).await?,
             });
         }
 

--- a/modules/advisory/src/endpoints/mod.rs
+++ b/modules/advisory/src/endpoints/mod.rs
@@ -9,7 +9,8 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
     let service = AdvisoryService::new(db);
     config
         .app_data(web::Data::new(service))
-        .service(web::scope("/api/v1/advisory").service(all).service(get));
+        .service(all)
+        .service(get);
 }
 
 #[derive(OpenApi)]
@@ -32,7 +33,6 @@ pub struct ApiDoc;
 
 #[utoipa::path(
     tag = "advisory",
-    context_path = "/api/v1/advisory",
     params(
         Query,
         Paginated,
@@ -41,7 +41,7 @@ pub struct ApiDoc;
         (status = 200, description = "Matching vulnerabilities", body = PaginatedAdvisorySummary),
     ),
 )]
-#[get("")]
+#[get("/api/v1/advisory")]
 pub async fn all(
     state: web::Data<AdvisoryService>,
     web::Query(search): web::Query<Query>,
@@ -52,7 +52,6 @@ pub async fn all(
 
 #[utoipa::path(
     tag = "advisory",
-    context_path = "/api/v1/advisory",
     params(
         ("sha256", Path, description = "SHA256 of the advisory")
     ),
@@ -61,7 +60,7 @@ pub async fn all(
         (status = 404, description = "Matching advisory not found"),
     ),
 )]
-#[get("/{sha256}")]
+#[get("/api/v1/advisory/{sha256}")]
 pub async fn get(
     state: web::Data<AdvisoryService>,
     sha256: web::Path<String>,

--- a/modules/advisory/src/endpoints/mod.rs
+++ b/modules/advisory/src/endpoints/mod.rs
@@ -32,6 +32,7 @@ pub struct ApiDoc;
 
 #[utoipa::path(
     tag = "advisory",
+    context_path = "/api/v1/advisory",
     params(
         Query,
         Paginated,
@@ -51,6 +52,7 @@ pub async fn all(
 
 #[utoipa::path(
     tag = "advisory",
+    context_path = "/api/v1/advisory",
     params(
         ("sha256", Path, description = "SHA256 of the advisory")
     ),
@@ -59,7 +61,7 @@ pub async fn all(
         (status = 404, description = "Matching advisory not found"),
     ),
 )]
-#[get("{sha256}")]
+#[get("/{sha256}")]
 pub async fn get(
     state: web::Data<AdvisoryService>,
     sha256: web::Path<String>,

--- a/modules/advisory/src/endpoints/test.rs
+++ b/modules/advisory/src/endpoints/test.rs
@@ -207,7 +207,7 @@ async fn one_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     log::debug!("{:#?}", response);
 
     assert_eq!(
-        response.clone().path("$.issuer").unwrap(),
+        response.clone().path("$.issuer.name").unwrap(),
         json!(["Red Hat Product Security"])
     );
 

--- a/modules/advisory/src/service/mod.rs
+++ b/modules/advisory/src/service/mod.rs
@@ -59,7 +59,9 @@ impl AdvisoryService {
             .await?;
 
         if let Some(advisory) = results {
-            Ok(AdvisoryDetails::from_entity(&advisory, &connection).await?)
+            Ok(Some(
+                AdvisoryDetails::from_entity(&advisory, &connection).await?,
+            ))
         } else {
             Ok(None)
         }

--- a/modules/organization/Cargo.toml
+++ b/modules/organization/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "trustify-module-organization"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+trustify-auth = { workspace = true }
+trustify-entity = { workspace = true }
+trustify-common = { workspace = true }
+trustify-migration = { workspace = true }
+trustify-model = { workspace = true }
+trustify-cvss = { workspace = true }
+
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+log = { workspace = true }
+sea-orm = { workspace = true, features = ["sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros", "debug-print"] }
+sea-orm-migration = { workspace = true }
+sea-query = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+utoipa = { workspace = true, features = ["actix_extras"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+test-log = { workspace = true, features = ["log", "trace"] }
+test-context = { workspace = true }
+trustify-module-ingestor = { workspace = true }
+trustify-module-storage = { workspace = true }
+jsonpath-rust = { workspace = true }

--- a/modules/organization/src/endpoints/mod.rs
+++ b/modules/organization/src/endpoints/mod.rs
@@ -1,0 +1,75 @@
+use crate::service::OrganizationService;
+use actix_web::{get, web, HttpResponse, Responder};
+use trustify_common::db::query::Query;
+use trustify_common::db::Database;
+use trustify_common::model::Paginated;
+use utoipa::OpenApi;
+
+pub fn configure(config: &mut web::ServiceConfig, db: Database) {
+    let service = OrganizationService::new(db);
+    config
+        .app_data(web::Data::new(service))
+        .service(web::scope("/api/v1/organization").service(all).service(get));
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(all, get),
+    components(schemas(
+        trustify_model::organization::OrganizationHead,
+        trustify_model::organization::OrganizationSummary,
+        trustify_model::organization::OrganizationDetails,
+        trustify_model::organization::PaginatedOrganizationSummary,
+    )),
+    tags()
+)]
+pub struct ApiDoc;
+
+#[utoipa::path(
+    tag = "organization",
+    context_path = "/api/v1/organization",
+    params(
+        Query,
+        Paginated,
+    ),
+    responses(
+        (status = 200, description = "Matching organizations", body = PaginatedAdvisorySummary),
+    ),
+)]
+#[get("")]
+pub async fn all(
+    state: web::Data<OrganizationService>,
+    web::Query(search): web::Query<Query>,
+    web::Query(paginated): web::Query<Paginated>,
+) -> actix_web::Result<impl Responder> {
+    Ok(HttpResponse::Ok().json(state.fetch_organizations(search, paginated, ()).await?))
+}
+
+#[utoipa::path(
+    tag = "organization",
+    context_path = "/api/v1/organization",
+    params(
+        ("id", Path, description = "Opaque ID of the organization")
+    ),
+    responses(
+        (status = 200, description = "Matching advisory", body = AdvisoryDetails),
+        (status = 404, description = "Matching advisory not found"),
+    ),
+)]
+#[get("/{id}")]
+pub async fn get(
+    state: web::Data<OrganizationService>,
+    id: web::Path<i32>,
+) -> actix_web::Result<impl Responder> {
+    println!("HEY");
+    let fetched = state.fetch_organization(*id, ()).await?;
+
+    if let Some(fetched) = fetched {
+        Ok(HttpResponse::Ok().json(fetched))
+    } else {
+        Ok(HttpResponse::NotFound().finish())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/modules/organization/src/endpoints/mod.rs
+++ b/modules/organization/src/endpoints/mod.rs
@@ -9,7 +9,8 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
     let service = OrganizationService::new(db);
     config
         .app_data(web::Data::new(service))
-        .service(web::scope("/api/v1/organization").service(all).service(get));
+        .service(all)
+        .service(get);
 }
 
 #[derive(OpenApi)]
@@ -27,7 +28,6 @@ pub struct ApiDoc;
 
 #[utoipa::path(
     tag = "organization",
-    context_path = "/api/v1/organization",
     params(
         Query,
         Paginated,
@@ -36,7 +36,7 @@ pub struct ApiDoc;
         (status = 200, description = "Matching organizations", body = PaginatedAdvisorySummary),
     ),
 )]
-#[get("")]
+#[get("/api/v1/organization")]
 pub async fn all(
     state: web::Data<OrganizationService>,
     web::Query(search): web::Query<Query>,
@@ -47,7 +47,6 @@ pub async fn all(
 
 #[utoipa::path(
     tag = "organization",
-    context_path = "/api/v1/organization",
     params(
         ("id", Path, description = "Opaque ID of the organization")
     ),
@@ -56,7 +55,7 @@ pub async fn all(
         (status = 404, description = "Matching advisory not found"),
     ),
 )]
-#[get("/{id}")]
+#[get("/api/v1/organization/{id}")]
 pub async fn get(
     state: web::Data<OrganizationService>,
     id: web::Path<i32>,

--- a/modules/organization/src/endpoints/test.rs
+++ b/modules/organization/src/endpoints/test.rs
@@ -1,0 +1,127 @@
+use actix_web::cookie::time::OffsetDateTime;
+use actix_web::test::TestRequest;
+use actix_web::App;
+use jsonpath_rust::JsonPathQuery;
+use serde_json::{json, Value};
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db::query::Query;
+use trustify_common::db::test::TrustifyContext;
+use trustify_common::model::Paginated;
+use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
+use trustify_module_ingestor::graph::Graph;
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn all_organizations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Graph::new(db.clone());
+
+    let app = actix_web::test::init_service(
+        App::new().configure(|config| crate::endpoints::configure(config, db.clone())),
+    )
+    .await;
+
+    graph
+        .ingest_advisory(
+            "CAPT-1",
+            "http://captpickles.com/",
+            "8675309",
+            AdvisoryInformation {
+                title: Some("CAPT-1".to_string()),
+                issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    graph
+        .ingest_advisory(
+            "EMPORIUM-1",
+            "http://captpickles.com/",
+            "8675319",
+            AdvisoryInformation {
+                title: Some("EMPORIUM-1".to_string()),
+                issuer: Some("Capt Pickles Boutique Emporium".to_string()),
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let uri = "/api/v1/organization?sort=name";
+
+    let request = TestRequest::get().uri(uri).to_request();
+
+    let response: Value = actix_web::test::call_and_read_body_json(&app, request).await;
+
+    let names = response.path("$.items[*].name").unwrap();
+
+    assert_eq!(
+        names,
+        json!([
+            "Capt Pickles Boutique Emporium",
+            "Capt Pickles Industrial Conglomerate",
+        ])
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn one_organization(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Graph::new(db.clone());
+
+    let app = actix_web::test::init_service(
+        App::new().configure(|config| crate::endpoints::configure(config, db.clone())),
+    )
+    .await;
+
+    let advisory = graph
+        .ingest_advisory(
+            "CAPT-1",
+            "http://captpickles.com/",
+            "8675309",
+            AdvisoryInformation {
+                title: Some("Pickles can experience a buffer overflow".to_string()),
+                issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    advisory.link_to_vulnerability("CVE-123", ()).await?;
+
+    let service = crate::service::OrganizationService::new(db);
+
+    let orgs = service
+        .fetch_organizations(Query::default(), Paginated::default(), ())
+        .await?;
+
+    assert_eq!(1, orgs.total);
+
+    let first_org = &orgs.items[0];
+    let org_id = first_org.head.id;
+
+    let uri = format!("/api/v1/organization/{}", org_id);
+
+    let request = TestRequest::get().uri(&uri).to_request();
+
+    let response: Value = actix_web::test::call_and_read_body_json(&app, request).await;
+
+    let name = response.clone().path("$.name").unwrap();
+
+    assert_eq!(name, json!(["Capt Pickles Industrial Conglomerate"]));
+
+    Ok(())
+}

--- a/modules/organization/src/lib.rs
+++ b/modules/organization/src/lib.rs
@@ -1,0 +1,29 @@
+use actix_web::ResponseError;
+use sea_orm::DbErr;
+
+pub mod endpoints;
+
+pub mod service;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Database(#[from] DbErr),
+
+    #[error(transparent)]
+    Search(#[from] trustify_common::db::query::Error),
+
+    #[error(transparent)]
+    Any(#[from] anyhow::Error),
+}
+
+impl From<trustify_model::Error> for Error {
+    fn from(value: trustify_model::Error) -> Self {
+        match value {
+            trustify_model::Error::Database(inner) => Self::Database(inner),
+            trustify_model::Error::Any(inner) => Self::Any(inner),
+        }
+    }
+}
+
+impl ResponseError for Error {}

--- a/modules/organization/src/service/mod.rs
+++ b/modules/organization/src/service/mod.rs
@@ -1,0 +1,62 @@
+use crate::Error;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use trustify_common::db::limiter::LimiterTrait;
+use trustify_common::db::query::{Filtering, Query};
+use trustify_common::db::{Database, Transactional};
+use trustify_common::model::{Paginated, PaginatedResults};
+use trustify_entity::organization;
+use trustify_model::organization::{OrganizationDetails, OrganizationSummary};
+
+pub struct OrganizationService {
+    db: Database,
+}
+
+impl OrganizationService {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    pub async fn fetch_organizations<TX: AsRef<Transactional> + Sync + Send>(
+        &self,
+        search: Query,
+        paginated: Paginated,
+        tx: TX,
+    ) -> Result<PaginatedResults<OrganizationSummary>, Error> {
+        let connection = self.db.connection(&tx);
+
+        let limiter = organization::Entity::find().filtering(search)?.limiting(
+            &connection,
+            paginated.offset,
+            paginated.limit,
+        );
+
+        let total = limiter.total().await?;
+
+        Ok(PaginatedResults {
+            total,
+            items: OrganizationSummary::from_entities(&limiter.fetch().await?, &connection).await?,
+        })
+    }
+    pub async fn fetch_organization<TX: AsRef<Transactional> + Sync + Send>(
+        &self,
+        id: i32,
+        tx: TX,
+    ) -> Result<Option<OrganizationDetails>, Error> {
+        let connection = self.db.connection(&tx);
+
+        if let Some(organization) = organization::Entity::find()
+            .filter(organization::Column::Id.eq(id))
+            .one(&connection)
+            .await?
+        {
+            Ok(Some(
+                OrganizationDetails::from_entity(&organization, &connection).await?,
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/modules/organization/src/service/test.rs
+++ b/modules/organization/src/service/test.rs
@@ -1,0 +1,43 @@
+use actix_web::cookie::time::OffsetDateTime;
+use std::sync::Arc;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db::query::Query;
+use trustify_common::db::test::TrustifyContext;
+use trustify_common::model::Paginated;
+use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
+use trustify_module_ingestor::graph::Graph;
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn all_organizations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Arc::new(Graph::new(db.clone()));
+
+    graph
+        .ingest_advisory(
+            "CPIC-1",
+            "http://captpickles.com/",
+            "8675309",
+            AdvisoryInformation {
+                title: Some("CAPT-1".to_string()),
+                issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let service = crate::service::OrganizationService::new(db);
+
+    let orgs = service
+        .fetch_organizations(Query::default(), Paginated::default(), ())
+        .await?;
+
+    assert_eq!(1, orgs.total);
+    assert_eq!(1, orgs.items.len());
+
+    Ok(())
+}

--- a/modules/vulnerability/src/endpoints/mod.rs
+++ b/modules/vulnerability/src/endpoints/mod.rs
@@ -7,11 +7,10 @@ use utoipa::OpenApi;
 
 pub fn configure(config: &mut web::ServiceConfig, db: Database) {
     let service = VulnerabilityService::new(db);
-    config.app_data(web::Data::new(service)).service(
-        web::scope("/api/v1/vulnerability")
-            .service(all)
-            .service(get),
-    );
+    config
+        .app_data(web::Data::new(service))
+        .service(all)
+        .service(get);
 }
 
 #[derive(OpenApi)]
@@ -34,7 +33,6 @@ pub struct ApiDoc;
 
 #[utoipa::path(
     tag = "vulnerability",
-    context_path = "/api/v1/vulnerability",
     params(
         Query,
         Paginated,
@@ -43,7 +41,7 @@ pub struct ApiDoc;
         (status = 200, description = "Matching vulnerabilities", body = PaginatedVulnerabilitySummary),
     ),
 )]
-#[get("")]
+#[get("/api/v1/vulnerability")]
 pub async fn all(
     state: web::Data<VulnerabilityService>,
     web::Query(search): web::Query<Query>,
@@ -58,7 +56,6 @@ pub async fn all(
 
 #[utoipa::path(
     tag = "vulnerability",
-    context_path = "/api/v1/vulnerability",
     params(
         ("id", Path, description = "ID of the vulnerability")
     ),
@@ -67,7 +64,7 @@ pub async fn all(
         (status = 404, description = "Specified vulnerability not found"),
     ),
 )]
-#[get("/{id}")]
+#[get("/api/v1/vulnerability/{id}")]
 pub async fn get(
     state: web::Data<VulnerabilityService>,
     id: web::Path<String>,
@@ -78,24 +75,6 @@ pub async fn get(
     } else {
         Ok(HttpResponse::NotFound().finish())
     }
-}
-
-#[utoipa::path(
-    context_path = "/api/v1/vulnerability",
-    tag = "vulnerability",
-    params(
-        ("id", Path, description = "ID of the vulnerability")
-    ),
-    responses(
-        (status = 200, description = "Affected products"),
-    ),
-)]
-#[get("{id}/affected/products")]
-pub async fn affected_products(
-    //state: web::Data<Graph>,
-    _id: web::Path<String>,
-) -> actix_web::Result<impl Responder> {
-    Ok(HttpResponse::Ok().finish())
 }
 
 #[cfg(test)]

--- a/modules/vulnerability/src/endpoints/mod.rs
+++ b/modules/vulnerability/src/endpoints/mod.rs
@@ -34,6 +34,7 @@ pub struct ApiDoc;
 
 #[utoipa::path(
     tag = "vulnerability",
+    context_path = "/api/v1/vulnerability",
     params(
         Query,
         Paginated,
@@ -56,8 +57,8 @@ pub async fn all(
 }
 
 #[utoipa::path(
-    context_path = "/api/v1/vulnerability",
     tag = "vulnerability",
+    context_path = "/api/v1/vulnerability",
     params(
         ("id", Path, description = "ID of the vulnerability")
     ),
@@ -66,7 +67,7 @@ pub async fn all(
         (status = 404, description = "Specified vulnerability not found"),
     ),
 )]
-#[get("{id}")]
+#[get("/{id}")]
 pub async fn get(
     state: web::Data<VulnerabilityService>,
     id: web::Path<String>,

--- a/modules/vulnerability/src/endpoints/test.rs
+++ b/modules/vulnerability/src/endpoints/test.rs
@@ -29,11 +29,11 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
 
     let advisory = graph
         .ingest_advisory(
-            "RHSA-1",
-            "http://redhat.com/",
+            "CAPT-1",
+            "http://captpickles.com/",
             "8675309",
             AdvisoryInformation {
-                title: Some("RHSA-1".to_string()),
+                title: Some("CAPT-1".to_string()),
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -50,10 +50,10 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
                 minor_version: 0,
                 av: AttackVector::Network,
                 ac: AttackComplexity::Low,
-                pr: PrivilegesRequired::None,
+                pr: PrivilegesRequired::High,
                 ui: UserInteraction::None,
-                s: Scope::Unchanged,
-                c: Confidentiality::None,
+                s: Scope::Changed,
+                c: Confidentiality::High,
                 i: Integrity::None,
                 a: Availability::None,
             },
@@ -85,6 +85,8 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
 
     let response: PaginatedResults<VulnerabilitySummary> =
         actix_web::test::call_and_read_body_json(&app, request).await;
+
+    log::debug!("{:#?}", response);
 
     assert_eq!(2, response.items.len());
 
@@ -125,12 +127,12 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 minor_version: 0,
                 av: AttackVector::Network,
                 ac: AttackComplexity::Low,
-                pr: PrivilegesRequired::None,
+                pr: PrivilegesRequired::High,
                 ui: UserInteraction::None,
-                s: Scope::Unchanged,
-                c: Confidentiality::None,
-                i: Integrity::None,
-                a: Availability::None,
+                s: Scope::Changed,
+                c: Confidentiality::High,
+                i: Integrity::High,
+                a: Availability::Low,
             },
             (),
         )
@@ -170,6 +172,8 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let uri = "/api/v1/vulnerability/CVE-123";
     let request = TestRequest::get().uri(uri).to_request();
     let response: Value = actix_web::test::call_and_read_body_json(&app, request).await;
+
+    log::debug!("{:#?}", response);
 
     let identifier = response.clone().path("$.identifier").unwrap();
     let published = response.clone().path("$.published").unwrap();

--- a/modules/vulnerability/src/service/mod.rs
+++ b/modules/vulnerability/src/service/mod.rs
@@ -53,7 +53,9 @@ impl VulnerabilityService {
             .one(&connection)
             .await?
         {
-            Ok(VulnerabilityDetails::from_entity(&vulnerability, &connection).await?)
+            Ok(Some(
+                VulnerabilityDetails::from_entity(&vulnerability, &connection).await?,
+            ))
         } else {
             Ok(None)
         }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ trustify-module-importer = { workspace = true }
 trustify-module-storage = { workspace = true }
 trustify-module-ui = { workspace = true }
 trustify-module-advisory = { workspace = true }
+trustify-module-organization = { workspace = true }
 trustify-module-vulnerability = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -207,6 +207,7 @@ impl InitData {
                             trustify_module_fetch::endpoints::configure(svc, db.clone());
 
                             trustify_module_advisory::endpoints::configure(svc, db.clone());
+                            trustify_module_organization::endpoints::configure(svc, db.clone());
                             trustify_module_vulnerability::endpoints::configure(svc, db.clone());
                             #[cfg(feature = "ui")]
                             trustify_module_ui::endpoints::configure(svc, &self.ui);

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -14,6 +14,7 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
     doc.merge(trustify_module_storage::endpoints::ApiDoc::openapi());
 
     doc.merge(trustify_module_advisory::endpoints::ApiDoc::openapi());
+    doc.merge(trustify_module_organization::endpoints::ApiDoc::openapi());
     doc.merge(trustify_module_vulnerability::endpoints::ApiDoc::openapi());
 
     doc


### PR DESCRIPTION
- Includes advisories issued by an organization.
- Simplify some of the from_entity ish to avoid unnecessary Result<Option<T>>
- Clean up API paths on openapi, etc, a bit.