### PR TITLE
Test ensuring that the happy-path has correct statuses.

### DIFF
--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -1,11 +1,9 @@
 use crate::vulnerability::service::VulnerabilityService;
-use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use tokio_util::io::ReaderStream;
 use trustify_common::db::test::TrustifyContext;
 use trustify_common::db::Transactional;
-use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use trustify_module_storage::service::fs::FileSystemBackend;
@@ -40,23 +38,38 @@ async fn statuses(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         .ingest(("source", "test"), None, Format::CVE, data)
         .await?;
 
-    // finally ingest a specific known-affected version.
-
-    ingestor
-        .graph()
-        .ingest_qualified_package(
-            &Purl::from_str("pkg:cargo/hyper@0.14.1")?,
-            Transactional::None,
-        )
-        .await?;
-
     let vuln = service
         .fetch_vulnerability("CVE-2021-32714", Transactional::None)
         .await?;
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
-
     assert!(vuln.is_some());
+
+    let vuln = vuln.unwrap();
+
+    assert_eq!(2, vuln.advisories.len());
+
+    let rustsec_advisory = vuln
+        .advisories
+        .iter()
+        .find(|e| e.head.head.identifier == "RUSTSEC-2021-0079");
+    assert!(rustsec_advisory.is_some());
+    let rustsec_advisory = rustsec_advisory.unwrap();
+
+    let cve_advisory = vuln
+        .advisories
+        .iter()
+        .find(|e| e.head.head.identifier == "CVE-2021-32714");
+    assert!(cve_advisory.is_some());
+    let cve_advisory = cve_advisory.unwrap();
+
+    let rustsec_statuses: Vec<_> = rustsec_advisory.statuses.keys().collect();
+
+    assert_eq!(2, rustsec_statuses.len());
+    assert!(rustsec_statuses.contains(&&"fixed".to_string()));
+    assert!(rustsec_statuses.contains(&&"affected".to_string()));
+
+    let cve_statuses: Vec<_> = cve_advisory.statuses.keys().collect();
+    assert_eq!(0, cve_statuses.len());
 
     Ok(())
 }


### PR DESCRIPTION
For the RUSTSEC advisory, statuses of "fixed" and "affected" shall be present. For the CVE advisory for the same vulnerability, no statuses are expected.