### PR TITLE
Allow calculation of CVSS3 score using SQL functions, like a madman.

### DIFF
--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -36,3 +36,11 @@ impl Iden for ToJson {
         s.write_str("to_json").unwrap();
     }
 }
+
+pub struct Cvss3Score;
+
+impl Iden for Cvss3Score {
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(s, "cvss3_score").unwrap()
+    }
+}

--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -437,6 +437,7 @@ fn envalue(s: &str, ct: &ColumnType) -> Result<Value, Error> {
     }
     Ok(match ct {
         ColumnType::Integer => s.parse::<i32>().map_err(err)?.into(),
+        ColumnType::Decimal(_) => s.parse::<f64>().map_err(err)?.into(),
         ColumnType::TimestampWithTimeZone => {
             if let Ok(odt) = OffsetDateTime::parse(s, &Rfc3339) {
                 odt.into()

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fixed_package_version;
 pub mod importer;
 pub mod importer_report;
 pub mod not_affected_package_version;
+pub mod organization;
 pub mod package;
 pub mod package_relates_to_package;
 pub mod package_version;
@@ -23,5 +24,3 @@ pub mod sbom_package_cpe_ref;
 pub mod sbom_package_purl_ref;
 pub mod vulnerability;
 pub mod vulnerability_description;
-
-pub mod organization;

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -30,6 +30,7 @@ mod m0000280_add_advisory_vulnerability_meta;
 mod m0000290_create_product;
 mod m0000300_create_product_version;
 mod m0000310_alter_advisory_primary_key;
+mod m0000315_create_cvss3_scoring_function;
 
 pub struct Migrator;
 
@@ -66,6 +67,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000290_create_product::Migration),
             Box::new(m0000300_create_product_version::Migration),
             Box::new(m0000310_alter_advisory_primary_key::Migration),
+            Box::new(m0000315_create_cvss3_scoring_function::Migration),
         ]
     }
 }

