### PR TITLE
Add a cvss3_severity enum (none, low, medium, high, critical)

### DIFF
--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -1,5 +1,6 @@
 use crate::{advisory, vulnerability};
 use sea_orm::entity::prelude::*;
+use std::fmt::{Display, Formatter};
 use trustify_cvss::cvss3;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
@@ -24,6 +25,7 @@ pub struct Model {
     pub a: Availability,
 
     pub score: f64,
+    pub severity: Severity,
 }
 
 impl From<Model> for cvss3::Cvss3Base {
@@ -307,6 +309,55 @@ impl From<cvss3::Availability> for Availability {
             cvss3::Availability::None => Self::None,
             cvss3::Availability::Low => Self::Low,
             cvss3::Availability::High => Self::High,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_severity")]
+pub enum Severity {
+    #[sea_orm(string_value = "none")]
+    None,
+    #[sea_orm(string_value = "low")]
+    Low,
+    #[sea_orm(string_value = "medium")]
+    Medium,
+    #[sea_orm(string_value = "high")]
+    High,
+    #[sea_orm(string_value = "critical")]
+    Critical,
+}
+
+impl Display for Severity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Severity::None => {
+                write!(f, "none")
+            }
+            Severity::Low => {
+                write!(f, "low")
+            }
+            Severity::Medium => {
+                write!(f, "medium")
+            }
+            Severity::High => {
+                write!(f, "high")
+            }
+            Severity::Critical => {
+                write!(f, "critical")
+            }
+        }
+    }
+}
+
+impl From<cvss3::severity::Severity> for Severity {
+    fn from(value: cvss3::severity::Severity) -> Self {
+        match value {
+            cvss3::severity::Severity::None => Self::None,
+            cvss3::severity::Severity::Low => Self::Low,
+            cvss3::severity::Severity::Medium => Self::Medium,
+            cvss3::severity::Severity::High => Self::High,
+            cvss3::severity::Severity::Critical => Self::Critical,
         }
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -32,6 +32,7 @@ mod m0000300_create_product_version;
 mod m0000310_alter_advisory_primary_key;
 mod m0000315_create_cvss3_scoring_function;
 mod m0000320_create_cvss3_score_column;
+mod m0000325_create_cvss3_severity_column;
 
 pub struct Migrator;
 
@@ -70,6 +71,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000310_alter_advisory_primary_key::Migration),
             Box::new(m0000315_create_cvss3_scoring_function::Migration),
             Box::new(m0000320_create_cvss3_score_column::Migration),
+            Box::new(m0000325_create_cvss3_severity_column::Migration),
         ]
     }
 }

