### PR TITLE
Allow setting labels for advisories and SBOMs

### DIFF
--- a/entity/src/labels.rs
+++ b/entity/src/labels.rs
@@ -58,6 +58,10 @@ impl Labels {
         }
         self
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<'a> FromIterator<(&'a str, &'a str)> for Labels {

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -1,0 +1,61 @@
+use crate::advisory::service::AdvisoryService;
+use actix_web::{patch, put, web, HttpResponse, Responder};
+use trustify_common::id::Id;
+use trustify_entity::labels::Labels;
+
+/// Replace the labels of an advisory
+#[utoipa::path(
+    tag = "advisory",
+    context_path = "/api",
+    request_body = inline(Labels),
+    params(
+        ("id" = string, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
+    ),
+    responses(
+        (status = 204, description = "Replaced the labels of the advisory"),
+        (status = 404, description = "The advisory could not be found"),
+    ),
+)]
+#[put("/v1/advisory/{id}/label")]
+pub async fn set(
+    advisory: web::Data<AdvisoryService>,
+    id: web::Path<Id>,
+    web::Json(labels): web::Json<Labels>,
+) -> actix_web::Result<impl Responder> {
+    Ok(
+        match advisory.set_labels(id.into_inner(), labels, ()).await? {
+            Some(()) => HttpResponse::NoContent(),
+            None => HttpResponse::NotFound(),
+        },
+    )
+}
+
+/// Modify existing labels of an advisory
+#[utoipa::path(
+    tag = "advisory",
+    context_path = "/api",
+    request_body = inline(Labels),
+    params(
+        ("id" = string, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
+    ),
+    responses(
+        (status = 204, description = "Modified the labels of the advisory"),
+        (status = 404, description = "The advisory could not be found"),
+    ),
+)]
+#[patch("/v1/advisory/{id}/label")]
+pub async fn update(
+    advisory: web::Data<AdvisoryService>,
+    id: web::Path<Id>,
+    web::Json(update): web::Json<Labels>,
+) -> actix_web::Result<impl Responder> {
+    Ok(
+        match advisory
+            .update_labels(id.into_inner(), |labels| labels.apply(update))
+            .await?
+        {
+            Some(()) => HttpResponse::NoContent(),
+            None => HttpResponse::NotFound(),
+        },
+    )
+}

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -1,3 +1,4 @@
+mod label;
 #[cfg(test)]
 mod test;
 
@@ -23,12 +24,14 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
         .service(all)
         .service(get)
         .service(upload)
