### PR TITLE
Stop relying on npm to have the UI static files available in the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 
 /flamegraph*.svg
 /perf.data*
+
+/static

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6622,7 +6622,12 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
+ "base64 0.22.1",
  "log",
+ "serde",
+ "serde_json",
+ "static-files",
+ "tera",
  "trustify-ui",
 ]
 
@@ -6701,6 +6706,7 @@ dependencies = [
  "trustify-module-storage",
  "trustify-module-ui",
  "trustify-module-vulnerability",
+ "trustify-ui",
  "url",
  "urlencoding",
  "utoipa",
@@ -6730,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git#453a50222a313dda2cc5ed534d44e27ef692d5e1"
+source = "git+https://github.com/carlosthe19916/trustify-ui?branch=static-ui#505720e95fbb4bdc2bf72ee4c723f4b92966330b"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,12 +122,12 @@ trustify-module-importer = { path = "modules/importer" }
 trustify-module-ingestor = { path = "modules/ingestor" }
 trustify-module-search = { path = "modules/search" }
 trustify-module-storage = { path = "modules/storage" }
-trustify-module-ui = { path = "modules/ui", default-features = false }
+trustify-module-ui = { path = "modules/ui" }
 trustify-module-advisory = { path = "modules/advisory" }
 trustify-module-organization = { path = "modules/organization" }
 trustify-module-vulnerability = { path = "modules/vulnerability" }
 trustify-server = { path = "server", default-features = false }
-trustify-ui = { git = "https://github.com/trustification/trustify-ui.git" }
+trustify-ui = { git = "https://github.com/carlosthe19916/trustify-ui", branch = "static-ui" }
 
 [patch.crates-io]
 #csaf-walker = { git = "https://github.com/ctron/csaf-walker", rev = "7b6e64dd56e4be79e184b053ef754a42e1496fe0" }

--- a/README.md
+++ b/README.md
@@ -18,8 +18,19 @@ cargo run --bin trustd --no-default-features
 
 That will create its own database on your local filesystem.
 
-* The first command also contains **UI** so point your browser at <http://localhost:8080>.
-* The second runs without **UI** then you can go at <http://localhost:8080/swagger-ui/> to view the API.
+* You can go at <http://localhost:8080> to view the UI.
+* You can go at <http://localhost:8080/swagger-ui/> to view the API.
+
+### Running server with the latest version of the UI
+
+- The server renders the UI from the `./static-local` folder
+- If the `./static` directory exists then it will be used for serving the UI
+
+Copy the UI static files executing:
+
+```shell
+podman cp $(docker create --name ui-download ghcr.io/trustification/trustify-ui:latest):/opt/app-root/dist/client/dist static && podman rm ui-download
+```
 
 ### Running containerized UI
 

--- a/modules/ui/Cargo.toml
+++ b/modules/ui/Cargo.toml
@@ -7,8 +7,13 @@ edition = "2021"
 actix-web = { workspace = true }
 log = { workspace = true }
 actix-web-static-files = { workspace = true }
-trustify-ui = { workspace = true, optional = true }
+trustify-ui = { workspace = true }
 
-[features]
-default = [ "ui" ]
-ui = ["trustify-ui"]
+static-files = "0.2.1"
+serde_json = "1.0.117"
+tera = "1.19.1"
+base64 = "0.22.1"
+serde = { version = "1.0.201", features = ["derive"] }
+
+[build-dependencies]
+static-files = "0.2.1"

--- a/modules/ui/build.rs
+++ b/modules/ui/build.rs
@@ -1,0 +1,13 @@
+use static_files::resource_dir;
+use std::path::Path;
+
+static STATIC_DIR: &str = "../../static";
+static STATIC_LOCAL_DIR: &str = "../../static-local";
+
+pub fn main() {
+    if Path::new(STATIC_DIR).exists() {
+        resource_dir(STATIC_DIR).build().unwrap();
+    } else {
+        resource_dir(STATIC_LOCAL_DIR).build().unwrap();
+    }
+}

--- a/modules/ui/src/endpoints.rs
+++ b/modules/ui/src/endpoints.rs
@@ -1,7 +1,8 @@
+use crate::ui::ui_resources;
 use actix_web::web;
 use actix_web_static_files::ResourceFiles;
-use trustify_ui::{trustify_ui, UI};
+use trustify_ui::UI;
 
 pub fn configure(config: &mut web::ServiceConfig, ui: &UI) {
-    config.service(ResourceFiles::new("/", trustify_ui(ui)).resolve_not_found_to(""));
+    config.service(ResourceFiles::new("/", ui_resources(ui)).resolve_not_found_to(""));
 }

--- a/modules/ui/src/lib.rs
+++ b/modules/ui/src/lib.rs
@@ -1,5 +1,2 @@
-#[cfg(feature = "ui")]
-pub use trustify_ui::UI;
-
-#[cfg(feature = "ui")]
 pub mod endpoints;
+pub mod ui;

--- a/modules/ui/src/ui.rs
+++ b/modules/ui/src/ui.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+
+use static_files::Resource;
+use trustify_ui::{trustify_ui, UI};
+
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+pub fn ui_resources(ui: &UI) -> HashMap<&'static str, Resource> {
+    let resources = generate();
+    trustify_ui(ui, resources)
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,10 +32,7 @@ url = "2"
 utoipa = { workspace = true, features = ["actix_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web"] }
 walker-common = { workspace = true }
+trustify-ui = { workspace = true }
 
 [dev-dependencies]
 urlencoding = { workspace = true }
-
-[features]
-default = [ "ui" ]
-ui = ["trustify-module-ui/ui"]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -39,11 +39,9 @@ use trustify_module_importer::server::importer;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_storage::service::dispatch::DispatchBackend;
 use trustify_module_storage::service::fs::FileSystemBackend;
+use trustify_ui::UI;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
-
-#[cfg(feature = "ui")]
-use trustify_module_ui::UI;
 
 /// Run the API server
 #[derive(clap::Args, Debug)]
@@ -82,7 +80,6 @@ struct InitData {
     http: HttpServerConfig<Trustify>,
     tracing: Tracing,
     swagger_oidc: Option<Arc<SwaggerUiOidc>>,
-    #[cfg(feature = "ui")]
     ui: UI,
 }
 
@@ -152,7 +149,6 @@ impl InitData {
 
         let storage = DispatchBackend::Filesystem(FileSystemBackend::new(storage).await?);
 
-        #[cfg(feature = "ui")]
         let ui = UI {
             // TODO: where/how should we configure these details?
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -173,7 +169,6 @@ impl InitData {
             tracing: run.infra.tracing,
             swagger_oidc,
             storage,
-            #[cfg(feature = "ui")]
             ui,
         })
     }
@@ -212,7 +207,6 @@ impl InitData {
                             trustify_module_storage::endpoints::configure(svc, storage.clone());
                             // I think the UI must come last due to
                             // its use of `resolve_not_found_to`
-                            #[cfg(feature = "ui")]
                             trustify_module_ui::endpoints::configure(svc, &self.ui);
                         });
                 })

