### PR TITLE
Add SBOM version, fix SBOM listing

### DIFF
--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -1,5 +1,6 @@
 use async_graphql::SimpleObject;
 use sea_orm::entity::prelude::*;
+use sea_orm::LinkDef;
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SimpleObject)]
@@ -24,6 +25,17 @@ pub enum Relation {
     Packages,
     #[sea_orm(has_one = "super::sbom_node::Entity")]
     Node,
+}
+
+pub struct SbomNodeLink;
+
+impl Linked for SbomNodeLink {
+    type FromEntity = Entity;
+    type ToEntity = super::sbom_node::Entity;
+
+    fn link(&self) -> Vec<LinkDef> {
+        vec![super::sbom_node::Relation::SbomNode.def().rev()]
+    }
 }
 
 impl Related<super::sbom_package::Entity> for Entity {

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -1,6 +1,5 @@
 use async_graphql::SimpleObject;
-use sea_orm::entity::prelude::*;
-use sea_orm::LinkDef;
+use sea_orm::{entity::prelude::*, LinkDef};
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SimpleObject)]

--- a/entity/src/sbom_node.rs
+++ b/entity/src/sbom_node.rs
@@ -27,8 +27,8 @@ pub enum Relation {
     Sbom,
     #[sea_orm(
         belongs_to = "super::sbom::Entity",
-        from = "Column::NodeId",
-        to = "super::sbom::Column::NodeId"
+        from = "(Column::NodeId, Column::SbomId)",
+        to = "(super::sbom::Column::NodeId, super::sbom::Column::SbomId)"
     )]
     SbomNode,
 }

--- a/entity/src/sbom_node.rs
+++ b/entity/src/sbom_node.rs
@@ -25,6 +25,12 @@ pub enum Relation {
         to = "super::sbom::Column::SbomId"
     )]
     Sbom,
