### PR TITLE
Use the static build of the trustify-ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6520,7 +6520,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git#453a50222a313dda2cc5ed534d44e27ef692d5e1"
+source = "git+https://github.com/trustification/trustify-ui.git?tag=static-main#7dbd4df6d58201f929c47c2e64e820d49bc4753f"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ trustify-module-ui = { path = "modules/ui", default-features = false }
 trustify-module-advisory = { path = "modules/advisory" }
 trustify-module-vulnerability = { path = "modules/vulnerability" }
 trustify-server = { path = "server", default-features = false }
-trustify-ui = { git = "https://github.com/trustification/trustify-ui.git" }
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", tag = "static-main" }
 
 [patch.crates-io]
 #csaf-walker = { git = "https://github.com/ctron/csaf-walker", rev = "7b6e64dd56e4be79e184b053ef754a42e1496fe0" }


### PR DESCRIPTION
This should eliminate the NPM builds.