### PR TITLE
Set OIDC manually, just to test if it works

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -157,10 +157,10 @@ impl InitData {
         let ui = UI {
             // TODO: where/how should we configure these details?
             version: env!("CARGO_PKG_VERSION").to_string(),
-            auth_required: String::from("false"),
-            oidc_server_url: String::from("http://localhost:8180/realms/trustify"),
-            oidc_client_id: String::from("trustify-ui"),
-            oidc_scope: String::from("email"),
+            auth_required: String::from("true"),
+            oidc_server_url: String::from("http://localhost:8090/realms/chicken"),
+            oidc_client_id: String::from("frontend"),
+            oidc_scope: String::from("openid"),
             analytics_enabled: String::from("false"),
             analytics_write_key: String::from(""),
         };


### PR DESCRIPTION
- Start Keycloak using the compose file within this repository:

```shell
docker-compose -f etc/deploy/compose/compose.yaml up
```

- This PR manually have set the appropriate OIDC parameters manually so you only need to start the server
- Start the server 
```shell
cargo run --bin trustd
```

- Open http://localhost:8080 . You should be redirected to the Keycloak login (username=admin, password=admin123456)

I have tested it and it works without any issues!