--- a/migration/src/m0000325_create_cvss3_severity_column.rs
+++ b/migration/src/m0000325_create_cvss3_severity_column.rs
@@ -1,0 +1,180 @@
+use crate::sea_orm::{IntoIdentity, Statement};
+use sea_orm_migration::prelude::*;
+use std::str::FromStr;
+
+use crate::extension::postgres::Type;
+use crate::sea_orm::prelude::Uuid;
+use trustify_cvss::cvss3::Cvss3Base;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // create the severity enum.
+        manager
+            .create_type(
+                Type::create()
+                    .as_enum(Cvss3Severity::Cvss3Severity)
+                    .values([
+                        Cvss3Severity::None,
+                        Cvss3Severity::Low,
+                        Cvss3Severity::Medium,
+                        Cvss3Severity::High,
+                        Cvss3Severity::Critical,
+                    ])
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0000325_create_cvss3_severity_column.sql"))
+            .await
+            .map(|_| ())?;
+
+        // Add `score` to cvss3 table, allowed to be null
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .add_column(ColumnDef::new(Cvss3::Severity).enumeration(
+                        Cvss3Severity::Cvss3Severity,
+                        [
+                            Cvss3Severity::None,
+                            Cvss3Severity::Low,
+                            Cvss3Severity::Medium,
+                            Cvss3Severity::High,
+                            Cvss3Severity::Critical,
+                        ],
+                    ))
+                    .to_owned(),
+            )
+            .await?;
+
+        // Use the Rust codepath to calculate scores and thence the severity for each row and update.
+
+        let results = manager
+            .get_connection()
+            .query_all(Statement::from_string(
+                manager.get_database_backend(),
+                Query::select()
+                    .columns([
+                        Cvss3::AdvisoryId,
+                        Cvss3::VulnerabilityId,
+                        Cvss3::MinorVersion,
+                        Cvss3::AV,
+                        Cvss3::AC,
+                        Cvss3::PR,
+                        Cvss3::UI,
+                        Cvss3::S,
+                        Cvss3::C,
+                        Cvss3::I,
+                        Cvss3::A,
+                    ])
+                    .from(Cvss3::Table)
+                    .to_string(PostgresQueryBuilder),
+            ))
+            .await?;
+
+        for row in results {
+            let advisory_id: Uuid = row.try_get("", "advisory_id")?;
+            let vulnerability_id: i32 = row.try_get("", "vulnerability_id")?;
+            let minor_version: i32 = row.try_get("", "minor_version")?;
+            let av: String = row.try_get("", "av")?;
+            let ac: String = row.try_get("", "ac")?;
+            let pr: String = row.try_get("", "pr")?;
+            let ui: String = row.try_get("", "ui")?;
+            let s: String = row.try_get("", "s")?;
+            let c: String = row.try_get("", "c")?;
+            let i: String = row.try_get("", "i")?;
+            let a: String = row.try_get("", "a")?;
+
+            let vector = format!(
+                "CVSS:3.{minor_version}/AV:{av}/AC:{ac}/PR:{pr}/UI:{ui}/S:{s}/C:{c}/I:{i}/A:{a}"
+            );
+
+            if let Ok(cvss3) = Cvss3Base::from_str(&vector) {
+                let severity = cvss3.score().roundup().severity().to_string();
+
+                let _ = manager
+                    .get_connection()
+                    .execute_unprepared(
+                        &Query::update()
+                            .table(Cvss3::Table)
+                            .value(Cvss3::Severity, severity)
+                            .and_where(
+                                Expr::col("vulnerability_id".into_identity()).eq(vulnerability_id),
+                            )
+                            .and_where(Expr::col("advisory_id".into_identity()).eq(advisory_id))
+                            .and_where(Expr::col("minor_version".into_identity()).eq(minor_version))
+                            .to_string(PostgresQueryBuilder),
+                    )
+                    .await?;
+            }
+        }
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .modify_column(ColumnDef::new(Cvss3::Severity).not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .drop_column(Cvss3::Severity)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"drop function cvss3_severity"#)
+            .await?;
+
+        manager
+            .drop_type(Type::drop().name(Cvss3Severity::Cvss3Severity).to_owned())
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum Cvss3 {
+    Table,
+    Severity,
+
+    AdvisoryId,
+    VulnerabilityId,
+    MinorVersion,
+    AV,
+    AC,
+    PR,
+    UI,
+    S,
+    C,
+    I,
+    A,
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Cvss3Severity {
+    Cvss3Severity,
+    None,
+    Low,
+    Medium,
+    High,
+    Critical,
+}

--- a/migration/src/m0000325_create_cvss3_severity_column.sql
+++ b/migration/src/m0000325_create_cvss3_severity_column.sql
@@ -1,0 +1,32 @@
+
+-- Calcuate a CVSS3 score from an *entire* row of the `cvss3` table
+create or replace function cvss3_severity(score_p double precision)
+    returns cvss3_severity
+as
+$$
+declare
+    exploitability decimal;
+    iss decimal;
+    iss_scoped decimal;
+    score decimal;
+begin
+    if score_p is null then
+        return null;
+    end if;
+
+    if score_p <= 3.9 then
+        return 'low'::"cvss3_severity";
+    end if;
+
+    if score_p <= 6.9 then
+        return 'medium'::"cvss3_severity";
+    end if;
+
+    if score_p <= 8.9 then
+        return 'high'::"cvss3_severity";
+    end if;
+
+    return 'critical'::"cvss3_severity";
+end
+$$
+    language 'plpgsql';

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -153,6 +153,77 @@ async fn all_advisories_filtered_by_average_score(
 
 #[test_context(TrustifyContext, skip_teardown)]
 #[test(actix_web::test)]
+async fn all_advisories_filtered_by_average_severity(
+    ctx: TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Arc::new(Graph::new(db.clone()));
+
+    let advisory = graph
+        .ingest_advisory(
+            "RHSA-1",
+            "http://redhat.com/",
+            "8675309",
+            AdvisoryInformation {
+                title: Some("RHSA-1".to_string()),
+                issuer: None,
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let advisory_vuln = advisory
+        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .await?;
+    advisory_vuln
+        .ingest_cvss3_score(
+            Cvss3Base {
+                minor_version: 0,
+                av: AttackVector::Network,
+                ac: AttackComplexity::Low,
+                pr: PrivilegesRequired::None,
+                ui: UserInteraction::None,
+                s: Scope::Unchanged,
+                c: Confidentiality::None,
+                i: Integrity::High,
+                a: Availability::High,
+            },
+            (),
+        )
+        .await?;
+
+    graph
+        .ingest_advisory(
+            "RHSA-2",
+            "http://redhat.com/",
+            "8675319",
+            AdvisoryInformation {
+                title: Some("RHSA-2".to_string()),
+                issuer: None,
+                published: Some(OffsetDateTime::now_utc()),
+                modified: None,
+                withdrawn: None,
+            },
+            (),
+        )
+        .await?;
+
+    let fetch = AdvisoryService::new(db);
+    let fetched = fetch
+        .fetch_advisories(q("average_severity>=critical"), Paginated::default(), ())
+        .await?;
+
+    println!("{:#?}", fetched);
+
+    assert_eq!(fetched.total, 1);
+    Ok(())
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
 async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let db = ctx.db;
     let graph = Arc::new(Graph::new(db.clone()));

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -16,6 +16,7 @@ use trustify_common::db::Transactional;
 use trustify_common::purl::Purl;
 use trustify_cvss::cvss3::Cvss3Base;
 use trustify_entity as entity;
+use trustify_entity::cvss3::Severity;
 use trustify_entity::vulnerability;
 
 #[derive(Clone, Debug)]
@@ -273,6 +274,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             i: Set(cvss3.i.into()),
             a: Set(cvss3.a.into()),
             score: Set(cvss3.score().roundup().value()),
+            severity: Set(Severity::from(cvss3.score().roundup().severity())),
         };
 
         Ok(model


### PR DESCRIPTION
Add a cvss3.severity column with that enum.
Calculate it in a migration.
Adjust Query API to support enums (Value->ValueOrSimpleExpr for envalue()) Add SQL function to calculate severity from score (for non-stored avg(score)) Add average_severity to the query.