### PR TITLE
Look up documents before retrieving, improve id/key naming conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6526,6 +6526,7 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
+ "sha2",
  "test-context",
  "test-log",
  "thiserror",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,7 @@ pub mod config;
 pub mod cpe;
 pub mod db;
 pub mod error;
-pub mod hash;
+pub mod id;
 pub mod model;
 pub mod package;
 pub mod purl;

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -30,17 +30,18 @@ utoipa = { workspace = true, features = ["actix_extras"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
+actix-http = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
 jsonpath-rust = { workspace = true }
 log = { workspace = true }
-serde_json = { workspace = true }
 rust-lzma = { workspace = true }
-test-log = { workspace = true, features = ["log", "trace"] }
-trustify-cvss = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 test-context = { workspace = true }
-urlencoding = { workspace = true }
+test-log = { workspace = true, features = ["log", "trace"] }
 tokio-util = { workspace = true }
-actix-http = { workspace = true }
+trustify-cvss = { workspace = true }
+urlencoding = { workspace = true }

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -140,12 +140,11 @@ pub async fn download(
     key: web::Path<String>,
 ) -> Result<impl Responder, Error> {
     let id = Id::from_str(&key).map_err(Error::HashKey)?;
-    let Some(hash_key) = advisory.fetch_advisory(id, ()).await?.and_then(|adv| {
-        adv.head
-            .hashes
-            .into_iter()
-            .find(|h| matches!(h, Id::Sha256(_)))
-    }) else {
+    let Some(hash_key) = advisory
+        .fetch_advisory(id, ())
+        .await?
+        .and_then(|adv| adv.head.find_sha256().cloned())
+    else {
         return Ok(HttpResponse::NotFound().finish());
     };
 

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -139,8 +139,11 @@ pub async fn download(
     advisory: web::Data<AdvisoryService>,
     key: web::Path<String>,
 ) -> Result<impl Responder, Error> {
+    // the user requested id
     let id = Id::from_str(&key).map_err(Error::HashKey)?;
-    let Some(hash_key) = advisory
+
+    // look up document by id
+    let Some(id) = advisory
         .fetch_advisory(id, ())
         .await?
         .and_then(|adv| adv.head.find_sha256().cloned())
@@ -152,7 +155,7 @@ pub async fn download(
         .get_ref()
         .storage()
         .clone()
-        .retrieve(hash_key)
+        .retrieve(id.try_into()?)
         .await
         .map_err(Error::Storage)?
         .map(|stream| stream.map_err(Error::Storage));

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use tokio_util::io::ReaderStream;
 use trustify_common::db::query::Query;
 use trustify_common::db::Database;
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use trustify_module_storage::service::StorageBackend;
@@ -39,7 +39,7 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
         trustify_common::advisory::AdvisoryVulnerabilityAssertions,
         trustify_common::advisory::Assertion,
         trustify_common::purl::Purl,
-        trustify_common::hash::HashOrUuidKey,
+        trustify_common::id::Id,
     )),
     tags()
 )]
@@ -81,7 +81,7 @@ pub async fn get(
     state: web::Data<AdvisoryService>,
     key: web::Path<String>,
 ) -> actix_web::Result<impl Responder> {
-    let hash_key = HashOrUuidKey::from_str(&key).map_err(Error::HashKey)?;
+    let hash_key = Id::from_str(&key).map_err(Error::HashKey)?;
     let fetched = state.fetch_advisory(hash_key, ()).await?;
 
     if let Some(fetched) = fetched {
@@ -138,7 +138,7 @@ pub async fn download(
     service: web::Data<IngestorService>,
     key: web::Path<String>,
 ) -> Result<impl Responder, Error> {
-    let hash_key = HashOrUuidKey::from_str(&key).map_err(Error::HashKey)?;
+    let hash_key = Id::from_str(&key).map_err(Error::HashKey)?;
 
     let stream = service
         .get_ref()

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -143,11 +143,7 @@ pub async fn download(
     let id = Id::from_str(&key).map_err(Error::HashKey)?;
 
     // look up document by id
-    let Some(id) = advisory
-        .fetch_advisory(id, ())
-        .await?
-        .and_then(|adv| adv.head.find_sha256().cloned())
-    else {
+    let Some(advisory) = advisory.fetch_advisory(id, ()).await? else {
         return Ok(HttpResponse::NotFound().finish());
     };
 
@@ -155,7 +151,7 @@ pub async fn download(
         .get_ref()
         .storage()
         .clone()
-        .retrieve(id.try_into()?)
+        .retrieve(advisory.head.hashes.try_into()?)
         .await
         .map_err(Error::Storage)?
         .map(|stream| stream.map_err(Error::Storage));

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -416,9 +416,9 @@ async fn upload_default_csaf_format(ctx: TrustifyContext) -> Result<(), anyhow::
         .to_request();
 
     let response = actix_web::test::call_service(&app, request).await;
-    let doc: Value = actix_web::test::read_body_json(response).await;
-    log::debug!("{doc}");
-    assert_eq!(doc.as_str(), Some("CVE-2023-33201"));
+    let id: Id = actix_web::test::read_body_json(response).await;
+    log::debug!("{id}");
+    assert!(matches!(id, Id::Uuid(_)));
 
     Ok(())
 }
@@ -442,8 +442,8 @@ async fn upload_osv_format(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response = actix_web::test::call_service(&app, request).await;
     assert!(response.status().is_success());
-    let id: String = actix_web::test::read_body_json(response).await;
-    assert_eq!(id, "RUSTSEC-2021-0079");
+    let id: Id = actix_web::test::read_body_json(response).await;
+    assert!(matches!(id, Id::Uuid(_)));
 
     Ok(())
 }
@@ -467,8 +467,8 @@ async fn upload_cve_format(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response = actix_web::test::call_service(&app, request).await;
     assert!(response.status().is_success());
-    let id: String = actix_web::test::read_body_json(response).await;
-    assert_eq!(id, "CVE-2024-27088");
+    let id: Id = actix_web::test::read_body_json(response).await;
+    assert!(matches!(id, Id::Uuid(_)));
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -92,6 +92,7 @@ impl AdvisoryHead {
         Ok(heads)
     }
 
+    /// Get the [`Id::Sha256`] variant from the hashes if there is one.
     pub fn find_sha256(&self) -> Option<&Id> {
         self.hashes.iter().find(|h| matches!(h, Id::Sha256(_)))
     }

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -91,4 +91,8 @@ impl AdvisoryHead {
 
         Ok(heads)
     }
+
+    pub fn find_sha256(&self) -> Option<&Id> {
+        self.hashes.iter().find(|h| matches!(h, Id::Sha256(_)))
+    }
 }

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -11,7 +11,7 @@ pub use details::advisory_vulnerability::*;
 pub use details::*;
 pub use summary::*;
 use trustify_common::db::ConnectionOrTransaction;
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_entity::{advisory, organization};
 
 mod details;
@@ -22,7 +22,7 @@ pub struct AdvisoryHead {
     #[serde(with = "uuid::serde::urn")]
     pub uuid: Uuid,
     pub identifier: String,
-    pub hashes: Vec<HashOrUuidKey>,
+    pub hashes: Vec<Id>,
     pub issuer: Option<OrganizationSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(with = "time::serde::rfc3339::option")]
@@ -53,7 +53,7 @@ impl AdvisoryHead {
         Ok(Self {
             uuid: entity.id,
             identifier: entity.identifier.clone(),
-            hashes: vec![HashOrUuidKey::Sha256(entity.sha256.clone())],
+            hashes: vec![Id::Sha256(entity.sha256.clone())],
             issuer,
             published: entity.published,
             modified: entity.modified,
@@ -80,7 +80,7 @@ impl AdvisoryHead {
             heads.push(Self {
                 uuid: advisory.id,
                 identifier: advisory.identifier.clone(),
-                hashes: vec![HashOrUuidKey::Sha256(advisory.sha256.clone())],
+                hashes: vec![Id::Sha256(advisory.sha256.clone())],
                 issuer,
                 published: advisory.published,
                 modified: advisory.modified,

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -91,9 +91,4 @@ impl AdvisoryHead {
 
         Ok(heads)
     }
-
-    /// Get the [`Id::Sha256`] variant from the hashes if there is one.
-    pub fn find_sha256(&self) -> Option<&Id> {
-        self.hashes.iter().find(|h| matches!(h, Id::Sha256(_)))
-    }
 }

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -11,7 +11,7 @@ use crate::Error;
 use trustify_common::db::limiter::LimiterAsModelTrait;
 use trustify_common::db::query::{Columns, Filtering, Query};
 use trustify_common::db::{Database, Transactional};
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_common::model::{Paginated, PaginatedResults};
 use trustify_entity::{advisory, cvss3};
 
@@ -107,15 +107,15 @@ impl AdvisoryService {
 
     pub async fn fetch_advisory<TX: AsRef<Transactional> + Sync + Send>(
         &self,
-        hash_key: HashOrUuidKey,
+        hash_key: Id,
         tx: TX,
     ) -> Result<Option<AdvisoryDetails>, Error> {
         let connection = self.db.connection(&tx);
 
         let results = advisory::Entity::find()
             .filter(match hash_key {
-                HashOrUuidKey::Uuid(uuid) => advisory::Column::Id.eq(uuid),
-                HashOrUuidKey::Sha256(hash) => advisory::Column::Sha256.eq(hash),
+                Id::Uuid(uuid) => advisory::Column::Id.eq(uuid),
+                Id::Sha256(hash) => advisory::Column::Sha256.eq(hash),
                 _ => return Err(Error::UnsupportedHashAlgorithm),
             })
             .one(&connection)

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -214,7 +214,7 @@ async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         .await?;
 
     let fetch = AdvisoryService::new(db);
-    let jenny = HashOrUuidKey::from_str("sha256:8675309")?;
+    let jenny = Id::from_str("sha256:8675309")?;
     let fetched = fetch.fetch_advisory(jenny.clone(), ()).await?;
     assert!(matches!(
             fetched,

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -3,13 +3,13 @@ use actix_web::body::BoxBody;
 use actix_web::{HttpResponse, ResponseError};
 use sea_orm::DbErr;
 use trustify_common::error::ErrorInformation;
-use trustify_common::hash::HashKeyError;
+use trustify_common::id::IdError;
 use trustify_common::purl::PurlErr;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    HashKey(HashKeyError),
+    HashKey(IdError),
     #[error(transparent)]
     Database(anyhow::Error),
     #[error(transparent)]

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -5,11 +5,14 @@ use sea_orm::DbErr;
 use trustify_common::error::ErrorInformation;
 use trustify_common::id::IdError;
 use trustify_common::purl::PurlErr;
+use trustify_module_storage::service::StorageKeyError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
     HashKey(IdError),
+    #[error(transparent)]
+    StorageKey(#[from] StorageKeyError),
     #[error(transparent)]
     Database(anyhow::Error),
     #[error(transparent)]
@@ -70,6 +73,9 @@ impl ResponseError for Error {
             }
             Error::HashKey(err) => {
                 HttpResponse::BadRequest().json(ErrorInformation::new("Key", err))
+            }
+            Error::StorageKey(err) => {
+                HttpResponse::BadRequest().json(ErrorInformation::new("Storage Key", err))
             }
             Error::Data(msg) => HttpResponse::InternalServerError()
                 .json(ErrorInformation::new("Data-model corruption", msg)),

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -15,3 +15,6 @@ pub use endpoints::configure;
 pub mod error;
 
 pub use error::Error;
+
+#[cfg(test)]
+pub mod test;

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -213,13 +213,13 @@ pub async fn download(
     service: web::Data<IngestorService>,
     key: web::Path<String>,
 ) -> Result<impl Responder, Error> {
-    let hash_key = Id::from_str(&key).map_err(Error::HashKey)?;
+    let id = Id::from_str(&key).map_err(Error::HashKey)?;
 
     let stream = service
         .get_ref()
         .storage()
         .clone()
-        .retrieve(hash_key)
+        .retrieve(id.try_into()?)
         .await
         .map_err(Error::Storage)?
         .map(|stream| stream.map_err(Error::Storage));

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -11,7 +11,7 @@ use trustify_auth::authorizer::Authorizer;
 use trustify_auth::Permission;
 use trustify_common::db::query::Query;
 use trustify_common::db::Database;
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_common::model::Paginated;
 use trustify_entity::relationship::Relationship;
 use trustify_module_ingestor::service::{Format, IngestorService};
@@ -44,7 +44,7 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
         trustify_common::advisory::AdvisoryVulnerabilityAssertions,
         trustify_common::advisory::Assertion,
         trustify_common::purl::Purl,
-        trustify_common::hash::HashOrUuidKey,
+        trustify_common::id::Id,
         trustify_entity::relationship::Relationship,
     )),
     tags()
@@ -213,7 +213,7 @@ pub async fn download(
     service: web::Data<IngestorService>,
     key: web::Path<String>,
 ) -> Result<impl Responder, Error> {
-    let hash_key = HashOrUuidKey::from_str(&key).map_err(Error::HashKey)?;
+    let hash_key = Id::from_str(&key).map_err(Error::HashKey)?;
 
     let stream = service
         .get_ref()

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -1,7 +1,7 @@
 use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_common::paginated;
 use trustify_entity::relationship::Relationship;
 use utoipa::ToSchema;
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct SbomSummary {
     pub id: Uuid,
-    pub hashes: Vec<HashOrUuidKey>,
+    pub hashes: Vec<Id>,
 
     pub document_id: String,
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::fmt::Debug;
 use tracing::instrument;
 use trustify_common::db::query::{Filtering, Query};
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 use trustify_common::{
     cpe::Cpe,
     db::{
@@ -54,7 +54,7 @@ impl SbomService {
             if let Some(node) = node {
                 items.push(SbomSummary {
                     id: sbom.sbom_id,
-                    hashes: vec![HashOrUuidKey::Sha256(sbom.sha256)],
+                    hashes: vec![Id::Sha256(sbom.sha256)],
                     document_id: sbom.document_id,
 
                     name: node.name,

--- a/modules/fundamental/src/test.rs
+++ b/modules/fundamental/src/test.rs
@@ -1,0 +1,20 @@
+use actix_http::Request;
+use actix_web::dev::{Service, ServiceResponse};
+use actix_web::Error;
+use sea_orm::prelude::async_trait::async_trait;
+
+/// A trait wrapping an `impl Service` in a way that we can pass it as a reference.
+#[async_trait(?Send)]
+pub trait CallService {
+    async fn call_service(&self, s: Request) -> ServiceResponse;
+}
+
+#[async_trait(?Send)]
+impl<S> CallService for S
+where
+    S: Service<Request, Response = ServiceResponse, Error = Error>,
+{
+    async fn call_service(&self, r: Request) -> ServiceResponse {
+        actix_web::test::call_service(self, r).await
+    }
+}

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -12,6 +12,7 @@ use std::io::Read;
 use std::str::FromStr;
 use time::OffsetDateTime;
 use trustify_common::db::Transactional;
+use trustify_common::id::Id;
 use trustify_common::purl::Purl;
 use trustify_cvss::cvss3::Cvss3Base;
 
@@ -50,7 +51,7 @@ impl<'g> CsafLoader<'g> {
         location: L,
         document: R,
         checksum: &str,
-    ) -> Result<String, Error> {
+    ) -> Result<Id, Error> {
         let mut reader = HashingRead::new(document);
 
         let csaf: Csaf = serde_json::from_reader(&mut reader)?;
@@ -84,7 +85,8 @@ impl<'g> CsafLoader<'g> {
         }
 
         tx.commit().await?;
-        Ok(advisory_id)
+
+        Ok(Id::Uuid(advisory.advisory.id))
     }
 
     async fn ingest_vulnerability<TX: AsRef<Transactional>>(

--- a/modules/ingestor/src/service/cve/loader.rs
+++ b/modules/ingestor/src/service/cve/loader.rs
@@ -4,6 +4,7 @@ use crate::graph::Graph;
 use crate::service::{hashing::HashingRead, Error};
 use cve::{Cve, Timestamp};
 use std::io::Read;
+use trustify_common::id::Id;
 
 /// Loader capable of parsing a CVE Record JSON file
 /// and manipulating the Graph to integrate it into
@@ -27,7 +28,7 @@ impl<'g> CveLoader<'g> {
         location: L,
         record: R,
         checksum: &str,
-    ) -> Result<String, Error> {
+    ) -> Result<Id, Error> {
         let mut reader = HashingRead::new(record);
         let cve: Cve = serde_json::from_reader(&mut reader)?;
         let id = cve.id();
@@ -123,7 +124,7 @@ impl<'g> CveLoader<'g> {
 
         tx.commit().await?;
 
-        Ok(id.into())
+        Ok(Id::Uuid(advisory.advisory.id))
     }
 }
 

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -6,6 +6,7 @@ use crate::service::advisory::{csaf::loader::CsafLoader, osv::loader::OsvLoader}
 use crate::service::Error;
 use jsn::{mask::*, Format as JsnFormat, TokenReader};
 use std::io::Read;
+use trustify_common::id::Id;
 
 #[derive(Debug)]
 pub enum Format {
@@ -24,7 +25,7 @@ impl<'g> Format {
         issuer: Option<String>,
         checksum: &str,
         reader: R,
-    ) -> Result<String, Error> {
+    ) -> Result<Id, Error> {
         match self {
             Format::CSAF => {
                 // issuer is internal as publisher of the document.

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -14,14 +14,14 @@ use futures::Stream;
 use sea_orm::error::DbErr;
 use std::time::Instant;
 use trustify_common::error::ErrorInformation;
-use trustify_common::hash::{HashKeyError, HashOrUuidKey};
+use trustify_common::id::{Id, IdError};
 use trustify_module_storage::service::dispatch::DispatchBackend;
 use trustify_module_storage::service::{StorageBackend, SyncAdapter};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    HashKey(#[from] HashKeyError),
+    HashKey(#[from] IdError),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
@@ -116,7 +116,7 @@ impl IngestorService {
             .map_err(|err| Error::Storage(anyhow!("{err}")))?;
         let sha256 = hex::encode(digest);
 
-        let hash_key = HashOrUuidKey::Sha256(sha256.clone());
+        let hash_key = Id::Sha256(sha256.clone());
 
         let storage = SyncAdapter::new(self.storage.clone());
         let reader = storage

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -102,7 +102,7 @@ impl IngestorService {
         issuer: Option<String>,
         fmt: Format,
         stream: S,
-    ) -> Result<String, Error>
+    ) -> Result<Id, Error>
     where
         E: std::error::Error,
         S: Stream<Item = Result<Bytes, E>>,

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use cyclonedx_bom::prelude::Bom;
 use std::io::Read;
+use trustify_common::id::Id;
 
 pub struct CyclonedxLoader<'g> {
     graph: &'g Graph,
@@ -19,7 +20,7 @@ impl<'g> CyclonedxLoader<'g> {
         source: L,
         document: R,
         sha256: &str,
-    ) -> Result<String, Error> {
+    ) -> Result<Id, Error> {
         let sbom = Bom::parse_json_value(serde_json::from_reader(document)?)
             .map_err(|err| Error::UnsupportedFormat(format!("Failed to parse: {err}")))?;
 
@@ -54,7 +55,7 @@ impl<'g> CyclonedxLoader<'g> {
 
         tx.commit().await?;
 
-        Ok(ctx.sbom.sbom_id.to_string())
+        Ok(Id::Uuid(ctx.sbom.sbom_id))
     }
 }
 

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -6,6 +6,7 @@ use crate::{
     service::Error,
 };
 use std::io::Read;
+use trustify_common::id::Id;
 
 pub struct SpdxLoader<'g> {
     graph: &'g Graph,
@@ -21,7 +22,7 @@ impl<'g> SpdxLoader<'g> {
         source: L,
         json: R,
         sha256: &str,
-    ) -> Result<String, Error> {
+    ) -> Result<Id, Error> {
         // FIXME: consider adding a report entry in case of "fixing" things
         let (spdx, _) = parse_spdx(json)?;
 
@@ -49,7 +50,7 @@ impl<'g> SpdxLoader<'g> {
 
         tx.commit().await?;
 
-        Ok(sbom.sbom.sbom_id.to_string())
+        Ok(Id::Uuid(sbom.sbom.sbom_id))
     }
 }
 

--- a/modules/storage/src/service/dispatch.rs
+++ b/modules/storage/src/service/dispatch.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use sha2::{digest::Output, Sha256};
 
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 
 use super::*;
 
@@ -36,7 +36,7 @@ impl StorageBackend for DispatchBackend {
 
     async fn retrieve(
         self,
-        hash_key: HashOrUuidKey,
+        hash_key: Id,
     ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error>
     where
         Self: Sized,

--- a/modules/storage/src/service/fs.rs
+++ b/modules/storage/src/service/fs.rs
@@ -16,7 +16,7 @@ use tokio::{
     io::{AsyncSeekExt, AsyncWriteExt},
 };
 use tokio_util::io::ReaderStream;
-use trustify_common::hash::{HashKeyError, HashOrUuidKey};
+use trustify_common::id::{Id, IdError};
 
 /// A filesystem backed store
 ///
@@ -150,14 +150,14 @@ impl StorageBackend for FileSystemBackend {
 
     async fn retrieve(
         self,
-        hash_key: HashOrUuidKey,
+        hash_key: Id,
     ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error> {
         let hash = match hash_key {
-            HashOrUuidKey::Sha256(inner) => inner,
+            Id::Sha256(inner) => inner,
             unsupported => {
                 return Err(std::io::Error::new(
                     ErrorKind::InvalidInput,
-                    HashKeyError::UnsupportedAlgorithm(unsupported.prefix().to_string()),
+                    IdError::UnsupportedAlgorithm(unsupported.prefix().to_string()),
                 ));
             }
         };

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -45,6 +45,7 @@ impl<T: StorageBackend> SyncAdapter<T> {
     pub fn new(delegate: T) -> Self {
         SyncAdapter { delegate }
     }
+
     /// Retrieve the content as a sync reader, the operation itself is async
     ///
     /// NOTE: The default implementation falls back to an in-memory buffer.

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -8,7 +8,7 @@ use sha2::{digest::Output, Sha256};
 use std::fmt::Debug;
 use std::future::Future;
 use std::io::{Cursor, Read};
-use trustify_common::hash::HashOrUuidKey;
+use trustify_common::id::Id;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError<S: Debug, B: Debug> {
@@ -33,7 +33,7 @@ pub trait StorageBackend {
     /// Retrieve the content as an async reader
     fn retrieve(
         self,
-        hash_key: HashOrUuidKey,
+        hash_key: Id,
     ) -> impl Future<Output = Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error>>;
 }
 
@@ -48,7 +48,7 @@ impl<T: StorageBackend> SyncAdapter<T> {
     /// Retrieve the content as a sync reader, the operation itself is async
     ///
     /// NOTE: The default implementation falls back to an in-memory buffer.
-    pub async fn retrieve(self, hash_key: HashOrUuidKey) -> Result<Option<impl Read>, T::Error>
+    pub async fn retrieve(self, hash_key: Id) -> Result<Option<impl Read>, T::Error>
     where
         Self: Sized,
     {


### PR DESCRIPTION
Fix #394: Before downloading the actual content, we look up the sha256 digest from the database and use that to fetch the content from the storage. This is done for advisories, but also for SBOMs.

Also:
  * When uploading a document, return the `Id` of the database instead of some ID field from the document
  * Rename `HashOrUuidKey` to `Id`
  * Make it clearer what key/id means for the storage (`StorageKey`)