### PR TITLE
Bring forward status assertions to package-versions.

### DIFF
--- a/modules/fundamental/src/package/model/details/package_version.rs
+++ b/modules/fundamental/src/package/model/details/package_version.rs
@@ -1,9 +1,17 @@
+use crate::advisory::model::AdvisoryHead;
 use crate::package::model::{PackageHead, PackageVersionHead, QualifiedPackageHead};
+use crate::vulnerability::model::VulnerabilityHead;
 use crate::Error;
-use sea_orm::ModelTrait;
+use sea_orm::{
+    ColumnTrait, EntityTrait, LoaderTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
+};
+use sea_query::{Asterisk, Expr, Func, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
-use trustify_entity::{package, package_version, qualified_package};
+use trustify_common::db::{ConnectionOrTransaction, VersionMatches};
+use trustify_entity::{
+    advisory, organization, package, package_status, package_version, qualified_package, status,
+    version_range, vulnerability,
+};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
@@ -12,20 +20,24 @@ pub struct PackageVersionDetails {
     pub head: PackageVersionHead,
     pub base: PackageHead,
     pub packages: Vec<QualifiedPackageHead>,
+    pub advisories: Vec<PackageVersionAdvisory>,
 }
 
 impl PackageVersionDetails {
     pub async fn from_entity(
+        package: Option<package::Model>,
         package_version: &package_version::Model,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
-        let package = package_version
-            .find_related(package::Entity)
-            .one(tx)
-            .await?
-            .ok_or(Error::Data(
-                "underlying package missing for package-version".to_string(),
-            ))?;
+        let package = if let Some(package) = package {
+            package
+        } else {
+            package_version
+                .find_related(package::Entity)
+                .one(tx)
+                .await?
+                .ok_or(Error::Data("underlying package missing".to_string()))?
+        };
 
         let qualified_packages = package_version
             .find_related(qualified_package::Entity)
@@ -36,10 +48,94 @@ impl PackageVersionDetails {
             QualifiedPackageHead::from_entities(&package, package_version, &qualified_packages, tx)
                 .await?;
 
+        let statuses = package_status::Entity::find()
+            .columns([
+                version_range::Column::Id,
+                version_range::Column::LowVersion,
+                version_range::Column::LowInclusive,
+                version_range::Column::HighVersion,
+                version_range::Column::HighInclusive,
+            ])
+            .left_join(package::Entity)
+            .join(JoinType::LeftJoin, package::Relation::PackageVersions.def())
+            .left_join(version_range::Entity)
+            .filter(package_status::Column::PackageId.eq(package.id))
+            .filter(SimpleExpr::FunctionCall(
+                Func::cust(VersionMatches)
+                    .arg(Expr::col(package_version::Column::Version))
+                    .arg(Expr::col((version_range::Entity, Asterisk))),
+            ))
+            .all(tx)
+            .await?;
+
         Ok(Self {
             head: PackageVersionHead::from_entity(&package, package_version, tx).await?,
             base: PackageHead::from_entity(&package, tx).await?,
             packages: qualified_packages,
+            advisories: PackageVersionAdvisory::from_entities(statuses, tx).await?,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct PackageVersionAdvisory {
+    #[serde(flatten)]
+    pub head: AdvisoryHead,
+    pub status: Vec<PackageVersionStatus>,
+}
+
+impl PackageVersionAdvisory {
+    pub async fn from_entities(
+        statuses: Vec<package_status::Model>,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Vec<Self>, Error> {
+        let vulns = statuses.load_one(vulnerability::Entity, tx).await?;
+
+        let advisories = statuses.load_one(advisory::Entity, tx).await?;
+
+        let mut results: Vec<Self> = Vec::new();
+
+        for ((vuln, advisory), status) in vulns.iter().zip(advisories.iter()).zip(statuses.iter()) {
+            if let (Some(vulnerability), Some(advisory)) = (vuln, advisory) {
+                let qualified_package_status =
+                    PackageVersionStatus::from_entity(vulnerability, status, tx).await?;
+
+                if let Some(entry) = results.iter_mut().find(|e| e.head.uuid == advisory.id) {
+                    entry.status.push(qualified_package_status)
+                } else {
+                    let organization = advisory.find_related(organization::Entity).one(tx).await?;
+
+                    results.push(Self {
+                        head: AdvisoryHead::from_entity(advisory, organization, tx).await?,
+                        status: vec![qualified_package_status],
+                    })
+                }
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct PackageVersionStatus {
+    pub vulnerability: VulnerabilityHead,
+    pub status: String,
+}
+
+impl PackageVersionStatus {
+    pub async fn from_entity(
+        vuln: &vulnerability::Model,
+        package_status: &package_status::Model,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        let status = package_status.find_related(status::Entity).one(tx).await?;
+
+        let status = status.map(|e| e.slug).unwrap_or("unknown".to_string());
+
+        Ok(Self {
+            vulnerability: VulnerabilityHead::from_vulnerability_entity(vuln, tx).await?,
+            status,
         })
     }
 }

--- a/modules/fundamental/src/package/service/mod.rs
+++ b/modules/fundamental/src/package/service/mod.rs
@@ -125,7 +125,7 @@ impl PackageService {
 
         if let Some(package_version) = package_version {
             Ok(Some(
-                PackageVersionDetails::from_entity(&package_version, &connection).await?,
+                PackageVersionDetails::from_entity(None, &package_version, &connection).await?,
             ))
         } else {
             Ok(None)
@@ -163,7 +163,7 @@ impl PackageService {
             .await?
         {
             Ok(Some(
-                PackageVersionDetails::from_entity(&package_version, &connection).await?,
+                PackageVersionDetails::from_entity(None, &package_version, &connection).await?,
             ))
         } else {
             Ok(None)

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,12 +1,21 @@
 use crate::advisory::model::AdvisoryHead;
+use crate::package::model::PackageHead;
 use crate::Error;
-use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, QueryFilter};
+use sea_orm::{
+    ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, QueryFilter, QuerySelect, RelationTrait,
+};
+use sea_query::JoinType;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use trustify_common::db::ConnectionOrTransaction;
+use trustify_common::purl::Purl;
 use trustify_cvss::cvss3::score::Score;
 use trustify_cvss::cvss3::Cvss3Base;
-use trustify_entity::{advisory, cvss3, vulnerability};
+use trustify_entity::{
+    advisory, cvss3, package, package_status, status, version_range, vulnerability,
+};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityAdvisoryHead {
@@ -86,6 +95,7 @@ pub struct VulnerabilityAdvisorySummary {
     pub head: VulnerabilityAdvisoryHead,
     #[schema(default, value_type = Vec < String >)]
     pub cvss3_scores: Vec<String>,
+    pub statuses: HashMap<String, Vec<VulnerabilityAdvisoryStatus>>,
 }
 
 impl VulnerabilityAdvisorySummary {
@@ -109,12 +119,148 @@ impl VulnerabilityAdvisorySummary {
                 .map(|e| Cvss3Base::from(e).to_string())
                 .collect();
 
+            let statuses = package_status::Entity::find()
+                .columns([
+                    version_range::Column::Id,
+                    version_range::Column::LowVersion,
+                    version_range::Column::LowInclusive,
+                    version_range::Column::HighVersion,
+                    version_range::Column::HighInclusive,
+                ])
+                .column_as(status::Column::Slug, "status")
+                .columns([
+                    package::Column::Type,
+                    package::Column::Name,
+                    package::Column::Namespace,
+                ])
+                .left_join(status::Entity)
+                .filter(package_status::Column::VulnerabilityId.eq(vulnerability.id))
+                .filter(package_status::Column::AdvisoryId.eq(advisory.id))
+                .left_join(package::Entity)
+                .column_as(package::Column::Id, "package_uuid")
+                .join(JoinType::LeftJoin, package::Relation::PackageVersions.def())
+                .left_join(version_range::Entity)
+                .into_model::<StatusCatcher>()
+                .all(tx)
+                .await?;
+
             summaries.push(VulnerabilityAdvisorySummary {
                 head: VulnerabilityAdvisoryHead::from_entity(vulnerability, advisory, tx).await?,
                 cvss3_scores,
+                statuses: VulnerabilityAdvisoryStatus::from_models(&statuses, tx).await?,
             });
         }
 
         Ok(summaries)
+    }
+}
+
+#[derive(FromQueryResult, Debug)]
+struct StatusCatcher {
+    status: String,
+    package_uuid: Uuid,
+    r#type: String,
+    namespace: Option<String>,
+    name: String,
+    low_version: Option<String>,
+    low_inclusive: Option<bool>,
+    high_version: Option<String>,
+    high_inclusive: Option<bool>,
+}
+
+impl StatusCatcher {
+    pub fn purl(&self) -> Purl {
+        Purl {
+            ty: self.r#type.clone(),
+            namespace: self.namespace.clone(),
+            name: self.name.clone(),
+            version: None,
+            qualifiers: Default::default(),
+        }
+    }
+
+    pub fn version(&self) -> String {
+        match (&self.low_version, &self.high_version) {
+            (Some(low), Some(high)) if low == high => low.clone(),
+            (Some(low), Some(high)) => {
+                let mut v = String::new();
+                v.push(Self::open_delim(self.low_inclusive));
+                v.push_str(&low);
+                v.push(',');
+                v.push_str(&high);
+                v.push(Self::close_delim(self.high_inclusive));
+                v
+            }
+
+            (Some(low), None) => {
+                let mut v = String::new();
+                v.push(Self::open_delim(self.low_inclusive));
+                v.push_str(&low);
+                v.push(',');
+                v.push(Self::close_delim(self.high_inclusive));
+                v
+            }
+            (None, Some(high)) => {
+                let mut v = String::new();
+                v.push(Self::open_delim(self.low_inclusive));
+                v.push(',');
+                v.push_str(&high);
+                v.push(Self::close_delim(self.high_inclusive));
+                v
+            }
+            (None, None) => "*".to_string(),
+        }
+    }
+
+    fn open_delim(incl: Option<bool>) -> char {
+        if let Some(incl) = incl {
+            if incl {
+                '['
+            } else {
+                '('
+            }
+        } else {
+            '('
+        }
+    }
+
+    fn close_delim(incl: Option<bool>) -> char {
+        if let Some(incl) = incl {
+            if incl {
+                ']'
+            } else {
+                ')'
+            }
+        } else {
+            ')'
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct VulnerabilityAdvisoryStatus {
+    package: PackageHead,
+    version: String,
+}
+
+impl VulnerabilityAdvisoryStatus {
+    async fn from_models(
+        models: &Vec<StatusCatcher>,
+        _tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<HashMap<String, Vec<Self>>, Error> {
+        let mut statuses = HashMap::new();
+
+        for each in models {
+            let status_entry = statuses.entry(each.status.clone()).or_insert(vec![]);
+            status_entry.push(VulnerabilityAdvisoryStatus {
+                package: PackageHead {
+                    uuid: each.package_uuid,
+                    purl: each.purl(),
+                },
+                version: each.version(),
+            });
+        }
+
+        Ok(statuses)
     }
 }

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -185,9 +185,9 @@ impl StatusCatcher {
             (Some(low), Some(high)) => {
                 let mut v = String::new();
                 v.push(Self::open_delim(self.low_inclusive));
-                v.push_str(&low);
+                v.push_str(low);
                 v.push(',');
-                v.push_str(&high);
+                v.push_str(high);
                 v.push(Self::close_delim(self.high_inclusive));
                 v
             }
@@ -195,7 +195,7 @@ impl StatusCatcher {
             (Some(low), None) => {
                 let mut v = String::new();
                 v.push(Self::open_delim(self.low_inclusive));
-                v.push_str(&low);
+                v.push_str(low);
                 v.push(',');
                 v.push(Self::close_delim(self.high_inclusive));
                 v
@@ -204,7 +204,7 @@ impl StatusCatcher {
                 let mut v = String::new();
                 v.push(Self::open_delim(self.low_inclusive));
                 v.push(',');
-                v.push_str(&high);
+                v.push_str(high);
                 v.push(Self::close_delim(self.high_inclusive));
                 v
             }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -61,3 +61,6 @@ impl VulnerabilityService {
         }
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -1,0 +1,62 @@
+use crate::vulnerability::service::VulnerabilityService;
+use std::str::FromStr;
+use test_context::test_context;
+use test_log::test;
+use tokio_util::io::ReaderStream;
+use trustify_common::db::test::TrustifyContext;
+use trustify_common::db::Transactional;
+use trustify_common::purl::Purl;
+use trustify_module_ingestor::graph::Graph;
+use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_storage::service::fs::FileSystemBackend;
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn statuses(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let service = VulnerabilityService::new(db.clone());
+    let (storage, _tmp) = FileSystemBackend::for_test().await?;
+
+    let ingestor = IngestorService::new(Graph::new(db.clone()), storage);
+
+    // ingest an advisory
+    let data = include_bytes!("../../../../../etc/test-data/osv/RUSTSEC-2021-0079.json");
+    let data = ReaderStream::new(&data[..]);
+
+    ingestor
+        .ingest(
+            ("source", "test"),
+            Some("RUSTSEC".to_string()),
+            Format::OSV,
+            data,
+        )
+        .await?;
+
+    // backfill ingest the CVE record
+    let data = include_bytes!("../../../../../etc/test-data/cve/CVE-2021-32714.json");
+    let data = ReaderStream::new(&data[..]);
+
+    ingestor
+        .ingest(("source", "test"), None, Format::CVE, data)
+        .await?;
+
+    // finally ingest a specific known-affected version.
+
+    ingestor
+        .graph()
+        .ingest_qualified_package(
+            &Purl::from_str("pkg:cargo/hyper@0.14.1")?,
+            Transactional::None,
+        )
+        .await?;
+
+    let vuln = service
+        .fetch_vulnerability("CVE-2021-32714", Transactional::None)
+        .await?;
+
+    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+
+    assert!(vuln.is_some());
+
+    Ok(())
+}


### PR DESCRIPTION
Also, bring towards Vulnerability details, including stanzas akin to Note: the set of possible statuses is unbound, but may include at least some intrinsic ones, such as "affected", "not_affected", and "fixed".

Versions are denoted as one of:

- A singular version without delimiters.
- A range, using [ and ] to denote *inclusive* and ( and ) as exclusive.
  - These can be mixed within a single range, to indicate that the range is half-open, possibly. (Inclusive of the low side, but exclusive to the high side)
- For any range, low or high may be absent, indicating unbounded/infinite.
- If no versions are provided, a `*` is provided, indicating _all versions_ are represented by that status.

```
      "statuses": {
        "affected": [
          {
            "package": {
              "uuid": "9adb7324-89b7-5fe0-a556-23218e39ebf3",
              "purl": "pkg://cargo/hyper"
            },
            "version": "[0.0.0-0,0.14.10)"
          }
        ],
        "fixed": [
          {
            "package": {
              "uuid": "9adb7324-89b7-5fe0-a556-23218e39ebf3",
              "purl": "pkg://cargo/hyper"
            },
            "version": "0.14.10"
          }
        ]
      }
    },
```