### PR TITLE
feat: enable backslash to escape operators in filter expressions

### DIFF
--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -527,7 +527,11 @@ fn encode(s: &str) -> String {
 }
 
 fn decode(s: &str) -> String {
-    s.replace('\x07', "&").replace('\x08', "|")
+    s.replace('\x07', "&")
+        .replace('\x08', "|")
+        .replace(r"\\", "\x08")
+        .replace('\\', "")
+        .replace('\x08', r"\")
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -698,6 +702,14 @@ mod tests {
             r#""advisory"."location" = 'foo'"#
         );
         assert_eq!(
+            where_clause(r"location=foo\=bar")?,
+            r#""advisory"."location" = 'foo=bar'"#
+        );
+        assert_eq!(
+            where_clause(r"location=foo\\bar")?,
+            r#""advisory"."location" = E'foo\\bar'"#
+        );
+        assert_eq!(
             where_clause("location!=foo")?,
             r#""advisory"."location" <> 'foo'"#
         );
@@ -785,6 +797,10 @@ mod tests {
         assert_eq!(
             where_clause("foo")?,
             r#"("advisory"."location" ILIKE '%foo%') OR ("advisory"."title" ILIKE '%foo%')"#
+        );
+        assert_eq!(
+            where_clause(r"type\=jar")?,
+            r#"("advisory"."location" ILIKE '%type=jar%') OR ("advisory"."title" ILIKE '%type=jar%')"#
         );
         assert_eq!(
             where_clause("foo&location=bar")?,

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -325,3 +325,6 @@ pub async fn download(
         None => HttpResponse::NotFound().finish(),
     })
 }
+
+#[cfg(test)]
+mod test;

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1,0 +1,71 @@
+use crate::{configure, sbom::model::SbomPackage};
+use actix_http::Request;
+use actix_web::{
+    body::MessageBody,
+    dev::{Service, ServiceResponse},
+    test::TestRequest,
+    web, App, Error,
+};
+use test_context::test_context;
+use test_log::test;
+use tokio_util::io::ReaderStream;
+use trustify_auth::authorizer::Authorizer;
+use trustify_common::{db::test::TrustifyContext, model::PaginatedResults};
+use trustify_module_ingestor::{graph::Graph, model::IngestResult, service::IngestorService};
+use trustify_module_storage::service::fs::FileSystemBackend;
+
+async fn query<S, B>(app: &S, id: &str, q: &str) -> PaginatedResults<SbomPackage>
+where
+    S: Service<Request, Response = ServiceResponse<B>, Error = Error>,
+    B: MessageBody,
+{
+    let uri = format!("/api/v1/sbom/{id}/packages?q={}", urlencoding::encode(q));
+    let req = TestRequest::get().uri(&uri).to_request();
+    actix_web::test::call_and_read_body_json(app, req).await
+}
+
+async fn ingest(service: &IngestorService, data: &[u8]) -> IngestResult {
+    use trustify_module_ingestor::service::Format;
+    service
+        .ingest(
+            ("source", "unit-test"),
+            None,
+            Format::from_bytes(data).unwrap(),
+            ReaderStream::new(data),
+        )
+        .await
+        .unwrap()
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn filter_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+    let graph = Graph::new(db.clone());
+    let (storage, _) = FileSystemBackend::for_test().await?;
+    let ingestor = IngestorService::new(graph, storage.clone());
+    let app = actix_web::test::init_service(
+        App::new()
+            .service(web::scope("/api").configure(|config| configure(config, db, storage.clone())))
+            .app_data(web::Data::new(Authorizer::new(None))),
+    )
+    .await;
+
+    let data = include_bytes!("../../../../../etc/test-data/zookeeper-3.9.2-cyclonedx.json");
+    let id = ingest(&ingestor, data).await.id.to_string();
+
+    let result = query(&app, &id, "").await;
+    assert_eq!(result.total, 41);
+
+    let result = query(&app, &id, "netty-common").await;
+    assert_eq!(result.total, 1);
+    assert_eq!(result.items[0].name, "netty-common");
+
+    let result = query(&app, &id, r"type\=jar").await;
+    assert_eq!(result.total, 41);
+
+    let result = query(&app, &id, "version=4.1.105.Final").await;
+    assert_eq!(result.total, 9);
+
+    Ok(())
+}

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -169,6 +169,7 @@ impl SbomService {
                 sbom_package::Entity
                     .columns()
                     .add_columns(sbom_node::Entity)
+                    .add_columns(package::Entity)
                     .add_columns(sbom_package_cpe_ref::Entity)
                     .add_columns(sbom_package_purl_ref::Entity),
             )?


### PR DESCRIPTION
Relates to #434 as a test for filtering packages was added