### PR TITLE
ci: add a multi-arch release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,68 +9,241 @@ permissions:
   contents: write
 
 jobs:
-  build-and-upload:
-    name: Build and upload
+
+  init:
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{steps.version.outputs.version}}
+      prerelease: ${{steps.state.outputs.prerelease}}
+    steps:
+      - name: Evaluate pre-release state
+        id: state
+        env:
+          HEAD_REF: ${{github.head_ref}}
+        run: |
+          test -z "${HEAD_REF}" && (echo 'do-publish=true' >> $GITHUB_OUTPUT)
+          if [[ "${{ github.event.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo release=true >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event.ref }}" =~ ^refs/tags/v.*$ ]]; then
+              echo prerelease=true >> $GITHUB_OUTPUT
+          fi
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "Version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Show result
+        run: |
+          echo "Version: $VERSION"
+          echo "Release: $release"
+          echo "Pre-release: $prerelease"
+
+  build:
+    name: Build
     runs-on: ${{ matrix.os }}
+    needs:
+      - init
 
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - build: linux
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            install: |
+              sudo apt install -y libssl-dev
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+            cross: "true"
+            args: --features vendored # The ubuntu version of cross is too old for openssl
 
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+            install: |
+              sudo apt install -y musl-tools
+            args: --features vendored
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04
+            cross: "true"
+            args: --features vendored
 
-          - build: windows-gnu
-            os: windows-latest
-            target: x86_64-pc-windows-gnu
+          - target: x86_64-apple-darwin
+            os: macos-12
+          - target: aarch64-apple-darwin
+            os: macos-14
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+            ext: ".exe"
+            archive: zip
+            install: |
+              git config --system core.longpaths true
+              echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+              vcpkg install openssl:x64-windows-static-md
+
+    env:
+      binary_name: "trustd"
+      dirname: "trustd-${{ needs.init.outputs.version }}-${{ matrix.target }}"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Get the release version from the tag
+      - name: Setup | Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Export GitHub Actions cache environment variables for vcpkg
+        uses: actions/github-script@v7
+        if: runner.os == 'Windows'
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
+
+      - name: Install dependencies
+        if: matrix.install != ''
+        run: ${{ matrix.install }}
+
+      - name: Disable rustup self-update
+        # workaround for: https://github.com/rust-lang/rustup/issues/3709
+        run: |
+          rustup set auto-self-update disable
+
+      - name: Setup Rust target
+        run: |
+          rustup target add ${{ matrix.target }}
+
+      - name: Setup Cross
+        if: matrix.cross == 'true'
+        run: |
+          curl -sSL https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz -o binstall.tar.gz
+          tar xzf binstall.tar.gz
+          mv cargo-binstall $HOME/.cargo/bin/
+          cargo binstall cross -y
+
+      - name: Build | Build
         shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        env:
+          POSTGRESQL_VERSION: 16
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for retrieving postgres
+        run: |
+          if [[ "${{ matrix.xcode }}" == "true" ]]; then
+            export SDKROOT=$(xcrun -sdk macosx --show-sdk-path)
+            export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)
+          fi
+          
+          CMD="cargo"
+          
+          if [[ -n "${{ matrix.cross }}" ]]; then
+            CMD="cross"
+          fi
+          
+          OPTS="--release"
+          
+          OPTS="$OPTS ${{ matrix.args }}"
+          
+          if [[ -n "${{ matrix.target }}" ]]; then
+            OPTS="$OPTS --target=${{ matrix.target }}"
+          fi
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+          ${CMD} build ${OPTS}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --verbose --release --target ${{ matrix.target }}
-
-      - name: Build archive
+      - name: Move binary
         shell: bash
         run: |
-          binary_name="trustd"
-
-          dirname="$binary_name-${{ env.VERSION }}-${{ matrix.target }}"
-          mkdir "$dirname"
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            mv "target/${{ matrix.target }}/release/$binary_name.exe" "$dirname"
+          mkdir -p "pack/$dirname"
+          
+          # if we have an alternate target, there is a sub-directory
+          if [[ -f "target/release/${binary_name}${{ matrix.ext }}" ]]; then
+            SRC="target/release/${binary_name}${{ matrix.ext }}"
+          elif [[ -f "target/${{ matrix.target }}/release/${binary_name}${{ matrix.ext }}" ]]; then
+            SRC="target/${{ matrix.target }}/release/${binary_name}${{ matrix.ext }}"
           else
