### PR TITLE
fix: use newer container to fix/workaround segfault in libgit2

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,7 @@ pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libssl-dev"
 ]
+# work around:
+# * https://github.com/cross-rs/cross/issues/1512
+# * https://github.com/rust-lang/git2-rs/issues/1057
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"


### PR DESCRIPTION
When building with cross, a container image using Ubuntu 16.04 is being used. This seems to be the cause for creating a binary which will segfault (or run into other such failures) when running on aarch64.

Using Ubuntu 20.04 does not produce this issue.

Also see:
 * https://github.com/cross-rs/cross/issues/1512
 * https://github.com/rust-lang/git2-rs/issues/1057

---

This might be a better way than https://github.com/trustification/trustify/pull/387 … as it doesn't add new code to work around this, but uses the existing, which should work anyway.

On the other side: Having the other PR might offer a quick way out should this occur on other targets. However, I am not sure it's that likely and worth it.