-        .service(download);
+        .service(download)
+        .service(label::set)
+        .service(label::update);
 }
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(all, get, upload, download),
+    paths(all, get, upload, download, label::set),
     components(schemas(
         crate::advisory::model::AdvisoryDetails,
         crate::advisory::model::AdvisoryHead,

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -1,21 +1,17 @@
-use sea_orm::prelude::Uuid;
-use sea_orm::{LoaderTrait, ModelTrait};
+mod details;
+mod summary;
 
-use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
-use utoipa::ToSchema;
-
-use crate::organization::model::OrganizationSummary;
-use crate::Error;
 pub use details::advisory_vulnerability::*;
 pub use details::*;
 pub use summary::*;
-use trustify_common::db::ConnectionOrTransaction;
-use trustify_common::id::Id;
-use trustify_entity::{advisory, organization};
 
-mod details;
-mod summary;
+use crate::{organization::model::OrganizationSummary, Error};
+use sea_orm::{prelude::Uuid, LoaderTrait, ModelTrait};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use trustify_common::{db::ConnectionOrTransaction, id::Id};
+use trustify_entity::{advisory, labels::Labels, organization};
+use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AdvisoryHead {
@@ -34,6 +30,8 @@ pub struct AdvisoryHead {
     #[serde(with = "time::serde::rfc3339::option")]
     pub withdrawn: Option<OffsetDateTime>,
     pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Labels::is_empty")]
+    pub labels: Labels,
 }
 
 impl AdvisoryHead {
@@ -59,6 +57,7 @@ impl AdvisoryHead {
             modified: entity.modified,
             withdrawn: entity.withdrawn,
             title: entity.title.clone(),
+            labels: entity.labels.clone(),
         })
     }
 
@@ -86,6 +85,7 @@ impl AdvisoryHead {
                 modified: advisory.modified,
                 withdrawn: advisory.withdrawn,
                 title: advisory.title.clone(),
+                labels: advisory.labels.clone(),
             })
         }
 

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -30,18 +30,18 @@ impl AdvisorySummary {
         averages: &[(Option<f64>, Option<Severity>)],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let mut vulnerabilities = entities
+        let vulnerabilities = entities
             .load_many_to_many(vulnerability::Entity, advisory_vulnerability::Entity, tx)
             .await?;
 
-        let mut issuers = entities.load_one(organization::Entity, tx).await?;
+        let issuers = entities.load_one(organization::Entity, tx).await?;
 
-        let mut summaries = Vec::new();
+        let mut summaries = Vec::with_capacity(issuers.len());
 
         for (((advisory, vulnerabilities), issuer), (average_score, average_severity)) in entities
             .iter()
-            .zip(vulnerabilities.drain(..))
-            .zip(issuers.drain(..))
+            .zip(vulnerabilities.into_iter())
+            .zip(issuers.into_iter())
             .zip(averages)
         {
             let vulnerabilities =

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -10,7 +10,7 @@ use trustify_module_storage::service::StorageKeyError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    HashKey(IdError),
+    HashKey(#[from] IdError),
     #[error(transparent)]
     StorageKey(#[from] StorageKeyError),
     #[error(transparent)]

--- a/modules/fundamental/src/sbom/endpoints/label.rs
+++ b/modules/fundamental/src/sbom/endpoints/label.rs
@@ -1,0 +1,59 @@
+use crate::sbom::service::SbomService;
+use actix_web::{patch, put, web, HttpResponse, Responder};
+use trustify_common::id::Id;
+use trustify_entity::labels::Labels;
+
+/// Modify existing labels of an SBOM
+#[utoipa::path(
+    tag = "advisory",
+    context_path = "/api",
+    request_body = inline(Labels),
+    params(
+        ("id" = string, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
+    ),
+    responses(
+        (status = 204, description = "Modified the labels of the SBOM"),
+        (status = 404, description = "The SBOM could not be found"),
+    ),
+)]
+#[patch("/v1/sbom/{id}/label")]
+pub async fn update(
+    sbom: web::Data<SbomService>,
+    id: web::Path<Id>,
+    web::Json(update): web::Json<Labels>,
+) -> actix_web::Result<impl Responder> {
+    Ok(
+        match sbom
+            .update_labels(id.into_inner(), |labels| labels.apply(update))
+            .await?
+        {
+            Some(()) => HttpResponse::NoContent(),
+            None => HttpResponse::NotFound(),
+        },
+    )
+}
+
+/// Replace the labels of an SBOM
+#[utoipa::path(
+    tag = "advisory",
+    context_path = "/api",
+    request_body = inline(Labels),
+    params(
+        ("id" = string, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
+    ),
+    responses(
+        (status = 204, description = "Replaced the labels of the SBOM"),
+        (status = 404, description = "The SBOM could not be found"),
+    ),
+)]
+#[put("/v1/sbom/{id}/label")]
+pub async fn set(
+    sbom: web::Data<SbomService>,
+    id: web::Path<Id>,
+    web::Json(labels): web::Json<Labels>,
+) -> actix_web::Result<impl Responder> {
+    Ok(match sbom.set_labels(id.into_inner(), labels, ()).await? {
+        Some(()) => HttpResponse::NoContent(),
+        None => HttpResponse::NotFound(),
+    })
+}

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1,18 +1,21 @@
-use crate::{configure, sbom::model::SbomPackage};
-use actix_http::Request;
+use crate::{configure, sbom::model::SbomPackage, test::CallService};
+use actix_http::{Request, StatusCode};
 use actix_web::{
     body::MessageBody,
     dev::{Service, ServiceResponse},
     test::TestRequest,
     web, App, Error,
 };
+use futures_util::future::LocalBoxFuture;
 use test_context::test_context;
 use test_log::test;
 use tokio_util::io::ReaderStream;
 use trustify_auth::authorizer::Authorizer;
-use trustify_common::{db::test::TrustifyContext, model::PaginatedResults};
+use trustify_common::{db::test::TrustifyContext, id::Id, model::PaginatedResults};
+use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{graph::Graph, model::IngestResult, service::IngestorService};
 use trustify_module_storage::service::fs::FileSystemBackend;
+use uuid::Uuid;
 
 async fn query<S, B>(app: &S, id: &str, q: &str) -> PaginatedResults<SbomPackage>
 where
@@ -68,4 +71,92 @@ async fn filter_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(result.total, 9);
 
     Ok(())
+}
+
+const DOC: &[u8] =
+    include_bytes!("../../../../../etc/test-data/quarkus-bom-2.13.8.Final-redhat-00004.json");
+
+/// This will upload [`DOC`], and then call the test function, providing the upload id of the document.
+async fn with_upload<F>(ctx: TrustifyContext, f: F) -> anyhow::Result<()>
+where
+    for<'a> F: FnOnce(IngestResult, &'a dyn CallService) -> LocalBoxFuture<'a, anyhow::Result<()>>,
+{
+    let db = ctx.db;
+    let (storage, _) = FileSystemBackend::for_test().await?;
+    let app = actix_web::test::init_service(
+        App::new()
+            .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
+            .service(web::scope("/api").configure(|svc| configure(svc, db, storage.clone()))),
+    )
+    .await;
+
+    // upload
+
+    let request = TestRequest::post()
+        .uri("/api/v1/sbom")
+        .set_payload(DOC)
+        .to_request();
+
+    let response = actix_web::test::call_service(&app, request).await;
+
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let result: IngestResult = actix_web::test::read_body_json(response).await;
+
+    log::debug!("ID: {result:?}");
+    assert!(matches!(result.id, Id::Uuid(_)));
+
+    f(result, &app).await?;
+
+    // download
+
+    Ok(())
+}
+
+/// Test setting labels
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn set_labels(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    with_upload(ctx, |result, app| {
+        Box::pin(async move {
+            // update labels
+
+            let request = TestRequest::patch()
+                .uri(&format!("/api/v1/sbom/{}/label", result.id))
+                .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
+                .to_request();
+
+            let response = app.call_service(request).await;
+
+            log::debug!("Code: {}", response.status());
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+            Ok(())
+        })
+    })
+    .await
+}
+
+/// Test setting labels, for a document that does not exists
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(actix_web::test)]
+async fn set_labels_not_found(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    with_upload(ctx, |_result, app| {
+        Box::pin(async move {
+            // update labels
+
+            let request = TestRequest::patch()
+                .uri(&format!("/api/v1/sbom/{}/label", Id::Uuid(Uuid::now_v7())))
+                .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
+                .to_request();
+
+            let response = app.call_service(request).await;
+
+            log::debug!("Code: {}", response.status());
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            Ok(())
+        })
+    })
+    .await
 }

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -2,7 +2,7 @@ use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use trustify_common::{id::Id, paginated};
-use trustify_entity::relationship::Relationship;
+use trustify_entity::{labels::Labels, relationship::Relationship};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -12,6 +12,8 @@ pub struct SbomSummary {
     pub hashes: Vec<Id>,
 
     pub document_id: String,
+    #[serde(default, skip_serializing_if = "Labels::is_empty")]
+    pub labels: Labels,
 
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/modules/fundamental/src/sbom/service/label.rs
+++ b/modules/fundamental/src/sbom/service/label.rs
@@ -1,0 +1,80 @@
+use crate::{sbom::service::SbomService, Error};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, DatabaseBackend, EntityTrait, IntoActiveModel, QueryTrait,
+    TransactionTrait,
+};
+use sea_query::Expr;
+use trustify_common::{
+    db::Transactional,
+    id::{Id, TrySelectForId},
+};
+use trustify_entity::{labels::Labels, sbom};
+
+impl SbomService {
+    /// Set the labels of an SBOM
+    ///
+    /// Returns `Ok(Some(()))` if a document was found and updated. If no document was found, it will
+    /// return `Ok(None)`.
+    pub async fn set_labels(
+        &self,
+        id: Id,
+        labels: Labels,
+        tx: impl AsRef<Transactional>,
+    ) -> Result<Option<()>, Error> {
+        let db = self.db.connection(&tx);
+
+        let result = sbom::Entity::update_many()
+            .try_filter(id)?
+            .col_expr(sbom::Column::Labels, Expr::value(labels))
+            .exec(&db)
+            .await?;
+
+        Ok((result.rows_affected > 0).then_some(()))
+    }
+
+    /// Update the labels of an SBOM
+    ///
+    /// Returns `Ok(Some(()))` if a document was found and updated. If no document was found, it will
+    /// return `Ok(None)`.
+    ///
+    /// The function will handle its own transaction.
+    pub async fn update_labels<F>(&self, id: Id, mutator: F) -> Result<Option<()>, Error>
+    where
+        F: FnOnce(Labels) -> Labels,
+    {
+        let tx = self.db.begin().await?;
+
+        // work around missing "FOR UPDATE" issue
+
+        let mut query = sbom::Entity::find()
+            .try_filter(id)?
+            .build(DatabaseBackend::Postgres);
+
+        query.sql.push_str(" FOR UPDATE");
+
+        // find the current entry
+
+        let Some(result) = sbom::Entity::find().from_raw_sql(query).one(&tx).await? else {
+            // return early, nothing found
+            return Ok(None);
+        };
+
+        // perform the mutation
+
+        let labels = result.labels.clone();
+        let mut result = result.into_active_model();
+        result.labels = Set(mutator(labels));
+
+        // store
+
+        result.update(&tx).await?;
+
+        // commit
+
+        tx.commit().await?;
+
+        // return
+
+        Ok(Some(()))
+    }
+}

