### PR TITLE
Reduce duplicate status ingestions.

### DIFF
--- a/etc/test-data/csaf/CVE-2024-5154.json
+++ b/etc/test-data/csaf/CVE-2024-5154.json
@@ -1,0 +1,14759 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/beta/vex/2024/cve-2024-5154.json"
+      }
+    ],
+    "title": "cri-o: malicious container can create symlink on host",
+    "tracking": {
+      "current_release_date": "2024-06-27T04:40:19+00:00",
+      "generator": {
+        "date": "2024-06-27T04:40:19+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.30.2"
+        }
+      },
+      "id": "CVE-2024-5154",
+      "initial_release_date": "2024-05-27T18:00:00+00:00",
+      "revision_history": [
+        {
+          "date": "2024-05-27T18:00:00+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-06-13T02:25:17+00:00",
+          "number": "2",
+          "summary": "Current version"
+        },
+        {
+          "date": "2024-06-27T04:40:19+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 3.11",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 3.11",
+                  "product_id": "red_hat_openshift_container_platform_3.11",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:3.11"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat OpenShift Container Platform 3.11"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.12",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.12",
+                  "product_id": "8Base-RHOSE-4.12",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.12::el8"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.14",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.14",
+                  "product_id": "8Base-RHOSE-4.14",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.14::el8"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.14",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.14",
+                  "product_id": "9Base-RHOSE-4.14",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.14::el9"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.15",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.15",
+                  "product_id": "9Base-RHOSE-4.15",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.15::el9"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.15",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.15",
+                  "product_id": "8Base-RHOSE-4.15",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.15::el8"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat OpenShift Enterprise"
+          },
+          {
+            "category": "product_version",
+            "name": "cri-o",
+            "product": {
+              "name": "cri-o",
+              "product_id": "cri-o",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/cri-o?arch=src"
+              }
+            }
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+                "product": {
+                  "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+                  "product_id": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+                "product": {
+                  "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+                  "product_id": "kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kata-containers@3.0.2-15.rhaos4.12.el8?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:4.18.0-372.109.1.el8_6.src",
+                "product": {
+                  "name": "kernel-0:4.18.0-372.109.1.el8_6.src",
+                  "product_id": "kernel-0:4.18.0-372.109.1.el8_6.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@4.18.0-372.109.1.el8_6?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+                "product": {
+                  "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+                  "product_id": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@4.18.0-372.109.1.rt7.269.el8_6?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el8?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el8?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el9?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el9?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                "product": {
+                  "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                  "product_id": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@5.14.0-284.69.1.rt14.354.el9_2?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el9?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                "product": {
+                  "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                  "product_id": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@5.14.0-284.69.1.rt14.354.el9_2?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el8?arch=src"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                "product": {
+                  "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_id": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_id": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_id": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+                "product": {
+                  "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+                  "product_id": "kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kata-containers@3.0.2-15.rhaos4.12.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-x86_64@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_id": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@4.18.0-372.109.1.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-core@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-core@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-devel@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-kvm@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-extra@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-internal@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-devel@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-kvm@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-extra@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-internal@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-selftests-internal@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-debuginfo@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_id": "kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo-common-x86_64@4.18.0-372.109.1.rt7.269.el8_6?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-uki-virt@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-uki-virt@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-x86_64@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-devel@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-devel-matched@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-kvm@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-extra@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-partner@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-devel@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-devel-matched@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-kvm@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-extra@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-partner@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-selftests-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-debuginfo@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo-common-x86_64@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el9?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-uki-virt@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-uki-virt@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-x86_64@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-devel@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-devel-matched@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-kvm@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-extra@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-modules-partner@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-devel@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-devel-matched@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-kvm@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-core@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-extra@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-modules-partner@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-selftests-internal@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debug-debuginfo@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                "product": {
+                  "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_id": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-rt-debuginfo-common-x86_64@5.14.0-284.69.1.rt14.354.el9_2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el8?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el8?arch=x86_64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                "product": {
+                  "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_id": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_id": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_id": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+                "product": {
+                  "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+                  "product_id": "kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kata-containers@3.0.2-15.rhaos4.12.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-aarch64@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_id": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@4.18.0-372.109.1.el8_6?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-aarch64@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el9?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-64k-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-aarch64@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el8?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el8?arch=aarch64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "aarch64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_id": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_id": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_id": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+                "product": {
+                  "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+                  "product_id": "kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kata-containers@3.0.2-15.rhaos4.12.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-ppc64le@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_id": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@4.18.0-372.109.1.el8_6?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-ppc64le@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el9?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-ipaclones-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-libs-devel@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-ppc64le@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el8?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el8?arch=ppc64le"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64le"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                "product": {
+                  "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_id": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_id": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_id": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.25.5-21.2.rhaos4.12.gita3eb75f.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+                "product": {
+                  "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+                  "product_id": "kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kata-containers@3.0.2-15.rhaos4.12.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-core@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-devel@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-extra@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-internal@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "perf-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "perf-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-s390x@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_id": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@4.18.0-372.109.1.el8_6?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+                "product": {
+                  "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+                  "product_id": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/conmon-rs@0.6.3-1.rhaos4.14.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                "product": {
+                  "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_id": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.27.7-3.rhaos4.14.git674563e.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_id": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.27.7-3.rhaos4.14.git674563e.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_id": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.27.7-3.rhaos4.14.git674563e.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-s390x@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el9?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_id": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool@7.0.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-cross-headers@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-headers@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-selftests-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-devel@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-devel-matched@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-core@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-extra@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-internal@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-modules-partner@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/rtla@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_id": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/bpftool-debuginfo@7.0.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debug-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-debuginfo-common-s390x@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-tools-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-zfcpdump-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/perf-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                "product": {
+                  "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_id": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3-perf-debuginfo@5.14.0-284.69.1.el9_2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                "product": {
+                  "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_id": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o@1.28.7-2.rhaos4.15.git111aec5.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                "product": {
+                  "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_id": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debugsource@1.28.7-2.rhaos4.15.git111aec5.el8?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                "product": {
+                  "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_id": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/cri-o-debuginfo@1.28.7-2.rhaos4.15.git111aec5.el8?arch=s390x"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "s390x"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+                "product": {
+                  "name": "kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+                  "product_id": "kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-doc@4.18.0-372.109.1.el8_6?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                "product": {
+                  "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_id": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-abi-stablelists@5.14.0-284.69.1.el9_2?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                "product": {
+                  "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_id": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-doc@5.14.0-284.69.1.el9_2?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                "product": {
+                  "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_id": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-abi-stablelists@5.14.0-284.69.1.el9_2?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                "product": {
+                  "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_id": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/kernel-doc@5.14.0-284.69.1.el9_2?arch=noarch"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "noarch"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64"
+        },
+        "product_reference": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le"
+        },
+        "product_reference": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x"
+        },
+        "product_reference": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src"
+        },
+        "product_reference": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64"
+        },
+        "product_reference": "cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x"
+        },
+        "product_reference": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64"
+        },
+        "product_reference": "kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le"
+        },
+        "product_reference": "kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x"
+        },
+        "product_reference": "kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.src as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.src"
+        },
+        "product_reference": "kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64"
+        },
+        "product_reference": "kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:4.18.0-372.109.1.el8_6.src as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.src"
+        },
+        "product_reference": "kernel-0:4.18.0-372.109.1.el8_6.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-doc-0:4.18.0-372.109.1.el8_6.noarch as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-doc-0:4.18.0-372.109.1.el8_6.noarch"
+        },
+        "product_reference": "kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src"
+        },
+        "product_reference": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64"
+        },
+        "product_reference": "kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "perf-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "perf-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "perf-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le"
+        },
+        "product_reference": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x"
+        },
+        "product_reference": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64 as a component of Red Hat OpenShift Container Platform 4.12",
+          "product_id": "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.src"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+        "relates_to_product_reference": "8Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.src"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64"
+        },
+        "product_reference": "conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64"
+        },
+        "product_reference": "cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.src"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch"
+        },
+        "product_reference": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch"
+        },
+        "product_reference": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src"
+        },
+        "product_reference": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.14",
+          "product_id": "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.14"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64"
+        },
+        "product_reference": "cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64"
+        },
+        "product_reference": "cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64"
+        },
+        "product_reference": "cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.src as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.src"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch"
+        },
+        "product_reference": "kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch"
+        },
+        "product_reference": "kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src"
+        },
+        "product_reference": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64"
+        },
+        "product_reference": "kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "perf-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.aarch64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.aarch64"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.ppc64le"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.s390x as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.s390x"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.s390x",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rtla-0:5.14.0-284.69.1.el9_2.x86_64 as a component of Red Hat OpenShift Container Platform 4.15",
+          "product_id": "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.x86_64"
+        },
+        "product_reference": "rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+        "relates_to_product_reference": "9Base-RHOSE-4.15"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cri-o as a component of Red Hat OpenShift Container Platform 3.11",
+          "product_id": "red_hat_openshift_container_platform_3.11:cri-o"
+        },
+        "product_reference": "cri-o",
+        "relates_to_product_reference": "red_hat_openshift_container_platform_3.11"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "acknowledgments": [
+        {
+          "names": [
+            "Erik Sjölund (erik.sjolund@gmail.com)"
+          ]
+        }
+      ],
+      "cve": "CVE-2024-5154",
+      "cwe": {
+        "id": "CWE-668",
+        "name": "Exposure of Resource to Wrong Sphere"
+      },
+      "discovery_date": "2024-05-10T00:00:00+00:00",
+      "flags": [
+        {
+          "label": "vulnerable_code_not_present",
+          "product_ids": [
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.src",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+            "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.src",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+            "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.src",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+            "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.x86_64"
+          ]
+        }
+      ],
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2280190"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in cri-o. A malicious container can create a symbolic link pointing to an arbitrary directory or file on the host via directory traversal (“../“). This flaw allows the container to read and write to arbitrary files on the host system.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "cri-o: malicious container can create symlink on host",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+          "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+          "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+          "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+          "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+          "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+          "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+          "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+          "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+          "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+          "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+          "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+          "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+          "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+          "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+          "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+          "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+          "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+          "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+          "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+          "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+          "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+          "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+          "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+          "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+          "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+          "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+          "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+          "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+          "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+          "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+          "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+          "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+          "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+          "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+          "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+          "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+          "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+          "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+          "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+          "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+          "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+          "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+          "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+          "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+          "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+          "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+          "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+          "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+          "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+          "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+          "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+          "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+          "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+          "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+          "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+          "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+          "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+          "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+          "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+          "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+          "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+          "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+          "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+          "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64"
+        ],
+        "known_affected": [
+          "red_hat_openshift_container_platform_3.11:cri-o"
+        ],
+        "known_not_affected": [
+          "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+          "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+          "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+          "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+          "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+          "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.src",
+          "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+          "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+          "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+          "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+          "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+          "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+          "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+          "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+          "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+          "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+          "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+          "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+          "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+          "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+          "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+          "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+          "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.src",
+          "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+          "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+          "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+          "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.src",
+          "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+          "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+          "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+          "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+          "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+          "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+          "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+          "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.x86_64"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-5154"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2280190",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2280190"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-5154",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-5154"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-5154",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5154"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/cri-o/cri-o/security/advisories/GHSA-j9hf-98c3-wrm8",
+          "url": "https://github.com/cri-o/cri-o/security/advisories/GHSA-j9hf-98c3-wrm8"
+        }
+      ],
+      "release_date": "2024-05-27T18:00:00+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For OpenShift Container Platform 4.14 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:\n\nhttps://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html",
+          "product_ids": [
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:3700"
+        },
+        {
+          "category": "vendor_fix",
+          "details": "For OpenShift Container Platform 4.12 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:\n\nhttps://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html",
+          "product_ids": [
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:4008"
+        },
+        {
+          "category": "vendor_fix",
+          "details": "For OpenShift Container Platform 4.15 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:\n\nhttps://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html",
+          "product_ids": [
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:3676"
+        },
+        {
+          "category": "workaround",
+          "details": "There is no mitigation available for this vulnerability, a package update is required.",
+          "product_ids": [
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:bpftool-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:bpftool-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.aarch64",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.ppc64le",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.s390x",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.src",
+            "8Base-RHOSE-4.12:kata-containers-0:3.0.2-15.rhaos4.12.el8.x86_64",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.src",
+            "8Base-RHOSE-4.12:kernel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-core-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-cross-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-core-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debug-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-aarch64-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-ppc64le-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-s390x-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-debuginfo-common-x86_64-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-doc-0:4.18.0-372.109.1.el8_6.noarch",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-headers-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-ipaclones-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-extra-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-modules-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.src",
+            "8Base-RHOSE-4.12:kernel-rt-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-core-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debug-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debuginfo-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-debuginfo-common-x86_64-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-devel-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-kvm-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-extra-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-modules-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-rt-selftests-internal-0:4.18.0-372.109.1.rt7.269.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-selftests-internal-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-tools-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-tools-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-libs-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:kernel-tools-libs-devel-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-core-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-devel-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-extra-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:kernel-zfcpdump-modules-internal-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:python3-perf-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.aarch64",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.ppc64le",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.s390x",
+            "8Base-RHOSE-4.12:python3-perf-debuginfo-0:4.18.0-372.109.1.el8_6.x86_64",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.aarch64",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.ppc64le",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.s390x",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.src",
+            "8Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.aarch64",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.ppc64le",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.s390x",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.src",
+            "9Base-RHOSE-4.14:conmon-rs-0:0.6.3-1.rhaos4.14.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.src",
+            "9Base-RHOSE-4.14:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+            "9Base-RHOSE-4.14:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.14:rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:bpftool-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:bpftool-debuginfo-0:7.0.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.src",
+            "9Base-RHOSE-4.15:kernel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-64k-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-64k-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-abi-stablelists-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-cross-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debug-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debug-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-aarch64-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-ppc64le-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-s390x-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-debuginfo-common-x86_64-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-devel-matched-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-doc-0:5.14.0-284.69.1.el9_2.noarch",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-headers-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-ipaclones-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-core-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-extra-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-modules-partner-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.src",
+            "9Base-RHOSE-4.15:kernel-rt-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debug-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debuginfo-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-debuginfo-common-x86_64-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-devel-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-devel-matched-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-kvm-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-core-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-extra-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-modules-partner-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-rt-selftests-internal-0:5.14.0-284.69.1.rt14.354.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-selftests-internal-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-tools-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-tools-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-libs-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:kernel-tools-libs-devel-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-uki-virt-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-devel-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-devel-matched-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-core-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-extra-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-internal-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:kernel-zfcpdump-modules-partner-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:python3-perf-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:python3-perf-debuginfo-0:5.14.0-284.69.1.el9_2.x86_64",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.aarch64",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.ppc64le",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.s390x",
+            "9Base-RHOSE-4.15:rtla-0:5.14.0-284.69.1.el9_2.x86_64",
+            "red_hat_openshift_container_platform_3.11:cri-o"
+          ]
+        },
+        {
+          "category": "no_fix_planned",
+          "details": "Out of support scope",
+          "product_ids": [
+            "red_hat_openshift_container_platform_3.11:cri-o"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:H/I:H/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "red_hat_openshift_container_platform_3.11:cri-o"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.src",
+            "8Base-RHOSE-4.12:cri-o-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debuginfo-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.aarch64",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.ppc64le",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.s390x",
+            "8Base-RHOSE-4.12:cri-o-debugsource-0:1.25.5-21.2.rhaos4.12.gita3eb75f.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.src",
+            "8Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.aarch64",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.ppc64le",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.s390x",
+            "8Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.src",
+            "8Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.aarch64",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.ppc64le",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.s390x",
+            "8Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el8.x86_64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.src",
+            "9Base-RHOSE-4.14:cri-o-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debuginfo-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.aarch64",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.ppc64le",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.s390x",
+            "9Base-RHOSE-4.14:cri-o-debugsource-0:1.27.7-3.rhaos4.14.git674563e.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.src",
+            "9Base-RHOSE-4.15:cri-o-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debuginfo-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.aarch64",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.ppc64le",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.s390x",
+            "9Base-RHOSE-4.15:cri-o-debugsource-0:1.28.7-2.rhaos4.15.git111aec5.el9.x86_64",
+            "red_hat_openshift_container_platform_3.11:cri-o"
+          ]
+        }
+      ],
+      "title": "cri-o: malicious container can create symlink on host"
+    }
+  ]
+}