--- a/migration/src/m0000315_create_cvss3_scoring_function.rs
+++ b/migration/src/m0000315_create_cvss3_scoring_function.rs
@@ -1,0 +1,74 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0000315_create_cvss3_scoring_function.sql"))
+            .await
+            .map(|_| ())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_exploitability"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_impact"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_av_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_ac_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_pr_scoped_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_ui_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_scope_changed"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_c_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_i_score"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_a_score"#)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0000315_create_cvss3_scoring_function.sql
+++ b/migration/src/m0000315_create_cvss3_scoring_function.sql
@@ -1,0 +1,234 @@
+
+-- Calcuate a CVSS3 score from an *entire* row of the `cvss3` table
+create or replace function cvss3_score(cvss3_p cvss3)
+    returns real
+as
+$$
+declare
+    exploitability decimal;
+    iss decimal;
+    iss_scoped decimal;
+    score decimal;
+begin
+    if cvss3_p is null then
+        return null;
+    end if;
+
+    exploitability := cvss3_exploitability(cvss3_p);
+    iss = cvss3_impact( cvss3_p );
+
+    if not(cvss3_scope_changed( cvss3_p.s)) then
+        iss_scoped := 6.42 * iss;
+    else
+        iss_scoped := (7.52 * (iss - 0.029)) - pow(3.25 * (iss - 0.02), 15.0);
+    end if;
+
+    if iss_scoped <= 0.0 then
+        score := 0.0;
+    elsif not(cvss3_scope_changed( cvss3_p.s)) then
+        score := least(iss_scoped + exploitability, 10.0);
+    else
+        score := least(1.08 * (iss_scoped + exploitability), 10.0);
+    end if;
+
+    return score;
+end
+$$
+    language 'plpgsql';
+
+
+create or replace function cvss3_exploitability(cvss3_p cvss3)
+    returns real
+as
+$$
+declare
+    av_score decimal;
+    ac_score decimal;
+    ui_score decimal;
+    pr_score decimal;
+    scope_changed bool;
+begin
+    scope_changed = cvss3_scope_changed(cvss3_p.s);
+
+    av_score := cvss3_av_score(cvss3_p.av);
+    ac_score := cvss3_ac_score(cvss3_p.ac);
+    ui_score := cvss3_ui_score(cvss3_p.ui);
+    pr_score := cvss3_pr_scoped_score(cvss3_p.pr, scope_changed);
+
+
+    return (8.22 * av_score * ac_score * pr_score * ui_score);
+end;
+$$
+    language 'plpgsql';
+
+
+
+create or replace function cvss3_impact(cvss3_p cvss3)
+    returns real
+as
+$$
+declare
+    c_score decimal;
+    i_score decimal;
+    a_score decimal;
+begin
+    c_score := cvss3_c_score(cvss3_p.c);
+    i_score := cvss3_i_score(cvss3_p.i);
+    a_score := cvss3_a_score(cvss3_p.a);
+
+    return (1.0 - abs((1.0 - c_score) * (1.0 - i_score) * (1.0 - a_score)));
+end;
+$$
+    language 'plpgsql';
+
+
+create or replace function cvss3_av_score(av_p cvss3_av)
+    returns real
+as
+$$
+begin
+    if av_p = 'p'::cvss3_av then
+        return 0.20;
+    elsif av_p = 'l'::cvss3_av then
+        return 0.55;
+    elsif av_p = 'a'::cvss3_av then
+        return 0.62;
+    elsif av_p = 'n'::cvss3_av then
+        return 0.85;
+    end if;
+
+    return 0.0;
+
+end;
+$$
+    language 'plpgsql';
+
+
+create or replace function cvss3_ac_score(ac_p cvss3_ac)
+    returns real
+as
+$$
+begin
+    if ac_p = 'h'::cvss3_ac then
+        return 0.44;
+    elsif ac_p = 'l'::cvss3_ac then
+        return 0.77;
+    end if;
+
+    return 0.0;
+
+end;
+$$
+    language 'plpgsql';
+
+
+
+
+
+create or replace function cvss3_pr_scoped_score(pr_p cvss3_pr, scope_changed_p bool)
+    returns real
+as
+$$
+begin
+    if pr_p = 'h'::cvss3_pr then
+        if scope_changed_p then
+            return 0.50;
+        else
+            return 0.27;
+        end if;
+    elsif pr_p = 'l'::cvss3_pr then
+        if scope_changed_p then
+            return 0.68;
+        else
+            return 0.62;
+        end if;
+    end if;
+
+    return 0.85;
+
+end;
+$$
+    language 'plpgsql';
+
+create or replace function cvss3_ui_score(ui_p cvss3_ui)
+    returns real
+as
+$$
+begin
+    if ui_p = 'r'::cvss3_ui then
+        return 0.62;
+    end if;
+
+    return 0.85;
+
+end;
+$$
+    language 'plpgsql';
+
+create or replace function cvss3_scope_changed(s_p cvss3_s)
+    returns bool
+as
+$$
+begin
+    return s_p = 'c'::cvss3_s;
+
+end;
+$$
+    language 'plpgsql';
+
+create or replace function cvss3_c_score(c_p cvss3_c)
+    returns real
+as
+$$
+begin
+    if c_p = 'n'::cvss3_c then
+        return 0.0;
+    elsif c_p = 'l'::cvss3_c then
+        return 0.22;
+    elsif c_p = 'h'::cvss3_c then
+        return 0.56;
+    end if;
+
+    return 0.85;
+
+end;
+$$
+    language 'plpgsql';
+
+create or replace function cvss3_i_score(i_p cvss3_i)
+    returns real
+as
+$$
+begin
+    if i_p = 'n'::cvss3_i then
+        return 0.0;
+    elsif i_p = 'l'::cvss3_i then
+        return 0.22;
+    elsif i_p = 'h'::cvss3_i then
+        return 0.56;
+    end if;
+
+    return 0.85;
+
+end;
+$$
+    language 'plpgsql';
+
+create or replace function cvss3_a_score(a_p cvss3_a)
+    returns real
+as
+$$
+begin
+    if a_p = 'n'::cvss3_a then
+        return 0.0;
+    elsif a_p = 'l'::cvss3_a then
+        return 0.22;
+    elsif a_p = 'h'::cvss3_a then
+        return 0.56;
+    end if;
+
+    return 0.85;
+
+end;
+$$
+    language 'plpgsql';

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -1,13 +1,19 @@
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ColumnTrait, ColumnTypeTrait, EntityTrait, FromQueryResult, IntoIdentity, QueryFilter,
+    QuerySelect, QueryTrait,
+};
+use sea_query::{ColumnType, Func, FunctionCall, SimpleExpr};
+use time::OffsetDateTime;
+use uuid::Uuid;
 
 use crate::advisory::model::{AdvisoryDetails, AdvisorySummary};
 use crate::Error;
-use trustify_common::db::limiter::LimiterTrait;
-use trustify_common::db::query::{Filtering, Query};
+use trustify_common::db::limiter::LimiterAsModelTrait;
+use trustify_common::db::query::{Columns, Filtering, Query};
 use trustify_common::db::{Database, Transactional};
 use trustify_common::hash::HashOrUuidKey;
 use trustify_common::model::{Paginated, PaginatedResults};
