### PR TITLE
feat: add ability to translate queries

### DIFF
--- a/common/src/db/limiter.rs
+++ b/common/src/db/limiter.rs
@@ -1,9 +1,7 @@
 use sea_orm::{
     ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Paginator, PaginatorTrait, QuerySelect,
-    Select, SelectModel, SelectTwo, SelectTwoMany, SelectTwoModel, Selector, SelectorTrait,
+    Select, SelectModel, SelectTwo, SelectTwoModel, Selector, SelectorTrait,
 };
-use std::future::Future;
-use std::marker::PhantomData;
 use std::num::NonZeroU64;
 
 pub struct Limiter<'db, C, S1, S2>

--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -3,20 +3,16 @@ use regex::Regex;
 use sea_orm::entity::ColumnDef;
 use sea_orm::sea_query::{extension::postgres::PgExpr, ConditionExpression, IntoCondition};
 use sea_orm::{
-    sea_query, ColumnTrait, ColumnType, Condition, EntityName, EntityTrait, Iden, IntoIdentity,
-    IntoSimpleExpr, Iterable, Order, PrimaryKeyToColumn, QueryFilter, QueryOrder, QuerySelect,
-    QueryTrait, Select, Value,
+    sea_query, ColumnTrait, ColumnType, Condition, EntityTrait, IntoIdentity, IntoSimpleExpr,
+    Iterable, Order, QueryFilter, QueryOrder, Select, Value,
 };
-use sea_query::{BinOper, ColumnRef, DynIden, Expr, IntoColumnRef, SimpleExpr};
-use std::collections::HashMap;
+use sea_query::{BinOper, ColumnRef, Expr, IntoColumnRef, SimpleExpr};
 use std::fmt::Display;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::OnceLock;
 use time::format_description::well_known::Rfc3339;
 use time::macros::format_description;
 use time::{Date, OffsetDateTime};
-use utoipa::IntoParams;
 
 /////////////////////////////////////////////////////////////////////////
 // Public interface
@@ -482,7 +478,7 @@ fn envalue(s: &str, ct: &ColumnType) -> Result<ValueOrSimpleExpr, Error> {
         ColumnType::Decimal(_) | ColumnType::Float | ColumnType::Double => {
             ValueOrSimpleExpr::Value(Value::from(s.parse::<f64>().map_err(err)?))
         }
-        ColumnType::Enum { name, variants } => ValueOrSimpleExpr::SimpleExpr(SimpleExpr::AsEnum(
+        ColumnType::Enum { name, .. } => ValueOrSimpleExpr::SimpleExpr(SimpleExpr::AsEnum(
             name.clone(),
             Box::new(SimpleExpr::Value(Value::String(Some(Box::new(
                 s.to_owned(),
@@ -515,8 +511,8 @@ fn envalue(s: &str, ct: &ColumnType) -> Result<ValueOrSimpleExpr, Error> {
 mod tests {
     use super::*;
     use chrono::{Local, TimeDelta};
-    use sea_orm::{ColumnTypeTrait, QueryFilter, QuerySelect, QueryTrait};
-    use sea_query::{Func, Function, IntoIden};
+    use sea_orm::{ColumnTypeTrait, QuerySelect, QueryTrait};
+    use sea_query::Func;
     use test_log::test;
 
     #[test(tokio::test)]

--- a/common/src/db/test.rs
+++ b/common/src/db/test.rs
@@ -4,9 +4,10 @@ use postgresql_archive::Version;
 use postgresql_embedded::{PostgreSQL, Settings};
 use std::str::FromStr;
 use tempfile::TempDir;
-use test_context::{test_context, AsyncTestContext};
+use test_context::AsyncTestContext;
 use tracing::{info_span, instrument, Instrument};
 
+#[allow(dead_code)]
 pub struct TrustifyContext {
     pub db: crate::db::Database,
     postgresql: Option<PostgreSQL>,
@@ -45,7 +46,7 @@ impl AsyncTestContext for TrustifyContext {
             ..Default::default()
         };
 
-        let mut postgresql = async {
+        let postgresql = async {
             let version = Version::from_str("16.3.0").expect("valid psql version");
             let mut postgresql = PostgreSQL::new(version, settings);
             postgresql

--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -1,5 +1,5 @@
 use serde::de::{Error, Visitor};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -136,12 +136,9 @@ impl FromStr for Id {
 mod test {
     use crate::id::Id;
     use serde_json::json;
-    use uuid::Uuid;
 
     #[test]
     fn deserialize() -> Result<(), anyhow::Error> {
-        let raw = "sha256:123123";
-
         let key: Id = serde_json::from_value(json!("sha256:123123"))?;
 
         assert_eq!(key, Id::Sha256("123123".to_string()));

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,7 +1,3 @@
-#![allow(unused)]
-
-use crate::config::Database;
-
 pub mod advisory;
 pub mod config;
 pub mod cpe;

--- a/common/src/model.rs
+++ b/common/src/model.rs
@@ -1,7 +1,5 @@
 use crate::db::limiter::Limiter;
-use sea_orm::{ConnectionTrait, DbErr, ItemsAndPagesNumber, SelectorTrait};
-use serde::{Serialize, Serializer};
-use std::num::NonZeroU64;
+use sea_orm::{ConnectionTrait, DbErr, SelectorTrait};
 use utoipa::{IntoParams, ToSchema};
 
 pub use concat_idents::concat_idents;

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::str::FromStr;
 
 use packageurl::PackageUrl;

--- a/common/src/time.rs
+++ b/common/src/time.rs
@@ -32,7 +32,7 @@ impl ChronoExt for DateTime<Utc> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    use chrono::NaiveDate;
     use time::macros::datetime;
 
     fn input(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Utc> {


### PR DESCRIPTION
This should enable filtering and sorting of enum fields like `severity` by translating them into queries for `score` instead.