--- a/modules/fundamental/src/package/service/test.rs
+++ b/modules/fundamental/src/package/service/test.rs
@@ -12,7 +12,6 @@ use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use trustify_module_storage::service::fs::FileSystemBackend;
-use uuid::Uuid;
 
 #[test_context(TrustifyContext, skip_teardown)]
 #[test(actix_web::test)]
@@ -602,77 +601,6 @@ async fn statuses(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let _results = service
         .qualified_package_by_uuid(&uuid, Transactional::None)
         .await?;
-
-    //println!("{:#?}", _results);
-
-    Ok(())
-}
-
-#[test_context(TrustifyContext, skip_teardown)]
-#[test(actix_web::test)]
-async fn unknown_statuses(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let service = PackageService::new(db.clone());
-    let (storage, _tmp) = FileSystemBackend::for_test().await?;
-
-    let ingestor = IngestorService::new(Graph::new(db.clone()), storage);
-
-    // ingest an advisory
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_2049.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_2054.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_2071.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_2776.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_2784.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_3351.json");
-    let data = ReaderStream::new(&data[..]);
-
-    ingestor
-        .ingest(("source", "test"), None, Format::CSAF, data)
-        .await?;
-
-    let results = service
-        .qualified_package_by_uuid(
-            //&Uuid::from_str("0d73ffb8-3b33-5834-82e6-ea243bd7abbc")?,
-            &Uuid::from_str("9b458d97-46a4-5837-89cc-dd1d65557c1f")?,
-            Transactional::None,
-        )
-        .await?;
-
-    log::debug!("{:#?}", results);
-
-    assert!(results.is_some());
-    let results = serde_json::to_string_pretty(&results)?;
-    assert!(!results.contains("unknown"));
 
     Ok(())
 }

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -121,7 +121,6 @@ impl VulnerabilityAdvisorySummary {
 
             let statuses = package_status::Entity::find()
                 .columns([
-                    version_range::Column::Id,
                     version_range::Column::LowVersion,
                     version_range::Column::LowInclusive,
                     version_range::Column::HighVersion,
@@ -140,6 +139,7 @@ impl VulnerabilityAdvisorySummary {
                 .column_as(package::Column::Id, "package_uuid")
                 .join(JoinType::LeftJoin, package::Relation::PackageVersions.def())
                 .left_join(version_range::Entity)
+                .distinct_on([package_status::Column::Id])
                 .into_model::<StatusCatcher>()
                 .all(tx)
                 .await?;

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -11,19 +11,19 @@ use trustify_entity as entity;
 use trustify_entity::cvss3::Severity;
 use trustify_entity::{package_status, status, version_range, vulnerability};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq)]
 pub struct VersionInfo {
     pub scheme: String,
     pub spec: VersionSpec,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq)]
 pub enum VersionSpec {
     Exact(String),
     Range(Version, Version),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq)]
 pub enum Version {
     Inclusive(String),
     Exclusive(String),

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -11,19 +11,19 @@ use trustify_entity as entity;
 use trustify_entity::cvss3::Severity;
 use trustify_entity::{package_status, status, version_range, vulnerability};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VersionInfo {
     pub scheme: String,
     pub spec: VersionSpec,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum VersionSpec {
     Exact(String),
     Range(Version, Version),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Version {
     Inclusive(String),
     Exclusive(String),

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -8,12 +8,13 @@ use crate::{
 use csaf::{definitions::ProductIdT, Csaf};
 use sea_orm::{ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use sea_query::IntoCondition;
+use std::collections::HashSet;
 use std::{collections::hash_map::Entry, collections::HashMap};
 use trustify_common::{db::chunk::EntityChunkedIter, purl::Purl};
 use trustify_entity::{package_status, status, version_range};
 use uuid::Uuid;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 struct PackageStatus {
     package: Purl,
     status: &'static str,
@@ -23,7 +24,7 @@ struct PackageStatus {
 pub struct PackageStatusCreator {
     advisory_id: Uuid,
     vulnerability_id: i32,
-    entries: Vec<PackageStatus>,
+    entries: HashSet<PackageStatus>,
 }
 
 impl PackageStatusCreator {
@@ -31,7 +32,7 @@ impl PackageStatusCreator {
         Self {
             advisory_id,
             vulnerability_id,
-            entries: Vec::new(),
+            entries: HashSet::new(),
         }
     }
 
@@ -51,9 +52,7 @@ impl PackageStatusCreator {
                         },
                     };
 
-                    if !self.entries.contains(&status) {
-                        self.entries.push(status);
-                    }
+                    self.entries.insert(status);
                 }
             }
         }


### PR DESCRIPTION
In the status-builder, ignore qualifiers, impl PartialEq where necessary. In the vuln fetching, add a `distinct`.