### PR TITLE
Vuln pk try 2

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -61,6 +61,9 @@ pub enum Relation {
 
     #[sea_orm(has_many = "super::cvss3::Entity")]
     Cvss3,
+
+    #[sea_orm(has_many = "super::advisory_vulnerability::Entity")]
+    AdvisoryVulnerability,
 }
 
 impl Related<organization::Entity> for Entity {
@@ -76,6 +79,12 @@ impl Related<vulnerability::Entity> for Entity {
 
     fn via() -> Option<RelationDef> {
         Some(advisory_vulnerability::Relation::Advisory.def().rev())
+    }
+}
+
+impl Related<advisory_vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AdvisoryVulnerability.def()
     }
 }
 

--- a/entity/src/advisory_vulnerability.rs
+++ b/entity/src/advisory_vulnerability.rs
@@ -1,4 +1,4 @@
-use crate::{advisory, vulnerability};
+use crate::{advisory, cvss3, vulnerability};
 use sea_orm::entity::prelude::*;
 use time::OffsetDateTime;
 
@@ -8,7 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub advisory_id: Uuid,
     #[sea_orm(primary_key)]
-    pub vulnerability_id: i32,
+    pub vulnerability_id: String,
 
     pub title: Option<String>,
     pub summary: Option<String>,
@@ -30,6 +30,9 @@ pub enum Relation {
         from = "super::advisory_vulnerability::Column::VulnerabilityId"
         to = "super::vulnerability::Column::Id")]
     Vulnerability,
+
+    #[sea_orm(has_many = "super::cvss3::Entity")]
+    Cvss3,
 }
 
 impl Related<advisory::Entity> for Entity {
@@ -41,6 +44,12 @@ impl Related<advisory::Entity> for Entity {
 impl Related<vulnerability::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Vulnerability.def()
+    }
+}
+
+impl Related<cvss3::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cvss3.def()
     }
 }
 

--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -1,4 +1,4 @@
-use crate::{advisory, vulnerability};
+use crate::{advisory, advisory_vulnerability, vulnerability};
 use sea_orm::entity::prelude::*;
 use std::fmt::{Display, Formatter};
 use trustify_cvss::cvss3;
@@ -10,7 +10,7 @@ pub struct Model {
     pub advisory_id: Uuid,
 
     #[sea_orm(primary_key)]
-    pub vulnerability_id: i32,
+    pub vulnerability_id: String,
 
     #[sea_orm(primary_key)]
     pub minor_version: i32,
@@ -53,10 +53,16 @@ pub enum Relation {
     Advisory,
 
     #[sea_orm(
-    belongs_to = "super::advisory::Entity",
+    belongs_to = "super::vulnerability::Entity",
     from = "super::cvss3::Column::VulnerabilityId"
-    to = "super::advisory::Column::Id")]
+    to = "super::vulnerability::Column::Id")]
     Vulnerability,
+
+    #[sea_orm(
+        belongs_to = "super::advisory_vulnerability::Entity",
+        from = "(super::cvss3::Column::AdvisoryId, super::cvss3::Column::VulnerabilityId)"
+        to = "(super::advisory_vulnerability::Column::AdvisoryId, super::advisory_vulnerability::Column::VulnerabilityId)")]
+    AdvisoryVulnerability,
 }
 
 impl Related<advisory::Entity> for Entity {
@@ -68,6 +74,12 @@ impl Related<advisory::Entity> for Entity {
 impl Related<vulnerability::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Vulnerability.def()
+    }
+}
+
+impl Related<advisory_vulnerability::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AdvisoryVulnerability.def()
     }
 }
 

--- a/entity/src/cvss4.rs
+++ b/entity/src/cvss4.rs
@@ -9,7 +9,7 @@ pub struct Model {
     pub advisory_id: i32,
 
     #[sea_orm(primary_key)]
-    pub vulnerability_id: i32,
+    pub vulnerability_id: String,
 
     #[sea_orm(primary_key)]
     pub minor_version: i32,
@@ -55,9 +55,9 @@ pub enum Relation {
     Advisory,
 
     #[sea_orm(
-    belongs_to = "super::advisory::Entity",
+    belongs_to = "super::vulnerability::Entity",
     from = "super::cvss4::Column::VulnerabilityId"
-    to = "super::advisory::Column::Id")]
+    to = "super::vulnerability::Column::Id")]
     Vulnerability,
 }
 

--- a/entity/src/package_status.rs
+++ b/entity/src/package_status.rs
@@ -7,7 +7,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: Uuid,
     pub advisory_id: Uuid,
-    pub vulnerability_id: i32,
+    pub vulnerability_id: String,
     pub status_id: Uuid,
     pub package_id: Uuid,
     pub version_range_id: Uuid,

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -8,8 +8,7 @@ use time::OffsetDateTime;
 #[graphql(concrete(name = "Vulnerability", params()))]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
-    pub identifier: String,
+    pub id: String,
     pub title: Option<String>,
     pub published: Option<OffsetDateTime>,
     pub modified: Option<OffsetDateTime>,

--- a/entity/src/vulnerability_description.rs
+++ b/entity/src/vulnerability_description.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
-    pub vulnerability_id: i32,
+    pub vulnerability_id: String,
     pub lang: String,
     pub description: String,
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -45,6 +45,7 @@ mod m0000360_add_sbom_file;
 mod m0000370_add_cwe;
 mod m0000380_create_package_status_index;
 mod m0000390_rename_package_purl;
+mod m0000395_alter_vulnerability_pk;
 
 pub struct Migrator;
 
@@ -96,6 +97,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000370_add_cwe::Migration),
             Box::new(m0000380_create_package_status_index::Migration),
             Box::new(m0000390_rename_package_purl::Migration),
+            Box::new(m0000395_alter_vulnerability_pk::Migration),
         ]
     }
 }