--- a/static-local/branding/strings.json
+++ b/static-local/branding/strings.json
@@ -1,0 +1,21 @@
+{
+  "application": {
+    "title": "Trustification",
+    "name": "Trustification UI",
+    "description": "Trustification UI"
+  },
+  "about": {
+    "displayName": "Trustification",
+    "imageSrc": "<%= brandingRoot %>/images/masthead-logo.svg",
+    "documentationUrl": "https://trustification.io/"
+  },
+  "masthead": {
+    "leftBrand": {
+      "src": "<%= brandingRoot %>/images/masthead-logo.svg",
+      "alt": "brand",
+      "height": "40px"
+    },
+    "leftTitle": null,
+    "rightBrand": null
+  }
+}

--- a/static-local/index.html.ejs
+++ b/static-local/index.html.ejs
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Trustify</title>
+  <body>
+    <h1>Welcome</h1>
+  </body>
+</html>

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -22,7 +22,3 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
-
-[features]
-default = ["ui"]
-ui = ["trustify-server/ui"]


### PR DESCRIPTION
Fix https://github.com/trustification/trustify/issues/265

Depends on: https://github.com/trustification/trustify-ui/pull/30

## Problem
Currently we rely on NPM to be installed for the UI crate to build the UI static files. This introduces a new layer that developers on the backend side might have difficulties with.

## Proposed solution
- By default the server uses the directory `./static-local` to serve the UI.
  - The directory `./static-local` contains just a basic "welcome" HTML page. 
- If the directory `./static` exists, then this directory will be used to serve the UI. We can populate this directory with the static files generated by trustify-ui (this process can be manual or we can set some automation on it)
  - Relying only on the existence of `./static` decouples the build phase of the UI and Trustify.
  - The static files can easily be added to the Dockerfile

## Steps to test this 
To test the default behaviour (default UI, not trustify-ui):

- Execute `cargo run --bin trustd` and then open http://localhost:8080. You should see only a welcome message.

To test the UI from trustify-ui:
- Clone the static files from ui into this repository directory:
```shell
podman cp $(docker create --name ui-download ghcr.io/trustification/trustify-ui:latest):/opt/app-root/dist/client/dist static && podman rm ui-download
```

- Execute `cargo clean`
-  Execute `cargo run --bin trustd` and open http://localhost:8080 (open it in incognito mode to make sure cache is not there)
