### PR TITLE
refactor: use UUIDs as primary keys instead of integers

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -18,7 +18,7 @@ pub struct Model {
     pub id: Uuid,
     #[graphql(name = "name")]
     pub identifier: String,
-    pub issuer_id: Option<i32>,
+    pub issuer_id: Option<Uuid>,
     pub sha256: String,
     pub sha384: Option<String>,
     pub sha512: Option<String>,

--- a/entity/src/cpe.rs
+++ b/entity/src/cpe.rs
@@ -8,7 +8,7 @@ use trustify_common::cpe::{Component, Cpe, CpeType};
 #[sea_orm(table_name = "cpe")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub part: Option<String>,
     pub vendor: Option<String>,
     pub product: Option<String>,
@@ -157,9 +157,11 @@ mod test {
         // parse into a CPE
         let cpe = Cpe::from_str(CPE).unwrap();
 
+        let id = Uuid::new_v4();
+
         // turn it into a model to be inserted
         let model = ActiveModel {
-            id: Set(0),
+            id: Set(id),
             ..cpe.into()
         };
 

--- a/entity/src/cvss4.rs
+++ b/entity/src/cvss4.rs
@@ -6,7 +6,7 @@ use trustify_cvss::cvss4;
 #[sea_orm(table_name = "cvss4")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub advisory_id: i32,
+    pub advisory_id: Uuid,
 
     #[sea_orm(primary_key)]
     pub vulnerability_id: String,

--- a/entity/src/organization.rs
+++ b/entity/src/organization.rs
@@ -7,7 +7,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "organization")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
     pub cpe_key: Option<String>,
     pub website: Option<String>,

--- a/entity/src/package_version_range.rs
+++ b/entity/src/package_version_range.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "package_version_range")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub package_id: Uuid,
     pub start: String,
     pub end: String,

--- a/entity/src/product.rs
+++ b/entity/src/product.rs
@@ -6,9 +6,9 @@ use crate::organization;
 #[sea_orm(table_name = "product")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
-    pub vendor_id: Option<i32>,
+    pub vendor_id: Option<Uuid>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/product_version.rs
+++ b/entity/src/product_version.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "product_version")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
-    pub product_id: i32,
+    pub id: Uuid,
+    pub product_id: Uuid,
     pub sbom_id: Option<Uuid>,
     pub version: String,
 }

--- a/entity/src/sbom_package_cpe_ref.rs
+++ b/entity/src/sbom_package_cpe_ref.rs
@@ -11,7 +11,7 @@ pub struct Model {
     pub node_id: String,
 
     #[sea_orm(primary_key)]
-    pub cpe_id: i32,
+    pub cpe_id: Uuid,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/vulnerability_description.rs
+++ b/entity/src/vulnerability_description.rs
@@ -5,7 +5,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "vulnerability_description")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub vulnerability_id: String,
     pub lang: String,
     pub description: String,