--- a/migration/src/m0000395_alter_vulnerability_pk.rs
+++ b/migration/src/m0000395_alter_vulnerability_pk.rs
@@ -1,0 +1,605 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // -- VulnerabilityDescription
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .add_column(
+                        ColumnDef::new(VulnerabilityDescription::VulnerabilityIdentifier)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE vulnerability_description
+                SET vulnerability_identifier = vulnerability.identifier
+                FROM vulnerability
+                WHERE vulnerability_description.vulnerability_id = vulnerability.id
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .drop_column(VulnerabilityDescription::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .rename_column(
+                        VulnerabilityDescription::VulnerabilityIdentifier,
+                        VulnerabilityDescription::VulnerabilityId,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- Cvss3
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .add_column(
+                        ColumnDef::new(Cvss3::VulnerabilityIdentifier)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE cvss3
+                SET vulnerability_identifier = vulnerability.identifier
+                FROM vulnerability
+                WHERE cvss3.vulnerability_id = vulnerability.id
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .drop_column(Cvss3::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .rename_column(Cvss3::VulnerabilityIdentifier, Cvss3::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- Cvss4
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .add_column(
+                        ColumnDef::new(Cvss4::VulnerabilityIdentifier)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE cvss4
+                SET vulnerability_identifier = vulnerability.identifier
+                FROM vulnerability
+                WHERE cvss4.vulnerability_id = vulnerability.id
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .drop_column(Cvss4::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .rename_column(Cvss4::VulnerabilityIdentifier, Cvss4::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- AdvisoryVulnerability
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .add_column(
+                        ColumnDef::new(AdvisoryVulnerability::VulnerabilityIdentifier)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE advisory_vulnerability
+                SET vulnerability_identifier = vulnerability.identifier
+                FROM vulnerability
+                WHERE advisory_vulnerability.vulnerability_id = vulnerability.id
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .drop_column(AdvisoryVulnerability::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .rename_column(
+                        AdvisoryVulnerability::VulnerabilityIdentifier,
+                        AdvisoryVulnerability::VulnerabilityId,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- PackageStatus
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .add_column(
+                        ColumnDef::new(PackageStatus::VulnerabilityIdentifier)
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE package_status
+                SET vulnerability_identifier = vulnerability.identifier
+                FROM vulnerability
+                WHERE package_status.vulnerability_id = vulnerability.id
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .drop_column(PackageStatus::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .rename_column(
+                        PackageStatus::VulnerabilityIdentifier,
+                        PackageStatus::VulnerabilityId,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- Drop the column from Vulnerability
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE vulnerability DROP CONSTRAINT vulnerability_pkey CASCADE
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DROP INDEX IF EXISTS vulnerability_pkey
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .drop_column(Vulnerability::Id)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .rename_column(Vulnerability::Identifier, Vulnerability::Id)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .modify_column(ColumnDef::new(Vulnerability::Id).primary_key())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE vulnerability DROP CONSTRAINT vulnerability_pkey CASCADE
+                "#,
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DROP INDEX IF EXISTS vulnerability_pkey
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .rename_column(Vulnerability::Id, Vulnerability::Identifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .add_column(
+                        ColumnDef::new(Vulnerability::Id)
+                            .integer()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- AdvisoryVulnerability
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .rename_column(
+                        AdvisoryVulnerability::VulnerabilityId,
+                        AdvisoryVulnerability::VulnerabilityIdentifier,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .add_column(
+                        ColumnDef::new(AdvisoryVulnerability::VulnerabilityId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE advisory_vulnerability
+                SET vulnerability_id = vulnerability.id
+                FROM vulnerability
+                WHERE advisory_vulnerability.vulnerability_identifier = vulnerability.identifier
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AdvisoryVulnerability::Table)
+                    .drop_column(AdvisoryVulnerability::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- PackageStatus
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .rename_column(
+                        PackageStatus::VulnerabilityId,
+                        PackageStatus::VulnerabilityIdentifier,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .add_column(
+                        ColumnDef::new(PackageStatus::VulnerabilityId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE package_status
+                SET vulnerability_id = vulnerability.id
+                FROM vulnerability
+                WHERE package_status.vulnerability_identifier = vulnerability.identifier
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(PackageStatus::Table)
+                    .drop_column(PackageStatus::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- Cvss3
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .rename_column(Cvss3::VulnerabilityId, Cvss3::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .add_column(ColumnDef::new(Cvss3::VulnerabilityId).integer().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE cvss3
+                SET vulnerability_id = vulnerability.id
+                FROM vulnerability
+                WHERE cvss3.vulnerability_identifier = vulnerability.identifier
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss3::Table)
+                    .drop_column(Cvss3::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- Cvss4
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .rename_column(Cvss4::VulnerabilityId, Cvss4::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .add_column(ColumnDef::new(Cvss4::VulnerabilityId).integer().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE cvss4
+                SET vulnerability_id = vulnerability.id
+                FROM vulnerability
+                WHERE cvss4.vulnerability_identifier = vulnerability.identifier
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Cvss4::Table)
+                    .drop_column(Cvss4::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        // -- VulnerabilityDescription
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .rename_column(
+                        VulnerabilityDescription::VulnerabilityId,
+                        VulnerabilityDescription::VulnerabilityIdentifier,
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .add_column(
+                        ColumnDef::new(VulnerabilityDescription::VulnerabilityId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE vulnerability_description
+                SET vulnerability_id = vulnerability.id
+                FROM vulnerability
+                WHERE vulnerability_description.vulnerability_identifier = vulnerability.identifier
+                "#,
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(VulnerabilityDescription::Table)
+                    .drop_column(VulnerabilityDescription::VulnerabilityIdentifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Vulnerability {
+    Table,
+    Id,
+    Identifier,
+}
+
+#[derive(DeriveIden)]
+enum VulnerabilityDescription {
+    Table,
+    VulnerabilityId,
+    VulnerabilityIdentifier,
+}
+
+#[derive(DeriveIden)]
+enum Cvss3 {
+    Table,
+    VulnerabilityId,
+    VulnerabilityIdentifier,
+}
+
+#[derive(DeriveIden)]
+enum Cvss4 {
+    Table,
+    VulnerabilityId,
+    VulnerabilityIdentifier,
+}
+
+#[derive(DeriveIden)]
+enum AdvisoryVulnerability {
+    Table,
+    VulnerabilityId,
+    VulnerabilityIdentifier,
+}
+
+#[derive(DeriveIden)]
+enum PackageStatus {
+    Table,
+    VulnerabilityId,
+    VulnerabilityIdentifier,
+}

--- a/migration/tests/tests.rs
+++ b/migration/tests/tests.rs
@@ -20,3 +20,9 @@ async fn test_migrations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn only_up_migration(_ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    Ok(())
+}

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -27,7 +27,7 @@ impl AdvisoryVulnerabilityHead {
     ) -> Result<Self, Error> {
         let cvss3 = cvss3::Entity::find()
             .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
-            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
@@ -46,7 +46,7 @@ impl AdvisoryVulnerabilityHead {
 
         let advisory_vuln = advisory_vulnerability::Entity::find()
             .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
-            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(vulnerability.id))
+            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(&vulnerability.id))
             .one(tx)
             .await?;
 
@@ -97,7 +97,7 @@ impl AdvisoryVulnerabilityHead {
 
             let advisory_vuln = advisory_vulnerability::Entity::find()
                 .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
-                .filter(advisory_vulnerability::Column::VulnerabilityId.eq(vuln.id))
+                .filter(advisory_vulnerability::Column::VulnerabilityId.eq(&vuln.id))
                 .one(tx)
                 .await?;
             if let Some(advisory_vuln) = advisory_vuln {

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -35,7 +35,7 @@ pub struct AdvisoryHead {
 }
 
 impl AdvisoryHead {
-    pub async fn from_entity(
+    pub async fn from_advisory(
         entity: &advisory::Model,
         issuer: Option<organization::Model>,
         tx: &ConnectionOrTransaction<'_>,

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -1,4 +1,4 @@
-use sea_orm::LoaderTrait;
+use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, QueryFilter, QuerySelect};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -30,27 +30,30 @@ impl AdvisorySummary {
         averages: &[(Option<f64>, Option<Severity>)],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let vulnerabilities = entities
-            .load_many_to_many(vulnerability::Entity, advisory_vulnerability::Entity, tx)
-            .await?;
-
         let issuers = entities.load_one(organization::Entity, tx).await?;
 
         let mut summaries = Vec::with_capacity(issuers.len());
 
-        for (((advisory, vulnerabilities), issuer), (average_score, average_severity)) in entities
-            .iter()
-            .zip(vulnerabilities.into_iter())
-            .zip(issuers.into_iter())
-            .zip(averages)
+        for ((advisory, issuer), (average_score, average_severity)) in
+            entities.iter().zip(issuers.into_iter()).zip(averages)
         {
+            let vulnerabilities = vulnerability::Entity::find()
+                .right_join(advisory_vulnerability::Entity)
+                .column_as(
+                    advisory_vulnerability::Column::VulnerabilityId,
+                    vulnerability::Column::Id,
+                )
+                .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
+                .all(tx)
+                .await?;
+
             let vulnerabilities =
                 AdvisoryVulnerabilityHead::from_entities(advisory, &vulnerabilities, tx).await?;
 
             let average_score = average_score.map(|score| Score::new(score).roundup());
 
             summaries.push(AdvisorySummary {
-                head: AdvisoryHead::from_entity(advisory, issuer, tx).await?,
+                head: AdvisoryHead::from_advisory(advisory, issuer, tx).await?,
                 average_severity: average_severity
                     .as_ref()
                     .map(|severity| severity.to_string()),

--- a/modules/fundamental/src/package/model/details/package_version.rs
+++ b/modules/fundamental/src/package/model/details/package_version.rs
@@ -111,7 +111,7 @@ impl PackageVersionAdvisory {
                     let organization = advisory.find_related(organization::Entity).one(tx).await?;
 
                     results.push(Self {
-                        head: AdvisoryHead::from_entity(advisory, organization, tx).await?,
+                        head: AdvisoryHead::from_advisory(advisory, organization, tx).await?,
                         status: vec![qualified_package_status],
                     })
                 }

--- a/modules/fundamental/src/package/model/details/qualified_package.rs
+++ b/modules/fundamental/src/package/model/details/qualified_package.rs
@@ -122,7 +122,7 @@ impl QualifiedPackageAdvisory {
                     let organization = advisory.find_related(organization::Entity).one(tx).await?;
 
                     results.push(Self {
-                        head: AdvisoryHead::from_entity(advisory, organization, tx).await?,
+                        head: AdvisoryHead::from_advisory(advisory, organization, tx).await?,
                         status: vec![qualified_package_status],
                     })
                 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -130,6 +130,7 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, Transactional::None)
         .await?;
+
     advisory_vuln
         .ingest_cvss3_score(
             Cvss3Base {

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use trustify_common::db::ConnectionOrTransaction;
 use trustify_cvss::cvss3::score::Score;
 use trustify_cvss::cvss3::Cvss3Base;
-use trustify_entity::{advisory, cvss3, vulnerability};
+use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -23,17 +23,69 @@ pub struct VulnerabilityDetails {
 }
 
 impl VulnerabilityDetails {
+    pub async fn from_advisory_vulnerabilities(
+        vulnerability_identifier: &str,
+        advisory_vulnerabilities: &[advisory_vulnerability::Model],
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        let advisories = VulnerabilityAdvisorySummary::from_entities(
+            vulnerability_identifier,
+            advisory_vulnerabilities,
+            tx,
+        )
+        .await?;
+
+        let cvss3 = trustify_entity::cvss3::Entity::find()
+            .filter(trustify_entity::cvss3::Column::VulnerabilityId.eq(vulnerability_identifier))
+            .all(tx)
+            .await?;
+
+        let total_score = cvss3
+            .iter()
+            .map(|e| {
+                let base = Cvss3Base::from(e.clone());
+                base.score().value()
+            })
+            .reduce(|accum, e| accum + e);
+
+        let average_score = total_score.map(|total| Score::new(total / cvss3.len() as f64));
+
+        Ok(VulnerabilityDetails {
+            head: VulnerabilityHead {
+                non_normative: false,
+                identifier: vulnerability_identifier.to_string(),
+                title: None,
+                published: None,
+                modified: None,
+                withdrawn: None,
+                discovered: None,
+                released: None,
+                cwe: None,
+            },
+            average_severity: average_score.map(|score| score.severity().to_string()),
+            average_score: average_score.map(|score| score.value()),
+            advisories,
+        })
+    }
+
     pub async fn from_entity(
         vulnerability: &vulnerability::Model,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
-        let advisories = vulnerability.find_related(advisory::Entity).all(tx).await?;
+        let advisory_vulnerabilities = vulnerability
+            .find_related(advisory_vulnerability::Entity)
+            .all(tx)
+            .await?;
 
-        let advisories =
-            VulnerabilityAdvisorySummary::from_entities(vulnerability, &advisories, tx).await?;
+        let advisories = VulnerabilityAdvisorySummary::from_entities(
+            &vulnerability.id,
+            &advisory_vulnerabilities,
+            tx,
+        )
+        .await?;
 
         let cvss3 = cvss3::Entity::find()
-            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
@@ -59,15 +111,17 @@ impl VulnerabilityDetails {
         vulnerabilities: &[vulnerability::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let advisories = vulnerabilities
-            .load_many(advisory::Entity::find(), tx)
+        let advisory_vulnerabilities = vulnerabilities
+            .load_many(advisory_vulnerability::Entity::find(), tx)
             .await?;
 
         let mut details = Vec::new();
 
-        for (vulnerability, advisories) in vulnerabilities.iter().zip(advisories.iter()) {
+        for (vulnerability, advisory_vulnerabilities) in
+            vulnerabilities.iter().zip(advisory_vulnerabilities.iter())
+        {
             let cvss3 = cvss3::Entity::find()
-                .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+                .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
                 .all(tx)
                 .await?;
 
@@ -86,8 +140,8 @@ impl VulnerabilityDetails {
                 average_severity: average_score.map(|score| score.severity().to_string()),
                 average_score: average_score.map(|score| score.value()),
                 advisories: VulnerabilityAdvisorySummary::from_entities(
-                    vulnerability,
-                    advisories,
+                    &vulnerability.id,
+                    advisory_vulnerabilities,
                     tx,
                 )
                 .await?,

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,6 +1,7 @@
 use crate::{advisory::model::AdvisoryHead, package::model::PackageHead, Error};
 use sea_orm::{
-    ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, QueryFilter, QuerySelect, RelationTrait,
+    ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait, QueryFilter, QuerySelect,
+    RelationTrait,
 };
 use sea_query::JoinType;
 use serde::{Deserialize, Serialize};
@@ -8,7 +9,8 @@ use std::collections::HashMap;
 use trustify_common::{db::ConnectionOrTransaction, purl::Purl};
 use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
 use trustify_entity::{
-    advisory, base_purl, cvss3, package_status, status, version_range, vulnerability,
+    advisory, advisory_vulnerability, base_purl, cvss3, package_status, status, version_range,
+    vulnerability,
 };
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -23,13 +25,13 @@ pub struct VulnerabilityAdvisoryHead {
 
 impl VulnerabilityAdvisoryHead {
     pub async fn from_entity(
-        vulnerability: &vulnerability::Model,
-        advisory: &advisory::Model,
+        vulnerability_identifier: &str,
+        advisory_vulnerability: &advisory_vulnerability::Model,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let cvss3 = cvss3::Entity::find()
-            .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
-            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .filter(cvss3::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
+            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability_identifier))
             .all(tx)
             .await?;
 
@@ -43,11 +45,19 @@ impl VulnerabilityAdvisoryHead {
 
         let score = total_score.map(|score| Score::new(score / cvss3.len() as f64));
 
-        Ok(VulnerabilityAdvisoryHead {
-            head: AdvisoryHead::from_entity(advisory, None, tx).await?,
-            severity: score.map(|score| score.severity().to_string()),
-            score: score.map(|score| score.value()),
-        })
+        if let Some(advisory) = &advisory_vulnerability
+            .find_related(advisory::Entity)
+            .one(tx)
+            .await?
+        {
+            Ok(VulnerabilityAdvisoryHead {
+                head: AdvisoryHead::from_advisory(advisory, None, tx).await?,
+                severity: score.map(|score| score.severity().to_string()),
+                score: score.map(|score| score.value()),
+            })
+        } else {
+            Err(Error::Data("Underlying advisory is missing".to_string()))
+        }
     }
     pub async fn from_entities(
         vulnerability: &vulnerability::Model,
@@ -56,7 +66,7 @@ impl VulnerabilityAdvisoryHead {
     ) -> Result<Vec<Self>, Error> {
         let cvss3s = advisories
             .load_many(
-                cvss3::Entity::find().filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id)),
+                cvss3::Entity::find().filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id)),
                 tx,
             )
             .await?;
@@ -75,7 +85,7 @@ impl VulnerabilityAdvisoryHead {
             let score = total_score.map(|score| Score::new(score / cvss3.len() as f64));
 
             heads.push(VulnerabilityAdvisoryHead {
-                head: AdvisoryHead::from_entity(advisory, None, tx).await?,
+                head: AdvisoryHead::from_advisory(advisory, None, tx).await?,
                 severity: score.map(|score| score.severity().to_string()),
                 score: score.map(|score| score.value()),
             });
@@ -96,20 +106,23 @@ pub struct VulnerabilityAdvisorySummary {
 
 impl VulnerabilityAdvisorySummary {
     pub async fn from_entities(
-        vulnerability: &vulnerability::Model,
-        advisories: &[advisory::Model],
+        vulnerability_identifier: &str,
+        advisory_vulnerabilities: &[advisory_vulnerability::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut summaries = Vec::new();
 
-        let mut cvss3s = advisories
+        let mut cvss3s = advisory_vulnerabilities
             .load_many(
-                cvss3::Entity::find().filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id)),
+                cvss3::Entity::find()
+                    .filter(cvss3::Column::VulnerabilityId.eq(vulnerability_identifier)),
                 tx,
             )
             .await?;
 
-        for (advisory, mut cvss3) in advisories.iter().zip(cvss3s.drain(..)) {
+        for (advisory_vulnerability, mut cvss3) in
+            advisory_vulnerabilities.iter().zip(cvss3s.drain(..))
+        {
             let cvss3_scores = cvss3
                 .drain(..)
                 .map(|e| Cvss3Base::from(e).to_string())
@@ -129,8 +142,8 @@ impl VulnerabilityAdvisorySummary {
                     base_purl::Column::Namespace,
                 ])
                 .left_join(status::Entity)
-                .filter(package_status::Column::VulnerabilityId.eq(vulnerability.id))
-                .filter(package_status::Column::AdvisoryId.eq(advisory.id))
+                .filter(package_status::Column::VulnerabilityId.eq(vulnerability_identifier))
+                .filter(package_status::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
                 .left_join(base_purl::Entity)
                 .column_as(base_purl::Column::Id, "package_uuid")
                 .join(
@@ -144,7 +157,12 @@ impl VulnerabilityAdvisorySummary {
                 .await?;
 
             summaries.push(VulnerabilityAdvisorySummary {
-                head: VulnerabilityAdvisoryHead::from_entity(vulnerability, advisory, tx).await?,
+                head: VulnerabilityAdvisoryHead::from_entity(
+                    vulnerability_identifier,
+                    advisory_vulnerability,
+                    tx,
+                )
+                .await?,
                 cvss3_scores,
                 statuses: VulnerabilityAdvisoryStatus::from_models(&statuses, tx).await?,
             });

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -44,7 +44,7 @@ impl VulnerabilityHead {
     pub fn from_vulnerability_entity(entity: &vulnerability::Model) -> Self {
         Self {
             non_normative: false,
-            identifier: entity.identifier.clone(),
+            identifier: entity.id.clone(),
             title: entity.title.clone(),
             published: entity.published,
             modified: entity.modified,
@@ -61,7 +61,7 @@ impl VulnerabilityHead {
     ) -> Self {
         Self {
             non_normative: true,
-            identifier: vuln.identifier.clone(),
+            identifier: vuln.id.clone(),
             title: advisory_vulnerability.title.clone(),
             published: None,
             modified: None,

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -37,7 +37,7 @@ impl VulnerabilitySummary {
 
         for (vuln, advisories) in vulnerabilities.iter().zip(advisories.iter()) {
             let cvss3 = cvss3::Entity::find()
-                .filter(cvss3::Column::VulnerabilityId.eq(vuln.id))
+                .filter(cvss3::Column::VulnerabilityId.eq(&vuln.id))
                 .all(tx)
                 .await?;
 

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,4 +1,4 @@
-use sea_orm::{prelude::*, EntityTrait, QueryFilter};
+use sea_orm::{prelude::*, EntityTrait, QueryFilter, QuerySelect};
 
 use crate::vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary};
 use crate::Error;
@@ -7,7 +7,7 @@ use trustify_common::db::query::{Filtering, Query};
 use trustify_common::db::Database;
 use trustify_common::db::Transactional;
 use trustify_common::model::{Paginated, PaginatedResults};
-use trustify_entity::vulnerability;
+use trustify_entity::{advisory_vulnerability, vulnerability};
 
 pub struct VulnerabilityService {
     db: Database,
@@ -26,11 +26,14 @@ impl VulnerabilityService {
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
         let connection = self.db.connection(&tx);
 
-        let limiter = vulnerability::Entity::find().filtering(search)?.limiting(
-            &connection,
-            paginated.offset,
-            paginated.limit,
-        );
+        let limiter = vulnerability::Entity::find()
+            .right_join(advisory_vulnerability::Entity)
+            .column_as(
+                advisory_vulnerability::Column::VulnerabilityId,
+                vulnerability::Column::Id,
+            )
+            .filtering(search)?
+            .limiting(&connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;
 
@@ -49,7 +52,7 @@ impl VulnerabilityService {
         let connection = self.db.connection(&tx);
 
         if let Some(vulnerability) = vulnerability::Entity::find()
-            .filter(vulnerability::Column::Identifier.eq(identifier))
+            .filter(vulnerability::Column::Id.eq(identifier))
             .one(&connection)
             .await?
         {
@@ -57,7 +60,26 @@ impl VulnerabilityService {
                 VulnerabilityDetails::from_entity(&vulnerability, &connection).await?,
             ))
         } else {
-            Ok(None)
+            // no root vulnerability has been ingested, so let's see if there's
+            // any advisories referencing it.
+
+            let advisory_vulns = advisory_vulnerability::Entity::find()
+                .filter(advisory_vulnerability::Column::VulnerabilityId.eq(identifier))
+                .all(&connection)
+                .await?;
+
+            if advisory_vulns.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(
+                    VulnerabilityDetails::from_advisory_vulnerabilities(
+                        identifier,
+                        &advisory_vulns,
+                        &connection,
+                    )
+                    .await?,
+                ))
+            }
         }
     }
 }

--- a/modules/graphql/src/vulnerability.rs
+++ b/modules/graphql/src/vulnerability.rs
@@ -22,7 +22,6 @@ impl VulnerabilityQuery {
         match vulnerability {
             Ok(Some(vulnerability)) => Ok(Vulnerability {
                 id: vulnerability.vulnerability.id,
-                identifier: vulnerability.vulnerability.identifier,
                 title: vulnerability.vulnerability.title,
                 published: vulnerability.vulnerability.published,
                 modified: vulnerability.vulnerability.modified,
@@ -46,7 +45,6 @@ impl VulnerabilityQuery {
             .map(|vulnerability| {
                 Ok(Vulnerability {
                     id: vulnerability.vulnerability.id,
-                    identifier: vulnerability.vulnerability.identifier,
                     title: vulnerability.vulnerability.title,
                     published: vulnerability.vulnerability.published,
                     modified: vulnerability.vulnerability.modified,

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -137,7 +137,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         tx: TX,
     ) -> Result<Option<VulnerabilityContext>, Error> {
         Ok(
-            vulnerability::Entity::find_by_id(self.advisory_vulnerability.vulnerability_id)
+            vulnerability::Entity::find_by_id(&self.advisory_vulnerability.vulnerability_id)
                 .one(&self.advisory.graph.connection(&tx))
                 .await?
                 .map(|vuln| VulnerabilityContext::new(self.advisory.graph, vuln)),
@@ -318,7 +318,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         let package_status = package_status::ActiveModel {
             id: Default::default(),
             advisory_id: Set(self.advisory_vulnerability.advisory_id),
-            vulnerability_id: Set(self.advisory_vulnerability.vulnerability_id),
+            vulnerability_id: Set(self.advisory_vulnerability.vulnerability_id.clone()),
             status_id: Set(status.id),
             package_id: Set(package.package.id),
             version_range_id: Set(version_range.id),
@@ -374,7 +374,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
             .filter(
                 entity::cvss3::Column::VulnerabilityId
-                    .eq(self.advisory_vulnerability.vulnerability_id),
+                    .eq(self.advisory_vulnerability.vulnerability_id.clone()),
             )
             .all(&self.advisory.graph.connection(&tx))
             .await?
@@ -392,7 +392,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
             .filter(
                 entity::cvss3::Column::VulnerabilityId
-                    .eq(self.advisory_vulnerability.vulnerability_id),
+                    .eq(self.advisory_vulnerability.vulnerability_id.clone()),
             )
             .filter(entity::cvss3::Column::MinorVersion.eq(minor_version as i32))
             .one(&self.advisory.graph.connection(&tx))
@@ -412,7 +412,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         let model = entity::cvss3::ActiveModel {
             advisory_id: Set(self.advisory_vulnerability.advisory_id),
-            vulnerability_id: Set(self.advisory_vulnerability.vulnerability_id),
+            vulnerability_id: Set(self.advisory_vulnerability.vulnerability_id.clone()),
             minor_version: sea_orm::ActiveValue::Set(cvss3.minor_version as i32),
             av: Set(cvss3.av.into()),
             ac: Set(cvss3.ac.into()),
@@ -431,256 +431,6 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .await?
             .into())
     }
-
-    /*
-    #[instrument(skip(self, tx), err)]
-    pub async fn vulnerability_assertions<TX: AsRef<Transactional>>(
-        &self,
-        tx: TX,
-    ) -> Result<AdvisoryVulnerabilityAssertions, Error> {
-        let affected = self.affected_assertions(&tx).await?;
-        let not_affected = self.not_affected_assertions(&tx).await?;
-        let fixed = self.fixed_assertions(&tx).await?;
-
-        let mut merged = affected.assertions.clone();
-
-        for (package_key, assertions) in not_affected.assertions {
-            merged
-                .entry(package_key)
-                .or_insert(Vec::default())
-                .extend_from_slice(&assertions)
-        }
-
-        for (package_key, assertions) in fixed.assertions {
-            merged
-                .entry(package_key)
-                .or_insert(Vec::default())
-                .extend_from_slice(&assertions)
-        }
-
-        Ok(AdvisoryVulnerabilityAssertions { assertions: merged })
-    }
-
-    pub async fn affected_assertions<TX: AsRef<Transactional>>(
-        &self,
-        tx: TX,
-    ) -> Result<AdvisoryVulnerabilityAssertions, Error> {
-        #[derive(FromQueryResult, Debug)]
-        struct AffectedVersion {
-            ty: String,
-            namespace: Option<String>,
-            name: String,
-            start: String,
-            end: String,
-        }
-
-        let affected_version_ranges = entity::affected_package_version_range::Entity::find()
-            .column_as(entity::package::Column::Type, "ty")
-            .column_as(entity::package::Column::Namespace, "namespace")
-            .column_as(entity::package::Column::Name, "name")
-            .column_as(entity::package_version_range::Column::Start, "start")
-            .column_as(entity::package_version_range::Column::End, "end")
-            .column_as(entity::vulnerability::Column::Identifier, "vulnerability")
-            .column_as(entity::advisory::Column::Identifier, "identifier")
-            .column_as(entity::advisory::Column::Labels, "labels")
-            .column_as(entity::advisory::Column::Sha256, "sha256")
-            .join(
-                JoinType::Join,
-                entity::affected_package_version_range::Relation::PackageVersionRange.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::affected_package_version_range::Relation::Advisory.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::package_version_range::Relation::Package.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Advisory
-                    .def()
-                    .rev(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Vulnerability.def(),
-            )
-            .filter(
-                entity::affected_package_version_range::Column::AdvisoryId
-                    .eq(self.advisory.advisory.id),
-            )
-            .into_model::<AffectedVersion>()
-            .all(&self.advisory.graph.connection(&tx))
-            .await?;
-
-        let mut assertions = HashMap::new();
-
-        for each in affected_version_ranges {
-            let package_key = Purl {
-                ty: each.ty,
-                namespace: each.namespace,
-                name: each.name,
-                version: None,
-                qualifiers: Default::default(),
-            }
-            .to_string();
-
-            let package_assertions = assertions.entry(package_key.clone()).or_insert(vec![]);
-
-            package_assertions.push(Assertion::Affected {
-                start_version: each.start,
-                end_version: each.end,
-            });
-        }
-
-        Ok(AdvisoryVulnerabilityAssertions { assertions })
-    }
-
-    pub async fn not_affected_assertions<TX: AsRef<Transactional>>(
-        &self,
-        tx: TX,
-    ) -> Result<AdvisoryVulnerabilityAssertions, Error> {
-        #[derive(FromQueryResult, Debug)]
-        struct NotAffectedVersion {
-            ty: String,
-            namespace: Option<String>,
-            name: String,
-            version: String,
-        }
-
-        let not_affected_versions = entity::not_affected_package_version::Entity::find()
-            .column_as(entity::package::Column::Type, "ty")
-            .column_as(entity::package::Column::Namespace, "namespace")
-            .column_as(entity::package::Column::Name, "name")
-            .column_as(entity::package_version::Column::Version, "version")
-            .column_as(entity::vulnerability::Column::Identifier, "vulnerability")
-            .column_as(entity::advisory::Column::Identifier, "identifier")
-            .column_as(entity::advisory::Column::Labels, "labels")
-            .column_as(entity::advisory::Column::Sha256, "sha256")
-            .join(
-                JoinType::Join,
-                entity::not_affected_package_version::Relation::PackageVersion.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::not_affected_package_version::Relation::Advisory.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::package_version::Relation::Package.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Advisory
-                    .def()
-                    .rev(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Vulnerability.def(),
-            )
-            .filter(
-                entity::not_affected_package_version::Column::AdvisoryId
-                    .eq(self.advisory.advisory.id),
-            )
-            .into_model::<NotAffectedVersion>()
-            .all(&self.advisory.graph.connection(&tx))
-            .await?;
-
-        let mut assertions = HashMap::new();
-
-        for each in not_affected_versions {
-            let package_key = Purl {
-                ty: each.ty,
-                namespace: each.namespace,
-                name: each.name,
-                version: None,
-                qualifiers: Default::default(),
-            }
-            .to_string();
-
-            let package_assertions = assertions.entry(package_key.clone()).or_insert(vec![]);
-
-            package_assertions.push(Assertion::NotAffected {
-                version: each.version,
-            });
-        }
-
-        Ok(AdvisoryVulnerabilityAssertions { assertions })
-    }
-
-    pub async fn fixed_assertions<TX: AsRef<Transactional>>(
-        &self,
-        tx: TX,
-    ) -> Result<AdvisoryVulnerabilityAssertions, Error> {
-        #[derive(FromQueryResult, Debug)]
-        struct FixedVersion {
-            ty: String,
-            namespace: Option<String>,
-            name: String,
-            version: String,
-        }
-
-        let fixed_versions = entity::fixed_package_version::Entity::find()
-            .column_as(entity::package::Column::Type, "ty")
-            .column_as(entity::package::Column::Namespace, "namespace")
-            .column_as(entity::package::Column::Name, "name")
-            .column_as(entity::package_version::Column::Version, "version")
-            .column_as(entity::vulnerability::Column::Identifier, "vulnerability")
-            .column_as(entity::advisory::Column::Identifier, "identifier")
-            .column_as(entity::advisory::Column::Labels, "labels")
-            .column_as(entity::advisory::Column::Sha256, "sha256")
-            .join(
-                JoinType::Join,
-                entity::fixed_package_version::Relation::PackageVersion.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::fixed_package_version::Relation::Advisory.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::package_version::Relation::Package.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Advisory
-                    .def()
-                    .rev(),
-            )
-            .join(
-                JoinType::Join,
-                entity::advisory_vulnerability::Relation::Vulnerability.def(),
-            )
-            .filter(entity::fixed_package_version::Column::AdvisoryId.eq(self.advisory.advisory.id))
-            .into_model::<FixedVersion>()
-            .all(&self.advisory.graph.connection(&tx))
-            .await?;
-
-        let mut assertions = HashMap::new();
-
-        for each in fixed_versions {
-            let package_key = Purl {
-                ty: each.ty,
-                namespace: each.namespace,
-                name: each.name,
-                version: None,
-                qualifiers: Default::default(),
-            }
-            .to_string();
-
-            let package_assertions = assertions.entry(package_key.clone()).or_insert(vec![]);
-
-            package_assertions.push(Assertion::Fixed {
-                version: each.version,
-            });
-        }
-
-        Ok(AdvisoryVulnerabilityAssertions { assertions })
-    }
-
-     */
 }
 
 #[cfg(test)]

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -5,7 +5,8 @@ use crate::graph::error::Error;
 use crate::graph::Graph;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
+    ActiveModelTrait, ColumnTrait, DbErr, EntityTrait, ModelTrait, QueryFilter, QuerySelect,
+    RelationTrait,
 };
 use sea_query::{Condition, JoinType};
 use std::fmt::{Debug, Formatter};
@@ -63,19 +64,39 @@ impl Graph {
             if information.has_data() {
                 // we should update with the details.
                 let mut entity = vulnerability::ActiveModel::from(found.vulnerability);
-                entity.title = Set(information.title);
+                entity.title = Set(information.title.clone());
                 entity.published = Set(information.published);
                 entity.modified = Set(information.modified);
                 entity.withdrawn = Set(information.withdrawn);
-                let model = entity.update(&self.connection(&tx)).await?;
-                Ok(VulnerabilityContext::new(&found.graph, model))
+
+                match entity.update(&self.connection(&tx)).await {
+                    Ok(model) => Ok(VulnerabilityContext::new(&found.graph, model)),
+                    Err(err) => {
+                        if let DbErr::RecordNotUpdated = err {
+                            // there turns out to not be a row in the DB, so
+                            // attempt an insert instead of an update.
+                            let entity = vulnerability::ActiveModel {
+                                id: Set(identifier.to_string()),
+                                title: Set(information.title),
+                                published: Set(information.published),
+                                modified: Set(information.modified),
+                                withdrawn: Set(information.withdrawn),
+                                cwe: Default::default(),
+                            };
+
+                            let model = entity.insert(&self.connection(&tx)).await?;
+                            Ok(VulnerabilityContext::new(&found.graph, model))
+                        } else {
+                            Err(Error::from(err))
+                        }
+                    }
+                }
             } else {
                 Ok(found)
             }
         } else {
             let entity = vulnerability::ActiveModel {
-                id: Default::default(),
-                identifier: Set(identifier.to_string()),
+                id: Set(identifier.to_string()),
                 title: Set(information.title),
                 published: Set(information.published),
                 modified: Set(information.modified),
@@ -96,11 +117,25 @@ impl Graph {
         identifier: &str,
         tx: TX,
     ) -> Result<Option<VulnerabilityContext>, Error> {
-        Ok(vulnerability::Entity::find()
-            .filter(vulnerability::Column::Identifier.eq(identifier))
+        let vuln = vulnerability::Entity::find_by_id(identifier)
+            .one(&self.connection(&tx))
+            .await?;
+
+        if let Some(vuln) = vuln {
+            return Ok(Some(VulnerabilityContext::new(self, vuln)));
+        }
+
+        Ok(advisory_vulnerability::Entity::find()
+            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(identifier))
+            .left_join(vulnerability::Entity)
+            .column_as(
+                advisory_vulnerability::Column::VulnerabilityId,
+                vulnerability::Column::Id,
+            )
+            .into_model::<vulnerability::Model>()
             .one(&self.connection(&tx))
             .await?
-            .map(|cve| VulnerabilityContext::new(self, cve)))
+            .map(|vuln| VulnerabilityContext::new(self, vuln)))
     }
 
     pub async fn get_vulnerabilities<TX: AsRef<Transactional>>(
@@ -146,7 +181,9 @@ impl VulnerabilityContext {
                 JoinType::Join,
                 advisory_vulnerability::Relation::Advisory.def().rev(),
             )
-            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(self.vulnerability.id))
+            .filter(
+                advisory_vulnerability::Column::VulnerabilityId.eq(self.vulnerability.id.clone()),
+            )
             .all(&self.graph.connection(&tx))
             .await?
             .drain(0..)
@@ -162,7 +199,7 @@ impl VulnerabilityContext {
     ) -> Result<(), Error> {
         let model = vulnerability_description::ActiveModel {
             id: Default::default(),
-            vulnerability_id: Set(self.vulnerability.id),
+            vulnerability_id: Set(self.vulnerability.id.clone()),
             lang: Set(lang.to_string()),
             description: Set(description.to_string()),
         };
@@ -204,15 +241,19 @@ mod tests {
         let db = ctx.db;
         let system = Graph::new(db);
 
+        println!("A");
         let cve1 = system
             .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
+        println!("B");
         let cve2 = system
             .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
+        println!("C");
         let cve3 = system
             .ingest_vulnerability("CVE-456", (), Transactional::None)
             .await?;
+        println!("D");
 
         assert_eq!(cve1.vulnerability.id, cve2.vulnerability.id);
         assert_ne!(cve1.vulnerability.id, cve3.vulnerability.id);

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -23,15 +23,15 @@ struct PackageStatus {
 
 pub struct PackageStatusCreator {
     advisory_id: Uuid,
-    vulnerability_id: i32,
+    vulnerability_id: String,
     entries: HashSet<PackageStatus>,
 }
 
 impl PackageStatusCreator {
-    pub fn new(advisory_id: Uuid, vulnerability_id: i32) -> Self {
+    pub fn new(advisory_id: Uuid, vulnerability_identifier: String) -> Self {
         Self {
             advisory_id,
-            vulnerability_id,
+            vulnerability_id: vulnerability_identifier,
             entries: HashSet::new(),
         }
     }
@@ -122,7 +122,7 @@ impl PackageStatusCreator {
             let package_status = package_status::ActiveModel {
                 id: Default::default(),
                 advisory_id: Set(self.advisory_id),
-                vulnerability_id: Set(self.vulnerability_id),
+                vulnerability_id: Set(self.vulnerability_id.clone()),
                 status_id: Set(status.id),
                 package_id: Set(package_id),
                 version_range_id: Set(version_range_id),

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -155,7 +155,8 @@ impl<'g> CsafLoader<'g> {
             advisory_vulnerability.advisory_vulnerability.advisory_id,
             advisory_vulnerability
                 .advisory_vulnerability
-                .vulnerability_id,
+                .vulnerability_id
+                .clone(),
         );
 
         creator.add_all(csaf, &product_status.fixed, "fixed");

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -327,39 +327,6 @@ mod test {
         assert_eq!(1, loaded_advisory_vulnerabilities.len());
         let _loaded_advisory_vulnerability = &loaded_advisory_vulnerabilities[0];
 
-        /*
-        let affected_assertions = loaded_advisory_vulnerability
-            .affected_assertions(())
-            .await?;
-        assert_eq!(1, affected_assertions.assertions.len());
-
-        let affected_assertion = affected_assertions.assertions.get("pkg://cargo/hyper");
-        assert!(affected_assertion.is_some());
-
-        let affected_assertion = &affected_assertion.unwrap()[0];
-        assert!(
-            matches!( affected_assertion, Assertion::Affected {start_version,end_version}
-                if start_version == "0.0.0-0"
-                && end_version == "0.14.10"
-            )
-        );
-
-        let fixed_assertions = loaded_advisory_vulnerability.fixed_assertions(()).await?;
-        assert_eq!(1, fixed_assertions.assertions.len());
-
-        let fixed_assertion = fixed_assertions.assertions.get("pkg://cargo/hyper");
-        assert!(fixed_assertion.is_some());
-
-        let fixed_assertion = fixed_assertion.unwrap();
-        assert_eq!(1, fixed_assertion.len());
-
-        let fixed_assertion = &fixed_assertion[0];
-        assert!(matches!( fixed_assertion, Assertion::Fixed{version }
-            if version == "0.14.10"
-        ));
-
-         */
-
         let advisory_vuln = loaded_advisory
             .get_vulnerability("CVE-2021-32714", ())
             .await?;


### PR DESCRIPTION
    Move vulnerability table to use the identifier as the natural primary key.
    Adjust API service to vuln.identifier-centricism.
    Fix queries since vulnerabilities table may not have a related row.
    Fix up other queries.
    Rename vuln.identifier -> vuln.id
    Use two-stage search for vulnerabilities.

Fixes #471 