+    #[sea_orm(
+        belongs_to = "super::sbom::Entity",
+        from = "Column::NodeId",
+        to = "super::sbom::Column::NodeId"
+    )]
+    SbomNode,
 }
 
 impl Related<super::sbom_package::Entity> for Entity {

--- a/entity/src/sbom_package.rs
+++ b/entity/src/sbom_package.rs
@@ -7,6 +7,7 @@ pub struct Model {
     pub sbom_id: Uuid,
     #[sea_orm(primary_key)]
     pub node_id: String,
+    pub version: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/integration-tests/src/sbom/test/cyclonedx.rs
+++ b/integration-tests/src/sbom/test/cyclonedx.rs
@@ -22,6 +22,7 @@ async fn test_parse_cyclonedx(ctx: TrustifyContext) -> Result<(), anyhow::Error>
                 vec![SbomPackage {
                     id: "pkg:maven/org.apache.zookeeper/zookeeper@3.9.2?type=jar".to_string(),
                     name: "zookeeper".to_string(),
+                    version: Some("3.9.2".to_string()),
                     purl: vec![
                         "pkg://maven/org.apache.zookeeper/zookeeper@3.9.2?type=jar".to_string()
                     ],

--- a/integration-tests/src/sbom/test/perf.rs
+++ b/integration-tests/src/sbom/test/perf.rs
@@ -27,6 +27,7 @@ async fn ingest_spdx_medium(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 SbomPackage {
                     id: "SPDXRef-5fbf9e8d-2f8f-4cfe-a145-b69a1f7d73cc".to_string(),
                     name: "RHEL-8-RHOCS-4.8".to_string(),
+                    version: Some("4.8.z".to_string()),
                     purl: vec![],
                     cpe: vec!["cpe:/a:redhat:openshift_container_storage:4.8:*:el8:*".into()],
                 }

--- a/integration-tests/src/sbom/test/spdx.rs
+++ b/integration-tests/src/sbom/test/spdx.rs
@@ -24,6 +24,7 @@ async fn parse_spdx_quarkus(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 &SbomPackage {
                     id: "SPDXRef-b52acd7c-3a3f-441e-aef0-bbdaa1ec8acf".into(),
                     name: "quarkus-bom".into(),
+                    version: Some("2.13.8.Final-redhat-00004".to_string()),
                     purl: vec![
                         "pkg://maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=pom".into()
                     ],

--- a/migration/src/m0000250_create_sbom_package.rs
+++ b/migration/src/m0000250_create_sbom_package.rs
@@ -14,6 +14,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(ColumnDef::new(SbomPackage::SbomId).uuid().not_null())
                     .col(ColumnDef::new(SbomPackage::NodeId).string().not_null())
+                    .col(ColumnDef::new(SbomPackage::Version).string())
                     .primary_key(
                         Index::create()
                             .col(SbomPackage::SbomId)
@@ -53,4 +54,5 @@ pub enum SbomPackage {
     Table,
     SbomId,
     NodeId,
+    Version,
 }

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -1,8 +1,7 @@
 use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use trustify_common::id::Id;
-use trustify_common::paginated;
+use trustify_common::{id::Id, paginated};
 use trustify_entity::relationship::Relationship;
 use utoipa::ToSchema;
 
@@ -32,6 +31,7 @@ paginated!(SbomSummary);
 pub struct SbomPackage {
     pub id: String,
     pub name: String,
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub purl: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -21,6 +21,9 @@ pub struct SbomSummary {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authors: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub described_by: Vec<SbomPackage>,
 }
 
 paginated!(SbomSummary);

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -24,6 +24,7 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
     purl::Purl,
 };
+use trustify_entity::sbom::SbomNodeLink;
 use trustify_entity::{
     cpe::{self, CpeDto},
     package, package_relates_to_package, package_version,
@@ -70,7 +71,10 @@ impl SbomService {
 
         let limiter = sbom::Entity::find()
             .filtering(search)?
-            .find_also_related(sbom_node::Entity)
+            // FIXME: need to find a way to join this by node_id
+            .find_also_linked(SbomNodeLink)
+            // .join(JoinType::LeftJoin, sbom::Relation::SbomNode.def())
+            //.find_also_related(sbom_node::Entity)
             .limiting(&connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;

--- a/modules/ingestor/README.md
+++ b/modules/ingestor/README.md
@@ -1,0 +1,7 @@
+# Ingestor
+
+## Upload an SBOM
+
+```shell
+cat file.sbom | http POST localhost:8080/api/v1/sbom location==cli
+```

--- a/modules/ingestor/src/graph/sbom/common.rs
+++ b/modules/ingestor/src/graph/sbom/common.rs
@@ -49,6 +49,7 @@ impl PackageCreator {
         &mut self,
         node_id: String,
         name: String,
+        version: Option<String>,
         refs: impl IntoIterator<Item = PackageReference>,
     ) {
         for r#ref in refs {
@@ -79,6 +80,7 @@ impl PackageCreator {
         self.packages.push(sbom_package::ActiveModel {
             sbom_id: Set(self.sbom_id),
             node_id: Set(node_id),
+            version: Set(version),
         });
     }
 

--- a/modules/ingestor/src/graph/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/graph/sbom/cyclonedx.rs
@@ -184,7 +184,12 @@ impl<'a> Creator<'a> {
                 }
             }
 
-            packages.add(node_id, comp.name.to_string(), refs);
+            packages.add(
+                node_id,
+                comp.name.to_string(),
+                comp.version.as_ref().map(|v| v.to_string()),
+                refs,
+            );
         }
 
         for (left, rel, right) in self.relations {

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -540,6 +540,7 @@ impl SbomContext {
             self.ingest_package(
                 left_node_id.clone(),
                 left_node_id.clone(),
+                None,
                 left_purls,
                 left_cpes,
                 &tx,
@@ -551,6 +552,7 @@ impl SbomContext {
             self.ingest_package(
                 right_node_id.clone(),
                 right_node_id.clone(),
+                None,
                 right_purls,
                 right_cpes,
                 &tx,
@@ -611,6 +613,7 @@ impl SbomContext {
         &self,
         node_id: String,
         name: String,
+        version: Option<String>,
         purls: Vec<Uuid>,
         cpes: Vec<i32>,
         tx: TX,
@@ -621,7 +624,7 @@ impl SbomContext {
             .into_iter()
             .map(PackageReference::Purl)
             .chain(cpes.into_iter().map(PackageReference::Cpe));
-        creator.add(node_id, name, refs);
+        creator.add(node_id, name, version, refs);
 
         creator.create(&self.graph.db.connection(&tx)).await?;
 

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -77,6 +77,7 @@ impl SbomContext {
             packages.add(
                 package.package_spdx_identifier.clone(),
                 package.package_name.clone(),
+                package.package_version.clone(),
                 refs,
             );
         }


### PR DESCRIPTION
The main motivation of this PR is to fix issue #284, adding an SBOM version to the response.

For CycloneDX there can be a dedicated version of the main component of the SBOM. For SPDX, there can exist one or more packages describing the SBOM, which may include the version information.

So the information which can be provides is a "described_by" set of packages per SBOM, which contains CPEs, PURLs, a name and an optional version information. However, this set can also be empty.

During work in this issue I discovered another one (#414), where instead of returning all SBOMs, the endpoint returned all SBOM nodes. This is also fixed as part of this PR.