### PR TITLE
Ignoring embedded UI test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Test
         run: cargo test -- --nocapture
         env:
-          RUST_LOG: info
+          RUST_LOG: info,sqlx=error,sea_orm=error

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -127,7 +127,7 @@ impl Database {
         let port = database.port;
         let db_name = &database.name;
         let url = format!("postgres://{username}:{password}@{host}:{port}/{db_name}");
-        log::info!("connect to {}", url);
+        log::debug!("connect to {}", url);
 
         let mut opt = ConnectOptions::new(url);
         opt.min_connections(16);

--- a/integration-tests/src/sbom/test/cyclonedx.rs
+++ b/integration-tests/src/sbom/test/cyclonedx.rs
@@ -42,7 +42,7 @@ async fn test_parse_cyclonedx(ctx: TrustifyContext) -> Result<(), anyhow::Error>
                 )
                 .await?;
 
-            log::info!("{:?}", packages);
+            log::debug!("{:?}", packages);
 
             assert_eq!(41, packages.total);
 

--- a/integration-tests/src/sbom/test/perf.rs
+++ b/integration-tests/src/sbom/test/perf.rs
@@ -20,7 +20,7 @@ async fn ingest_spdx_medium(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 .describes_packages(sbom.sbom.sbom_id, Default::default(), ())
                 .await?;
 
-            log::info!("{:#?}", described);
+            log::debug!("{:#?}", described);
             assert_eq!(1, described.items.len());
             assert_eq!(
                 described.items[0],
@@ -65,7 +65,7 @@ async fn ingest_spdx_large(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
             let described = service
                 .describes_packages(sbom.sbom.sbom_id, Default::default(), Transactional::None)
                 .await?;
-            log::info!("{:#?}", described);
+            log::debug!("{:#?}", described);
             assert_eq!(1, described.items.len());
 
             let first = &described.items[0];

--- a/integration-tests/src/sbom/test/spdx.rs
+++ b/integration-tests/src/sbom/test/spdx.rs
@@ -17,7 +17,7 @@ async fn parse_spdx_quarkus(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
             let described = service
                 .describes_packages(sbom.sbom.sbom_id, Default::default(), Transactional::None)
                 .await?;
-            log::info!("{:#?}", described);
+            log::debug!("{:#?}", described);
             assert_eq!(1, described.items.len());
             let first = &described.items[0];
             assert_eq!(
@@ -42,7 +42,7 @@ async fn parse_spdx_quarkus(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 )
                 .await?;
 
-            log::info!("{}", contains.len());
+            log::debug!("{}", contains.len());
 
             assert!(contains.len() > 500);
 
@@ -78,7 +78,7 @@ async fn test_parse_spdx(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
                 .await?
                 .items;
 
-            log::info!("{}", contains.len());
+            log::debug!("{}", contains.len());
 
             assert!(contains.len() > 500);
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -587,7 +587,7 @@ mod test {
             .fetch_sboms(q("MySpAcE"), Paginated::default(), ())
             .await?;
 
-        println!("{:#?}", fetched.items);
+        log::debug!("{:#?}", fetched.items);
         assert_eq!(1, fetched.total);
 
         Ok(())

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -888,7 +888,7 @@ mod tests {
             .get_qualified_packages_by_query(select, Transactional::None)
             .await?;
 
-        log::info!("{result:?}");
+        log::debug!("{result:?}");
 
         assert_eq!(result.len(), 1);
         assert_eq!(

--- a/trustd/tests/tests.rs
+++ b/trustd/tests/tests.rs
@@ -6,6 +6,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 #[tokio::test]
+#[ignore]
 async fn test_embedded_ui() {
     // This test creates a 'trustify/trustd/.trustify' directory, so we need to remove it.
     let trustify_dir = Path::new(".trustify");


### PR DESCRIPTION
This test has problems:

- it takes too long (it never completes in my local env)
- it leaves .trustify dirs behind
- it shells out to a binary
- it uses a hardcoded port
- it makes requests of URL's that don't exist
- it's not clear that it affirms the fix for #422 

I recommend it be moved beneath `server/` and refactored to use TestRequest.