### PR TITLE
Fix some build issues

### DIFF
--- a/.github/scripts/Containerfile
+++ b/.github/scripts/Containerfile
@@ -10,7 +10,7 @@ RUN mkdir /stage
 
 # install zlib and cleanup
 
-RUN dnf install --installroot /stage --setop install_weak_deps=false --nodocs -y zlib
+RUN dnf install --installroot /stage --setop install_weak_deps=false --nodocs -y zlib openssl
 RUN dnf clean all --installroot /stage
 
 # prepare our binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6200,7 +6200,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -6233,7 +6233,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6269,7 +6269,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "serde",
  "test-log",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "cpe",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-integration-tests"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "cyclonedx-bom 0.6.0",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -6443,7 +6443,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -6487,7 +6487,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -6517,7 +6517,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -6546,7 +6546,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ log = { workspace = true }
 native-tls = { workspace = true }
 packageurl = { workspace = true }
 pem = { workspace = true }
-postgresql_embedded = { workspace = true, features = ["blocking", "bundled", "tokio"] }
+postgresql_embedded = { workspace = true, features = ["blocking", "tokio"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["native-tls"] }
 sea-orm = { workspace = true, features = ["sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-common"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/common/auth/Cargo.toml
+++ b/common/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-auth"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Authentication and authorization functionality"

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-infrastructure"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -7,7 +7,6 @@ pub mod test;
 
 use anyhow::Context;
 use migration::{Migrator, MigratorTrait};
-use postgresql_embedded::PostgreSQL;
 use sea_orm::{
     prelude::async_trait, ConnectOptions, ConnectionTrait, DatabaseConnection, DatabaseTransaction,
     DbBackend, DbErr, ExecResult, QueryResult, RuntimeErr, Statement,

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-cvss"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-entity"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-integration-tests"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dev-dependencies]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-migration"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 publish = false
 

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-module-fundamental"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/modules/importer/Cargo.toml
+++ b/modules/importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-module-importer"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-module-ingestor"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 publish = false
 

--- a/modules/storage/Cargo.toml
+++ b/modules/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-module-storage"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 publish = false
 

--- a/modules/ui/Cargo.toml
+++ b/modules/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-module-ui"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-server"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -24,9 +24,10 @@ openssl = "*"
 libz-sys = "*"
 
 [features]
-default = ["ui"]
+default = ["ui", "bundled"]
 
 ui = ["trustify-server/ui"]
+bundled = ["postgresql_embedded/bundled"]
 garage-door = ["trustify-server/garage-door"]
 
 vendored = [
@@ -37,5 +38,6 @@ vendored = [
 ]
 pm = [
     "garage-door",
-    "ui"
+    "ui",
+    "bundled"
 ]

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustify-trustd"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This change fixes some build issues:

* openssl is not part of ubi-micro, this will be installed now too
* postgresql-embedded is forced into "bundled" mode, which doesn't work with offline builds. It is still the default, but there's a way to opt-out now.
* I forgot to uptick the versions during the last release, this fixes it.