--- a/modules/fundamental/src/sbom/service/mod.rs
+++ b/modules/fundamental/src/sbom/service/mod.rs
@@ -1,4 +1,5 @@
 pub mod assertion;
+pub mod label;
 pub mod sbom;
 
 use trustify_common::db::Database;

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -119,6 +119,7 @@ impl SbomService {
                 authors: sbom.authors,
 
                 described_by,
+                labels: sbom.labels,
             }),
             None => None,
         })

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::fmt::Debug;
 use tracing::instrument;
+use trustify_common::id::TrySelectForId;
 use trustify_common::{
     cpe::Cpe,
     db::{
@@ -44,11 +45,7 @@ impl SbomService {
     ) -> Result<Option<SbomSummary>, Error> {
         let connection = self.db.connection(&tx);
 
-        let select = match id {
-            Id::Uuid(id) => sbom::Entity::find_by_id(id),
-            Id::Sha256(sha256) => sbom::Entity::find().filter(sbom::Column::Sha256.eq(sha256)),
-            _ => return Err(Error::UnsupportedHashAlgorithm),
-        };
+        let select = sbom::Entity::find().try_filter(id)?;
 
         Ok(
             match select


### PR DESCRIPTION
Coming from @bobmcwhirter's suggestion of making the labelling a two-step process: https://matrix.to/#/!heUmIqxVhZejiSjzVu:matrix.org/$VtbkZ9oC8eeQqzDLlsCes5sMWQRiBZrNwnhf231UZZ4?via=matrix.org&via=dentrassi.de 

![image](https://github.com/trustification/trustify/assets/202474/96675fb5-4576-4105-abb9-0b9f2e07ed9d)

… here is the PR to allow settings labels. I think this makes sense in any way. We can still add the ability to set initial labels once we find the best way to pass them to the backend.