### PR TITLE
Fix wall of notifications when adding multiple reviewers to a PR

### DIFF
--- a/.github/scripts/map-users/main.mjs
+++ b/.github/scripts/map-users/main.mjs
@@ -12,13 +12,8 @@ export class Mapper {
   requestedReviewers() {
     let users = [];
 
-    for (let user of this.payload?.pull_request?.requested_reviewers) {
-
-      const login = user?.login;
-      if (login === undefined) {
-        continue;
-      }
-
+    const login = this.payload?.requested_reviewer?.login;
+    if (login !== undefined) {
       users.push(login);
     }
 

--- a/.github/scripts/map-users/test.mjs
+++ b/.github/scripts/map-users/test.mjs
@@ -1,12 +1,14 @@
 import * as fs from 'fs';
 import { channelMessage, Mapper } from "./main.mjs";
 
-const github = JSON.parse(fs.readFileSync('payload.json'))?.github;
+// const github = JSON.parse(fs.readFileSync('payload.json'))?.github;
+// const output = channelMessage(github.event)
 
-const output = channelMessage(github.event)
+const payload = JSON.parse(fs.readFileSync('payload.json'));
+const output = channelMessage(payload)
 
 console.log("Output:", output)
 
-const args = new Mapper(github.event).directMessageArguments();
+const args = new Mapper(payload).directMessageArguments();
 console.log("Direct:", args)
 

--- a/.github/workflows/rita-request-review.yaml
+++ b/.github/workflows/rita-request-review.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: npm ci
         working-directory: .github/scripts/map-users
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: message
         with:
           script: |
@@ -31,7 +31,7 @@ jobs:
             return msg || "";
           result-encoding: string
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: directMessages
         with:
           script: |


### PR DESCRIPTION
Right now, when adding multiple reviewers on a PR, this triggers a repeated invocation of the event handler (one for each reviewer). It also send out an event for each reviewer, each time. So the number of messages sent is x².

This change fixes this and updates a few github actions in the process.