--- a/migration/src/m0000022_create_organization.rs
+++ b/migration/src/m0000022_create_organization.rs
@@ -1,3 +1,4 @@
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -13,9 +14,9 @@ impl MigrationTrait for Migration {
                     .table(Organization::Table)
                     .col(
                         ColumnDef::new(Organization::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Organization::Name).string().not_null())

--- a/migration/src/m0000040_create_vulnerability.rs
+++ b/migration/src/m0000040_create_vulnerability.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::Now;
+use crate::{Now, UuidV4};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -16,9 +16,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Vulnerability::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(

--- a/migration/src/m0000050_create_vulnerability_description.rs
+++ b/migration/src/m0000050_create_vulnerability_description.rs
@@ -2,7 +2,7 @@ use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000090_create_advisory_vulnerability::AdvisoryVulnerability;
 use sea_orm_migration::prelude::*;
 
-use crate::Now;
+use crate::{Now, UuidV4};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -18,14 +18,14 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(VulnerabilityDescription::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
                         ColumnDef::new(AdvisoryVulnerability::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000060_create_advisory.rs
+++ b/migration/src/m0000060_create_advisory.rs
@@ -1,4 +1,5 @@
 use crate::m0000022_create_organization::Organization;
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -15,12 +16,12 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Advisory::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Advisory::IssuerId).integer() /* allowed to be null if not known */)
+                    .col(ColumnDef::new(Advisory::IssuerId).uuid() /* allowed to be null if not known */)
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(Advisory::IssuerId)

--- a/migration/src/m0000070_create_cvss3.rs
+++ b/migration/src/m0000070_create_cvss3.rs
@@ -16,8 +16,8 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Cvss3::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(Cvss3::AdvisoryId).integer().not_null())
-                    .col(ColumnDef::new(Cvss3::VulnerabilityId).integer().not_null())
+                    .col(ColumnDef::new(Cvss3::AdvisoryId).uuid().not_null())
+                    .col(ColumnDef::new(Cvss3::VulnerabilityId).uuid().not_null())
                     .col(ColumnDef::new(Cvss3::MinorVersion).integer().not_null())
                     .primary_key(
                         Index::create()

--- a/migration/src/m0000070_create_cwe.rs
+++ b/migration/src/m0000070_create_cwe.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::Now;
+use crate::{Now, UuidV4};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -16,9 +16,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Cwe::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(

--- a/migration/src/m0000080_create_cvss4.rs
+++ b/migration/src/m0000080_create_cvss4.rs
@@ -17,8 +17,8 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Cvss4::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(Cvss4::AdvisoryId).integer().not_null())
-                    .col(ColumnDef::new(Cvss4::VulnerabilityId).integer().not_null())
+                    .col(ColumnDef::new(Cvss4::AdvisoryId).uuid().not_null())
+                    .col(ColumnDef::new(Cvss4::VulnerabilityId).uuid().not_null())
                     .col(ColumnDef::new(Cvss4::MinorVersion).integer().not_null())
                     .primary_key(
                         Index::create()

--- a/migration/src/m0000090_create_advisory_vulnerability.rs
+++ b/migration/src/m0000090_create_advisory_vulnerability.rs
@@ -16,7 +16,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(AdvisoryVulnerability::AdvisoryId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -26,7 +26,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(AdvisoryVulnerability::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000110_create_cpe.rs
+++ b/migration/src/m0000110_create_cpe.rs
@@ -1,3 +1,4 @@
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -14,9 +15,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Cpe::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Cpe::Part).string())

--- a/migration/src/m0000140_create_package_version_range.rs
+++ b/migration/src/m0000140_create_package_version_range.rs
@@ -1,7 +1,7 @@
 use crate::m0000100_create_package::Package;
 use sea_orm_migration::prelude::*;
 
-use crate::Now;
+use crate::{Now, UuidV4};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -17,9 +17,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(PackageVersionRange::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(

--- a/migration/src/m0000150_create_affected_package_version_range.rs
+++ b/migration/src/m0000150_create_affected_package_version_range.rs
@@ -1,6 +1,7 @@
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000140_create_package_version_range::PackageVersionRange;
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -17,14 +18,14 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::AdvisoryId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -34,7 +35,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -44,7 +45,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::PackageVersionRangeId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000160_create_fixed_package_version.rs
+++ b/migration/src/m0000160_create_fixed_package_version.rs
@@ -1,6 +1,7 @@
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000120_create_package_version::PackageVersion;
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -17,14 +18,14 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(FixedPackageVersion::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
                         ColumnDef::new(FixedPackageVersion::AdvisoryId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -34,7 +35,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(FixedPackageVersion::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000170_create_not_affected_package_version.rs
+++ b/migration/src/m0000170_create_not_affected_package_version.rs
@@ -1,6 +1,7 @@
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000120_create_package_version::PackageVersion;
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -17,14 +18,14 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(NotAffectedPackageVersion::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
                         ColumnDef::new(NotAffectedPackageVersion::AdvisoryId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -34,7 +35,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(NotAffectedPackageVersion::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000260_sbom_package_cpe_ref.rs
+++ b/migration/src/m0000260_sbom_package_cpe_ref.rs
@@ -20,11 +20,7 @@ impl MigrationTrait for Migration {
                             .string()
                             .not_null(),
                     )
-                    .col(
-                        ColumnDef::new(SbomPackageCpeRef::CpeId)
-                            .integer()
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(SbomPackageCpeRef::CpeId).uuid().not_null())
                     .foreign_key(
                         ForeignKey::create()
                             .from(

--- a/migration/src/m0000290_create_product.rs
+++ b/migration/src/m0000290_create_product.rs
@@ -1,6 +1,7 @@
 use sea_orm_migration::prelude::*;
 
 use crate::m0000022_create_organization::Organization;
+use crate::UuidV4;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -15,13 +16,13 @@ impl MigrationTrait for Migration {
                     .table(Product::Table)
                     .col(
                         ColumnDef::new(Product::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(ColumnDef::new(Product::Name).string().not_null())
-                    .col(ColumnDef::new(Product::VendorId).integer() /* allowed to be null if not known */)
+                    .col(ColumnDef::new(Product::VendorId).uuid() /* allowed to be null if not known */)
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(Product::VendorId)

--- a/migration/src/m0000300_create_product_version.rs
+++ b/migration/src/m0000300_create_product_version.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::{m0000030_create_sbom::Sbom, m0000290_create_product::Product, Now};
+use crate::{m0000030_create_sbom::Sbom, m0000290_create_product::Product, Now, UuidV4};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -16,9 +16,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(ProductVersion::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
@@ -26,11 +26,7 @@ impl MigrationTrait for Migration {
                             .timestamp_with_time_zone()
                             .default(Func::cust(Now)),
                     )
-                    .col(
-                        ColumnDef::new(ProductVersion::ProductId)
-                            .integer()
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(ProductVersion::ProductId).uuid().not_null())
                     .col(ColumnDef::new(ProductVersion::SbomId).uuid())
                     .col(ColumnDef::new(ProductVersion::Version).string().not_null())
                     .foreign_key(

--- a/migration/src/m0000310_alter_advisory_primary_key.rs
+++ b/migration/src/m0000310_alter_advisory_primary_key.rs
@@ -380,9 +380,9 @@ impl MigrationTrait for Migration {
                     .table(Advisory::Table)
                     .add_column(
                         ColumnDef::new(Advisory::Idx)
-                            .integer()
+                            .uuid()
                             .unique_key()
-                            .auto_increment(),
+                            .default(Func::cust(UuidV4)),
                     )
                     .to_owned(),
             )
@@ -397,7 +397,7 @@ impl MigrationTrait for Migration {
                     .table(AdvisoryVulnerability::Table)
                     .add_column(
                         ColumnDef::new(AdvisoryVulnerability::AdvisoryIdx)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),
@@ -420,7 +420,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Cvss3::Table)
-                    .add_column(ColumnDef::new(Cvss3::AdvisoryIdx).integer().not_null())
+                    .add_column(ColumnDef::new(Cvss3::AdvisoryIdx).uuid().not_null())
                     .to_owned(),
             )
             .await?;
@@ -441,7 +441,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Cvss4::Table)
-                    .add_column(ColumnDef::new(Cvss4::AdvisoryIdx).integer().not_null())
+                    .add_column(ColumnDef::new(Cvss4::AdvisoryIdx).uuid().not_null())
                     .to_owned(),
             )
             .await?;
@@ -464,7 +464,7 @@ impl MigrationTrait for Migration {
                     .table(AffectedPackageVersionRange::Table)
                     .add_column(
                         ColumnDef::new(AffectedPackageVersionRange::AdvisoryIdx)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),
@@ -489,7 +489,7 @@ impl MigrationTrait for Migration {
                     .table(NotAffectedPackageVersion::Table)
                     .add_column(
                         ColumnDef::new(NotAffectedPackageVersion::AdvisoryIdx)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),
@@ -514,7 +514,7 @@ impl MigrationTrait for Migration {
                     .table(FixedPackageVersion::Table)
                     .add_column(
                         ColumnDef::new(FixedPackageVersion::AdvisoryIdx)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),

--- a/migration/src/m0000340_create_package_status.rs
+++ b/migration/src/m0000340_create_package_status.rs
@@ -26,7 +26,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(PackageStatus::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000350_remove_old_assertion_tables.rs
+++ b/migration/src/m0000350_remove_old_assertion_tables.rs
@@ -1,4 +1,4 @@
-use crate::Now;
+use crate::{Now, UuidV4};
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -54,9 +54,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(PackageVersionRange::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
@@ -92,9 +92,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
@@ -109,7 +109,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -119,7 +119,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(AffectedPackageVersionRange::PackageVersionRangeId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -138,9 +138,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(NotAffectedPackageVersion::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
@@ -155,7 +155,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(NotAffectedPackageVersion::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(
@@ -184,9 +184,9 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(FixedPackageVersion::Id)
-                            .integer()
+                            .uuid()
                             .not_null()
-                            .auto_increment()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .col(
@@ -201,7 +201,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(FixedPackageVersion::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .foreign_key(

--- a/migration/src/m0000395_alter_vulnerability_pk.rs
+++ b/migration/src/m0000395_alter_vulnerability_pk.rs
@@ -1,3 +1,4 @@
+use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -324,8 +325,8 @@ impl MigrationTrait for Migration {
                     .table(Vulnerability::Table)
                     .add_column(
                         ColumnDef::new(Vulnerability::Id)
-                            .integer()
-                            .auto_increment()
+                            .uuid()
+                            .default(Func::cust(UuidV4))
                             .primary_key(),
                     )
                     .to_owned(),
@@ -352,7 +353,7 @@ impl MigrationTrait for Migration {
                     .table(AdvisoryVulnerability::Table)
                     .add_column(
                         ColumnDef::new(AdvisoryVulnerability::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),
@@ -400,7 +401,7 @@ impl MigrationTrait for Migration {
                     .table(PackageStatus::Table)
                     .add_column(
                         ColumnDef::new(PackageStatus::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),
@@ -443,7 +444,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Cvss3::Table)
-                    .add_column(ColumnDef::new(Cvss3::VulnerabilityId).integer().not_null())
+                    .add_column(ColumnDef::new(Cvss3::VulnerabilityId).uuid().not_null())
                     .to_owned(),
             )
             .await?;
@@ -484,7 +485,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Cvss4::Table)
-                    .add_column(ColumnDef::new(Cvss4::VulnerabilityId).integer().not_null())
+                    .add_column(ColumnDef::new(Cvss4::VulnerabilityId).uuid().not_null())
                     .to_owned(),
             )
             .await?;
@@ -530,7 +531,7 @@ impl MigrationTrait for Migration {
                     .table(VulnerabilityDescription::Table)
                     .add_column(
                         ColumnDef::new(VulnerabilityDescription::VulnerabilityId)
-                            .integer()
+                            .uuid()
                             .not_null(),
                     )
                     .to_owned(),

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -303,7 +303,7 @@ impl AdvisoryService {
 struct AdvisoryCatcher {
     pub id: Uuid,
     pub identifier: String,
-    pub issuer_id: Option<i32>,
+    pub issuer_id: Option<Uuid>,
     pub labels: Labels,
     pub sha256: String,
     pub sha384: Option<String>,

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -7,6 +7,7 @@ use trustify_common::db::query::Query;
 use trustify_common::db::Database;
 use trustify_common::model::Paginated;
 use utoipa::OpenApi;
+use uuid::Uuid;
 
 pub fn configure(config: &mut web::ServiceConfig, db: Database) {
     let service = OrganizationService::new(db);
@@ -63,7 +64,7 @@ pub async fn all(
 #[get("/v1/organization/{id}")]
 pub async fn get(
     state: web::Data<OrganizationService>,
-    id: web::Path<i32>,
+    id: web::Path<Uuid>,
 ) -> actix_web::Result<impl Responder> {
     let fetched = state.fetch_organization(*id, ()).await?;
 

--- a/modules/fundamental/src/organization/model/mod.rs
+++ b/modules/fundamental/src/organization/model/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 mod details;
 mod summary;
@@ -12,7 +13,7 @@ use trustify_entity::organization;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct OrganizationHead {
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpe_key: Option<String>,

--- a/modules/fundamental/src/organization/service/mod.rs
+++ b/modules/fundamental/src/organization/service/mod.rs
@@ -6,6 +6,7 @@ use trustify_common::db::query::{Filtering, Query};
 use trustify_common::db::{Database, Transactional};
 use trustify_common::model::{Paginated, PaginatedResults};
 use trustify_entity::organization;
+use uuid::Uuid;
 
 pub struct OrganizationService {
     db: Database,
@@ -39,7 +40,7 @@ impl OrganizationService {
     }
     pub async fn fetch_organization<TX: AsRef<Transactional> + Sync + Send>(
         &self,
-        id: i32,
+        id: Uuid,
         tx: TX,
     ) -> Result<Option<OrganizationDetails>, Error> {
         let connection = self.db.connection(&tx);

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -7,6 +7,7 @@ use trustify_common::db::query::Query;
 use trustify_common::db::Database;
 use trustify_common::model::Paginated;
 use utoipa::OpenApi;
+use uuid::Uuid;
 
 pub fn configure(config: &mut web::ServiceConfig, db: Database) {
     let service = ProductService::new(db);
@@ -62,7 +63,7 @@ pub async fn all(
 #[get("/v1/product/{id}")]
 pub async fn get(
     state: web::Data<ProductService>,
-    id: web::Path<i32>,
+    id: web::Path<Uuid>,
 ) -> actix_web::Result<impl Responder> {
     let fetched = state.fetch_product(*id, ()).await?;
     if let Some(fetched) = fetched {

--- a/modules/fundamental/src/product/model/mod.rs
+++ b/modules/fundamental/src/product/model/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 mod summary;
 pub use summary::*;
@@ -10,7 +11,7 @@ use trustify_entity::product;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct ProductHead {
-    pub id: i32,
+    pub id: Uuid,
     pub name: String,
 }
 

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -5,6 +5,7 @@ use trustify_common::db::query::{Filtering, Query};
 use trustify_common::db::{Database, Transactional};
 use trustify_common::model::{Paginated, PaginatedResults};
 use trustify_entity::product;
+use uuid::Uuid;
 
 use super::model::{ProductHead, ProductSummary};
 
@@ -41,7 +42,7 @@ impl ProductService {
 
     pub async fn fetch_product<TX: AsRef<Transactional> + Sync + Send>(
         &self,
-        id: i32,
+        id: Uuid,
         tx: TX,
     ) -> Result<Option<ProductHead>, Error> {
         let connection = self.db.connection(&tx);

--- a/modules/ingestor/src/graph/sbom/common/package.rs
+++ b/modules/ingestor/src/graph/sbom/common/package.rs
@@ -15,7 +15,7 @@ pub struct PackageCreator {
 
 pub enum PackageReference {
     Purl(Uuid),
-    Cpe(i32),
+    Cpe(Uuid),
 }
 
 impl PackageCreator {

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -597,7 +597,7 @@ impl SbomContext {
         name: String,
         version: Option<String>,
         purls: Vec<Uuid>,
-        cpes: Vec<i32>,
+        cpes: Vec<Uuid>,
         tx: TX,
     ) -> Result<(), Error> {
         let mut creator = PackageCreator::new(self.sbom.sbom_id);


### PR DESCRIPTION
Discussion: https://github.com/trustification/trustify/discussions/459

This ignores migrations and simply replaces the type. That's on purpose as explained in the discussion. It might be possible to do this actually, however that would involve:

* Disabling foreign key constraints being affected
* Deleting affected indexes
* Creating a new column with the UUID type
* Converting all data from i32 to UUID, using a UUID v5 with a namespace
  * Which requires loading a postgres extension
  * or doing the work in Rust, as part of the migration
* Re-creating foreign key constraints
* Re-creating indexes

And the same for the `down` migration. I just don't think it's worth the effort.