### PR TITLE
feat: add more labels to imported documents, allow user defined labels

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -46,6 +46,7 @@ mod m0000370_add_cwe;
 mod m0000380_create_package_status_index;
 mod m0000390_rename_package_purl;
 mod m0000395_alter_vulnerability_pk;
+mod m0000410_labels_index;
 
 pub struct Migrator;
 
@@ -98,6 +99,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000380_create_package_status_index::Migration),
             Box::new(m0000390_rename_package_purl::Migration),
             Box::new(m0000395_alter_vulnerability_pk::Migration),
+            Box::new(m0000410_labels_index::Migration),
         ]
     }
 }

--- a/migration/src/m0000410_labels_index.rs
+++ b/migration/src/m0000410_labels_index.rs
@@ -1,0 +1,80 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sbom::Table)
+                    .name(Indexes::AdvisoryLabelsIdx.to_string())
+                    .index_type(IndexType::Custom(gin()))
+                    .col(Advisory::Labels)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomLabelsIdx.to_string())
+                    .index_type(IndexType::Custom(gin()))
+                    .col(Sbom::Labels)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomLabelsIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryLabelsIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn gin() -> DynIden {
+    Alias::new("GIN").into_iden()
+}
+
+#[derive(DeriveIden)]
+pub enum Indexes {
+    SbomLabelsIdx,
+    AdvisoryLabelsIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum Sbom {
+    Table,
+    Labels,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+    Labels,
+}

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -542,7 +542,10 @@ async fn upload_with_labels(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(
         result.head.labels,
-        Labels::new().add("foo", "bar").add("bar", "baz")
+        Labels::new()
+            .add("foo", "bar")
+            .add("bar", "baz")
+            .add("type", "csaf")
     );
 
     // done

--- a/modules/importer/src/model/mod.rs
+++ b/modules/importer/src/model/mod.rs
@@ -12,6 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 use time::OffsetDateTime;
 use trustify_common::{model::Revisioned, paginated, revisioned};
+use trustify_entity::labels::Labels;
 use trustify_entity::{
     importer::{self, Model},
     importer_report,
@@ -118,14 +119,21 @@ impl DerefMut for ImporterConfiguration {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CommonImporter {
+    /// A flag to disable the importer, without deleting it.
     #[serde(default)]
     pub disabled: bool,
 
+    /// The period the importer should be run.
     #[serde(with = "humantime_serde")]
     pub period: Duration,
 
+    /// A description for users.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Labels which will be applied to the ingested documents.
+    #[serde(default, skip_serializing_if = "Labels::is_empty")]
+    pub labels: Labels,
 }
 
 impl TryFrom<Model> for Importer {

--- a/modules/importer/src/server/csaf/mod.rs
+++ b/modules/importer/src/server/csaf/mod.rs
@@ -52,6 +52,7 @@ impl super::Server {
         let storage = storage::StorageVisitor {
             name,
             ingestor,
+            labels: importer.common.labels,
             report: report.clone(),
         };
 

--- a/modules/importer/src/server/sbom/mod.rs
+++ b/modules/importer/src/server/sbom/mod.rs
@@ -56,6 +56,7 @@ impl super::Server {
         let storage = storage::StorageVisitor {
             name,
             source: importer.source,
+            labels: importer.common.labels,
             ingestor,
             report: report.clone(),
         };

--- a/modules/importer/src/server/sbom/storage.rs
+++ b/modules/importer/src/server/sbom/storage.rs
@@ -8,6 +8,7 @@ use tokio_util::io::ReaderStream;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use walker_common::compression::decompress_opt;
+use walker_common::utils::url::Urlify;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
@@ -20,6 +21,7 @@ pub enum StorageError {
 pub struct StorageVisitor {
     pub name: String,
     pub source: String,
+    pub labels: Labels,
     pub ingestor: IngestorService,
     /// the report to report our messages to
     pub report: Arc<Mutex<ReportBuilder>>,
@@ -51,13 +53,17 @@ impl ValidatedVisitor for StorageVisitor {
             None => (doc.data.clone(), false),
         };
 
+        let file = doc.possibly_relative_url();
+
         let fmt = Format::sbom_from_bytes(&data).map_err(|e| StorageError::Storage(e.into()))?;
 
         self.ingestor
             .ingest(
                 Labels::new()
                     .add("source", &self.source)
-                    .add("importer", &self.name),
+                    .add("importer", &self.name)
+                    .add("file", file)
+                    .extend(&self.labels.0),
                 None,
                 fmt,
                 ReaderStream::new(data.as_ref()),

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -18,6 +18,7 @@ fn mock_configuration(source: impl Into<String>) -> ImporterConfiguration {
             disabled: false,
             period: Duration::from_secs(30),
             description: None,
+            labels: Default::default(),
         },
         source: source.into(),
         keys: vec![],

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -63,6 +63,7 @@ impl<'g> CsafLoader<'g> {
         let tx = self.graph.transaction().await?;
 
         let advisory_id = csaf.document.tracking.id.clone();
+        let labels = labels.into().add("type", "csaf");
 
         let advisory = self
             .graph

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -33,6 +33,8 @@ impl<'g> OsvLoader<'g> {
     ) -> Result<IngestResult, Error> {
         let osv: Vulnerability = serde_json::from_reader(record)?;
 
+        let labels = labels.into().add("type", "osv");
+
         let issuer = issuer.or(detect_organization(&osv));
 
         let tx = self.graph.transaction().await?;

--- a/modules/ingestor/src/service/cve/loader.rs
+++ b/modules/ingestor/src/service/cve/loader.rs
@@ -33,6 +33,7 @@ impl<'g> CveLoader<'g> {
     ) -> Result<IngestResult, Error> {
         let cve: Cve = serde_json::from_reader(record)?;
         let id = cve.id();
+        let labels = labels.into().add("type", "cve");
 
         let tx = self.graph.transaction().await?;
 

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -26,6 +26,8 @@ impl<'g> CyclonedxLoader<'g> {
         let sbom = Bom::parse_json_value(serde_json::from_reader(document)?)
             .map_err(|err| Error::UnsupportedFormat(format!("Failed to parse: {err}")))?;
 
+        let labels = labels.add("type", "cyclonedx");
+
         log::info!(
             "Storing - version: {}, serialNumber: {:?}",
             sbom.version,

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -35,6 +35,8 @@ impl<'g> SpdxLoader<'g> {
 
         let tx = self.graph.transaction().await?;
 
+        let labels = labels.add("type", "spdx");
+
         let document_id = spdx
             .document_creation_information
             .spdx_document_namespace

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -37,6 +37,7 @@ async fn add_osv(
                 disabled: true,
                 period: Duration::from_secs(300),
                 description: Some(description.into()),
+                labels: Default::default(),
             },
             source: source.to_string(),
             path: base.map(|s| s.into()),
@@ -59,6 +60,7 @@ async fn add_cve(
                 disabled: true,
                 period: Duration::from_secs(300),
                 description: Some(description.into()),
+                labels: Default::default(),
             },
             source: DEFAULT_SOURCE_CVEPROJECT.into(),
             years: HashSet::default(),
@@ -75,7 +77,8 @@ pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()
         common: CommonImporter {
             disabled: true,
             period: Duration::from_secs(300),
-            description: Some("All Red Hat SBOMs".into())
+            description: Some("All Red Hat SBOMs".into()),
+            labels: Default::default(),
         },
         source: "https://access.redhat.com/security/data/sbom/beta/".to_string(),
         keys: vec![
@@ -93,6 +96,7 @@ pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()
                 disabled: true,
                 period: Duration::from_secs(300),
                 description: Some("All Red Hat CSAF data".into()),
+                labels: Default::default(),
             },
             source: "redhat.com".to_string(),
             v3_signatures: true,
@@ -109,6 +113,7 @@ pub async fn sample_data(db: trustify_common::db::Database) -> anyhow::Result<()
                 disabled: true,
                 period: Duration::from_secs(300),
                 description: Some("Red Hat VEX files from 2024".into()),
+                labels: Default::default(),
             },
             source: "redhat.com".to_string(),
             v3_signatures: true,


### PR DESCRIPTION
This PR adds:

* The ability to set labels on the importer which get applied to the imported documents: let the user decide, always comes in handy
* A `type` label to each document, reflecting the document type (csaf, osv, …): have the UI distinguish between document types when the name/ID is the same (like CVE IDs as names)
* A `file` label, containing the name of the file, relative to the source, that was ingested: prepare for getting all versions (history) of the same file