-            mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
+            echo "Unable to find output"
+            find target
+            false # stop build
           fi
+          
+          # stage for upload
+          mv -v "${SRC}" "pack/${dirname}"
 
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            7z a "$dirname.zip" "$dirname"
-            echo "ASSET=$dirname.zip" >> $GITHUB_ENV
-          else
-            tar -czf "$dirname.tar.gz" "$dirname"
-            echo "ASSET=$dirname.tar.gz" >> $GITHUB_ENV
-          fi
+      - run: mkdir -p upload
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Archive (zip)
+        if: matrix.archive == 'zip'
+        working-directory: pack
+        run: |
+          7z a ../upload/${{ env.dirname }}.zip .
+
+      - name: Archive (tar.gz)
+        if: matrix.archive != 'zip'
+        working-directory: pack
+        run: |
+          tar czvf ../upload/${{ env.dirname }}.tar.gz .
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
         with:
-          files: |
-            ${{ env.ASSET }}
+          name: trustd-${{ matrix.target }}
+          path: upload/*
+          if-no-files-found: error
+
+  publish:
+    needs: [ init, build ]
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install convco
+        run: |
+          curl -sLO https://github.com/convco/convco/releases/download/v0.5.1/convco-ubuntu.zip
+          unzip convco-ubuntu.zip
+          sudo install convco /usr/local/bin
+
+      - name: Generate changelog
+        run: |
+          convco changelog -s --max-majors=1 --max-minors=1 --max-patches=1 -n > /tmp/changelog.md
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ~/download
+
+      - name: Display downloaded content
+        run: ls -R ~/download
+
+      - name: Stage release
+        run: |
+          mkdir -p staging
+          cp -pv ~/download/*/* staging/
+
+      - name: Display staging area
+        run: ls -R staging
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.init.outputs.version }}
+        run: |
+          OPTS=""
+
+          if [[ "${{ needs.init.outputs.prerelease }}" == "true" ]]; then
+            OPTS="${OPTS} -p"
+          fi
+
+          gh release create ${OPTS} --title "${{ needs.init.outputs.version }}" -F /tmp/changelog.md ${TAG} \
+            $(find staging -type f)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.0+3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +3391,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6612,6 +6622,7 @@ dependencies = [
  "anyhow",
  "clap",
  "log",
+ "openssl",
  "postgresql_embedded",
  "tokio",
  "trustify-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "cyclonedx-bom"
 version = "0.5.0"
-source = "git+https://github.com/ctron/cyclonedx-rust-cargo?rev=3c8ebf47a00f9b4b596712af61602695ae5134f3#3c8ebf47a00f9b4b596712af61602695ae5134f3"
+source = "git+https://github.com/CycloneDX/cyclonedx-rust-cargo?branch=main#649dcba64d9e0e34e233450e0f1e7b96ea95d02d"
 dependencies = [
  "base64 0.21.7",
  "cyclonedx-bom-macros",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "cyclonedx-bom-macros"
 version = "0.1.0"
-source = "git+https://github.com/ctron/cyclonedx-rust-cargo?rev=3c8ebf47a00f9b4b596712af61602695ae5134f3#3c8ebf47a00f9b4b596712af61602695ae5134f3"
+source = "git+https://github.com/CycloneDX/cyclonedx-rust-cargo?branch=main#649dcba64d9e0e34e233450e0f1e7b96ea95d02d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,5 +142,5 @@ trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", tag =
 
 # required due to:
 # * https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/708
-cyclonedx-bom = { git = "https://github.com/ctron/cyclonedx-rust-cargo", rev = "3c8ebf47a00f9b4b596712af61602695ae5134f3" }
+cyclonedx-bom = { git = "https://github.com/CycloneDX/cyclonedx-rust-cargo", branch = "main" }
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libssl-dev"
+]

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -20,6 +20,11 @@ postgresql_embedded = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 
+openssl = "*"
+
 [features]
 default = ["ui"]
 ui = ["trustify-server/ui"]
+vendored = [
+    "openssl/vendored",
+]


### PR DESCRIPTION
This makes the release build multi-arch capable for the following targets:

* MacOS 12 for Intel
* MacOS 14 for Mx
* Windows
* Linux (GNU & MUSL) (amd64 & aarch64)

The release will look like this: https://github.com/ctron/trustify/releases/tag/v0.0.0-alpha.1