### PR TITLE
Fixes #393.

### DIFF
--- a/modules/fundamental/src/advisory/model/details/mod.rs
+++ b/modules/fundamental/src/advisory/model/details/mod.rs
@@ -5,6 +5,7 @@ use utoipa::ToSchema;
 use crate::advisory::model::AdvisoryHead;
 use advisory_vulnerability::AdvisoryVulnerabilitySummary;
 use trustify_common::db::ConnectionOrTransaction;
+use trustify_entity::cvss3::Severity;
 use trustify_entity::{advisory, organization, vulnerability};
 
 use crate::Error;
@@ -16,11 +17,17 @@ pub struct AdvisoryDetails {
     #[serde(flatten)]
     pub head: AdvisoryHead,
     pub vulnerabilities: Vec<AdvisoryVulnerabilitySummary>,
+    /// Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
+    pub average_severity: Option<String>,
+    /// Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
+    pub average_score: Option<f64>,
 }
 
 impl AdvisoryDetails {
     pub async fn from_entity(
         advisory: &advisory::Model,
+        average_score: Option<f64>,
+        average_severity: Option<Severity>,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let vulnerabilities = advisory.find_related(vulnerability::Entity).all(tx).await?;
@@ -33,6 +40,8 @@ impl AdvisoryDetails {
         Ok(AdvisoryDetails {
             head: AdvisoryHead::from_entity(advisory, issuer, tx).await?,
             vulnerabilities,
+            average_severity: average_severity.map(|e| e.to_string()),
+            average_score,
         })
     }
 }

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -287,13 +287,16 @@ async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let fetch = AdvisoryService::new(db);
     let jenny = Id::from_str("sha256:8675309")?;
     let fetched = fetch.fetch_advisory(jenny.clone(), ()).await?;
+
     assert!(matches!(
             fetched,
             Some(AdvisoryDetails {
                 head: AdvisoryHead { hashes, .. },
+            average_severity: Some(average_severity),
+
                 ..
             })
-        if hashes.contains(&jenny) ));
+        if hashes.contains(&jenny) && average_severity == "critical"));
 
     Ok(())
 }


### PR DESCRIPTION
Add `average_score` and `average_severity` to the root of advisory details when fetched by key.