-use trustify_entity::advisory;
+use trustify_entity::{advisory, cvss3};
 
 pub struct AdvisoryService {
     db: Database,
@@ -24,19 +30,79 @@ impl AdvisoryService {
         paginated: Paginated,
         tx: TX,
     ) -> Result<PaginatedResults<AdvisorySummary>, Error> {
+        #[derive(FromQueryResult, Debug)]
+        pub(crate) struct AdvisoryCatcher {
+            pub id: Uuid,
+            pub identifier: String,
+            pub issuer_id: Option<i32>,
+            pub location: String,
+            pub sha256: String,
+            pub published: Option<OffsetDateTime>,
+            pub modified: Option<OffsetDateTime>,
+            pub withdrawn: Option<OffsetDateTime>,
+            pub title: Option<String>,
+            // all of advisory, plus some.
+            pub average_score_cvss3: Option<f64>,
+        }
+
         let connection = self.db.connection(&tx);
 
-        let limiter = advisory::Entity::find().filtering(search)?.limiting(
-            &connection,
-            paginated.offset,
-            paginated.limit,
-        );
+        let cvss3_score: FunctionCall = Func::cust("cvss3_score".into_identity());
+        let cvss3_score = cvss3_score.args([SimpleExpr::Custom("cvss3".to_string())]);
+
+        // To be able to ORDER or WHERE using a synthetic column, we must first
+        // SELECT col, extra_col FROM (SELECT col, random as extra_col FROM...)
+        // which involves mucking about inside the Select<E> to re-target from
+        // the original underlying table it expects the entity to live in.
+        let inner_query = advisory::Entity::find()
+            .left_join(cvss3::Entity)
+            .expr_as_(
+                SimpleExpr::FunctionCall(Func::avg(SimpleExpr::FunctionCall(cvss3_score))),
+                "average_score",
+            )
+            .group_by(advisory::Column::Id);
+
+        let mut outer_query = advisory::Entity::find();
+
+        // Alias the inner query as exactly the table the entity is expecting
+        // so that column aliases link up correctly.
+        QueryTrait::query(&mut outer_query)
+            .from_clear()
+            .from_subquery(inner_query.into_query(), "advisory".into_identity());
+
+        // And then proceed as usual.
+        let limiter = outer_query
+            .filtering_with(
+                search,
+                Columns::from_entity::<advisory::Entity>()
+                    .add_column("average_score", ColumnType::Decimal(None).def()),
+            )?
+            .limiting_as::<AdvisoryCatcher>(&connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;
 
+        let items = limiter.fetch().await?;
+
+        let averages: Vec<_> = items.iter().map(|e| e.average_score_cvss3).collect();
+
+        let entities: Vec<_> = items
+            .into_iter()
+            .map(|e| advisory::Model {
+                id: e.id,
+                identifier: e.identifier,
+                issuer_id: e.issuer_id,
+                location: e.location,
+                sha256: e.sha256,
+                published: e.published,
+                modified: e.modified,
+                withdrawn: e.withdrawn,
+                title: e.title,
+            })
+            .collect();
+
         Ok(PaginatedResults {
             total,
-            items: AdvisorySummary::from_entities(&limiter.fetch().await?, &connection).await?,
+            items: AdvisorySummary::from_entities(&entities, &averages, &connection).await?,
         })
     }
 

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -77,7 +77,77 @@ async fn all_advisories(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let fetched = fetch
         .fetch_advisories(q(""), Paginated::default(), ())
         .await?;
+
     assert_eq!(fetched.total, 2);
+    Ok(())
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn all_advisories_filtered_by_average_score(
+    ctx: TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Arc::new(Graph::new(db.clone()));
+
+    let advisory = graph
+        .ingest_advisory(
+            "RHSA-1",
+            "http://redhat.com/",
+            "8675309",
+            AdvisoryInformation {
+                title: Some("RHSA-1".to_string()),
+                issuer: None,
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let advisory_vuln = advisory
+        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .await?;
+    advisory_vuln
+        .ingest_cvss3_score(
+            Cvss3Base {
+                minor_version: 0,
+                av: AttackVector::Network,
+                ac: AttackComplexity::Low,
+                pr: PrivilegesRequired::None,
+                ui: UserInteraction::None,
+                s: Scope::Unchanged,
+                c: Confidentiality::None,
+                i: Integrity::High,
+                a: Availability::High,
+            },
+            (),
+        )
+        .await?;
+
+    graph
+        .ingest_advisory(
+            "RHSA-2",
+            "http://redhat.com/",
+            "8675319",
+            AdvisoryInformation {
+                title: Some("RHSA-2".to_string()),
+                issuer: None,
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let fetch = AdvisoryService::new(db);
+    let fetched = fetch
+        .fetch_advisories(q("average_score>8"), Paginated::default(), ())
+        .await?;
+
+    assert_eq!(fetched.total, 1);
     Ok(())
 }
 


### PR DESCRIPTION
Provide enough escape-hatches around filterin/sorting to do my evil deeds. Do some evil deeds in SQL to allow sorting/filtering by synthetic `average_score` on advisories. Do even more evil, by writing entirely too many SQL functions. Lay in appropriate DOWN migration for cvss3 scoring functions.