### PR TITLE
fix: count items being processed for osv and cve

### DIFF
--- a/modules/importer/src/server/cve/mod.rs
+++ b/modules/importer/src/server/cve/mod.rs
@@ -27,6 +27,8 @@ impl Context {
     fn store(&self, cve: Cve) -> anyhow::Result<()> {
         let data = serde_json::to_vec(&cve)?;
 
+        self.report.lock().tick();
+
         Handle::current().block_on(async {
             self.ingestor
                 .ingest(

--- a/modules/importer/src/server/osv/mod.rs
+++ b/modules/importer/src/server/osv/mod.rs
@@ -29,6 +29,8 @@ impl Context {
     fn store(&self, osv: Vulnerability) -> anyhow::Result<()> {
         let data = serde_json::to_vec(&osv)?;
 
+        self.report.lock().tick();
+
         Handle::current().block_on(async {
             self.ingestor
                 .ingest(


### PR DESCRIPTION
The reports for CVE and OSV always show zero items, because the report was not updated with the number of processes items. This PR fixes this.