### PR TITLE
Ensure vulnerability.identifier is unique.

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -44,6 +44,7 @@ mod m0000355_labels;
 mod m0000360_add_sbom_file;
 mod m0000370_add_cwe;
 mod m0000380_create_package_status_index;
+mod m0000385_create_vulnerability_index_unique_constraint;
 
 pub struct Migrator;
 
@@ -94,6 +95,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000360_add_sbom_file::Migration),
             Box::new(m0000370_add_cwe::Migration),
             Box::new(m0000380_create_package_status_index::Migration),
+            Box::new(m0000385_create_vulnerability_index_unique_constraint::Migration),
         ]
     }
 }

--- a/migration/src/m0000385_create_vulnerability_index_unique_constraint.rs
+++ b/migration/src/m0000385_create_vulnerability_index_unique_constraint.rs
@@ -1,0 +1,30 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .modify_column(ColumnDef::new(Vulnerability::Identifier).unique_key())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Vulnerability {
+    Table,
+    Identifier,
+}

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -5,7 +5,8 @@ use crate::graph::error::Error;
 use crate::graph::Graph;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter,
+    QuerySelect, RelationTrait,
 };
 use sea_query::{Condition, JoinType};
 use std::fmt::{Debug, Formatter};
@@ -57,6 +58,10 @@ impl Graph {
         information: I,
         tx: TX,
     ) -> Result<VulnerabilityContext, Error> {
+        self.connection(&tx)
+            .execute_unprepared("LOCK TABLE vulnerability IN EXCLUSIVE MODE;")
+            .await?;
+
         // TODO: consider transforming into upsert
         let information = information.into();
         if let Some(found) = self.get_vulnerability(identifier, &tx).await? {


### PR DESCRIPTION
Add an EXCLUSIVE lock while ingesting vuln identifiers to prevent us from getting into an error state neeedlessly.

Fixes #471 