### PR TITLE
Bump to latest postgresql-embedded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1106,16 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1565,6 +1595,12 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deflate64"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
 
 [[package]]
 name = "der"
@@ -2950,6 +2986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3160,15 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -3383,6 +3437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3455,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -4163,6 +4233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,40 +4436,47 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postgresql_archive"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28699e132cab7de76c38c0d9e40743b6dfffeeb38523b66e713341557d4248e7"
+checksum = "e98b50bbcd9723dd54906658dcd0f5f1b05e5fd50231b952a335ff466a9aa7db"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
+ "blake2",
  "flate2",
  "hex",
  "http 1.1.0",
  "human_bytes",
  "lazy_static",
+ "md-5",
  "num-format",
+ "quick-xml",
  "regex",
  "reqwest 0.12.5",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
+ "semver",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
+ "sha3",
  "tar",
  "target-triple",
- "task-local-extensions",
  "tempfile",
  "thiserror",
  "tracing",
+ "url",
+ "xz2",
+ "zip 2.1.3",
 ]
 
 [[package]]
 name = "postgresql_commands"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c6b2c6fc84eb56c87121ed8e135f5a0195da869225a316a455e5f92e735d6a"
+checksum = "b0e5497b62c8adfb74fe3a0208f278266f86526596f59f7b1ce500e8c3a95e99"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -4399,17 +4486,19 @@ dependencies = [
 
 [[package]]
 name = "postgresql_embedded"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0812db3fd1441a7a48869c00f048876c842179f6fe9337e62a758cf419b27ad9"
+checksum = "ca4f189984d88258a624e1cffc9413471f361d9d91e10a2d825d13cd765eeab4"
 dependencies = [
  "anyhow",
- "bytes",
  "home",
  "lazy_static",
  "postgresql_archive",
  "postgresql_commands",
  "rand",
+ "semver",
+ "sqlx",
+ "target-triple",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4555,6 +4644,16 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e446ed58cef1bbfe847bc2fda0e2e4ea9f0e57b90c507d4781292590d72a4e"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quinn"
@@ -4854,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f342894422862af74c50e1e9601cf0931accc9c6981e5eb413c46603b616b5"
+checksum = "cf2a94ba69ceb30c42079a137e2793d6d0f62e581a24c06cd4e9bb32e973c7da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4902,12 +5001,10 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "anyhow",
- "chrono",
  "rand",
 ]
 
@@ -5734,6 +5831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5760,6 +5867,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -6317,15 +6430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
 name = "temp-env"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6831,7 +6935,6 @@ dependencies = [
  "native-tls",
  "packageurl",
  "pem",
- "postgresql_archive",
  "postgresql_embedded",
  "rand",
  "regex",
@@ -7418,7 +7521,7 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
- "zip",
+ "zip 1.1.4",
 ]
 
 [[package]]
@@ -8036,6 +8139,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "zerovec"
@@ -8073,6 +8190,49 @@ dependencies = [
  "indexmap 2.2.6",
  "num_enum",
  "thiserror",
+]
+
+[[package]]
+name = "zip"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.2.6",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand",
+ "sha1",
+ "thiserror",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,7 +3725,7 @@ version = "5.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "098af5a5110b4deacf3200682963713b143ae9d28762b739bdb7b98429dfaf68"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom",
  "http 1.1.0",
@@ -5072,16 +5083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-lzma"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d62915608f6cee1d7f2fc00f28b4f058ff79d6e4ec3c2fe0006b09b52437c84"
-dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5547,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b870b0275eeae174058fcf0ce5affccaaafeb7eceeabce8d6c7f51fbe6a41e2a"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "buffered-reader",
  "chrono",
  "dyn-clone",
@@ -6924,7 +6925,6 @@ dependencies = [
  "cyclonedx-bom",
  "humantime",
  "log",
- "rust-lzma",
  "serde_json",
  "spdx-rs",
  "test-context",
@@ -6936,6 +6936,7 @@ dependencies = [
  "trustify-module-fundamental",
  "trustify-module-ingestor",
  "trustify-module-storage",
+ "xz2",
 ]
 
 [[package]]
@@ -7946,6 +7947,15 @@ name = "xxhash-rust"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ osv = { version = "0.2.0", default-features = false }
 packageurl = "0.3.0"
 parking_lot = "0.12"
 pem = "3"
-postgresql_archive = "0.10.1"
-postgresql_embedded = "0.10.1"
+postgresql_archive = "0.13.0"
+postgresql_embedded = "0.13.0"
 prometheus = "0.13.3"
 rand = "0.8.5"                                                        # for testing
 regex = "1.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ regex = "1.10.3"
 reqwest = "0.12"
 ring = "0.17.8"
 rstest = "0.21"
-rust-lzma = "0.6.0"
 sbom-walker = { version = "0.8.0", default-features = false }
 schemars = "0.8"
 sea-orm = "0.12"
@@ -118,6 +117,7 @@ uuid = "1.7.0"
 walkdir = "2.5"
 walker-common = "0.8.0"
 walker-extras = "0.8.0"
+xz2 = "0.1.7"
 
 trustify-auth = { path = "common/auth", features = ["actix", "swagger"] }
 trustify-common = { path = "common" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,7 +20,6 @@ native-tls = { workspace = true }
 packageurl = { workspace = true }
 pem = { workspace = true }
 postgresql_embedded = { workspace = true, features = ["blocking", "tokio"] }
-postgresql_archive = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["native-tls"] }
 ring = { workspace = true }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,10 +16,10 @@ csaf = { workspace = true }
 cyclonedx-bom = { workspace = true }
 humantime = { workspace = true }
 log = { workspace = true }
-rust-lzma = { workspace = true }
 serde_json = { workspace = true }
 spdx-rs = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+xz2 = { workspace = true }

--- a/integration-tests/src/sbom/reingest/mod.rs
+++ b/integration-tests/src/sbom/reingest/mod.rs
@@ -301,7 +301,8 @@ async fn nhc_same_content(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     );
 
     // ingest the second version
-
+    use std::io::Read;
+    use xz2::read::XzDecoder;
     let result2 = ingest
         .ingest(
             ("source", "test"),
@@ -309,10 +310,11 @@ async fn nhc_same_content(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
             Format::SPDX,
             stream::once({
                 // re-serialize file (non-pretty)
-                let json: Value = serde_json::from_slice(&lzma::decompress(include_bytes!(
-                    "data/nhc/v1/nhc-0.4.z.json.xz"
-                ))?)?;
-
+                let data = include_bytes!("data/nhc/v1/nhc-0.4.z.json.xz");
+                let mut reader = XzDecoder::new(&data[..]);
+                let mut buf: Vec<u8> = Vec::new();
+                reader.read_to_end(&mut buf).unwrap();
+                let json: Value = serde_json::from_slice(&buf)?;
                 let result = serde_json::to_vec(&json).map(Bytes::from);
 
                 async { result }

--- a/integration-tests/src/sbom/test/mod.rs
+++ b/integration-tests/src/sbom/test/mod.rs
@@ -5,7 +5,6 @@ mod perf;
 mod spdx;
 
 use cyclonedx_bom::prelude::Bom;
-use lzma::LzmaReader;
 use spdx_rs::models::SPDX;
 use std::collections::HashSet;
 use std::fs::File;
@@ -23,6 +22,7 @@ use trustify_module_ingestor::graph::{
     sbom::{self, spdx::parse_spdx, SbomContext, SbomInformation},
     Graph,
 };
+use xz2::read::XzDecoder;
 
 #[instrument]
 pub fn open_sbom(name: &str) -> anyhow::Result<impl Read> {
@@ -35,7 +35,7 @@ pub fn open_sbom(name: &str) -> anyhow::Result<impl Read> {
 
 #[instrument]
 pub fn open_sbom_xz(name: &str) -> anyhow::Result<impl Read> {
-    Ok(LzmaReader::new_decompressor(open_sbom(name)?)?)
+    Ok(XzDecoder::new(open_sbom(name)?))
 }
 
 /// remove all relationships having broken references

--- a/integration-tests/src/stream.rs
+++ b/integration-tests/src/stream.rs
@@ -1,16 +1,18 @@
 #![cfg(test)]
 
 use bytes::Bytes;
-use lzma::LzmaError;
 use std::convert::Infallible;
-
+use std::io::Read;
 use test_context::futures::{stream, Stream};
+use xz2::read::XzDecoder;
 
 /// Take a slice, xa decompress the data and return it as a stream.
 ///
 /// If the decompression fails, that will result in an error on the stream.
-pub fn xz_stream(data: &[u8]) -> impl Stream<Item = Result<Bytes, LzmaError>> {
-    let result = lzma::decompress(data).map(|data| data.into());
+pub fn xz_stream(data: &[u8]) -> impl Stream<Item = Result<Bytes, std::io::Error>> {
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut reader = XzDecoder::new(data);
+    let result = reader.read_to_end(&mut buffer).map(|_| buffer.into());
     stream::once(async { result })
 }
 

--- a/trustd/src/db.rs
+++ b/trustd/src/db.rs
@@ -1,4 +1,4 @@
-use postgresql_embedded::PostgreSQL;
+use postgresql_embedded::{PostgreSQL, VersionReq};
 use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
@@ -73,6 +73,7 @@ impl Run {
             "pg_stat_statements".to_string(),
         )]);
         let settings = postgresql_embedded::Settings {
+            version: VersionReq::parse("=16.3.0")?,
             username: self.database.username.clone(),
             password: self.database.password.clone(),
             temporary: false,
@@ -82,7 +83,7 @@ impl Run {
             data_dir,
             ..Default::default()
         };
-        let mut postgresql = PostgreSQL::new(PostgreSQL::default_version(), settings);
+        let mut postgresql = PostgreSQL::new(settings);
         postgresql.setup().await?;
         postgresql.start().await?;
 


### PR DESCRIPTION
Fixes #501 

Required refactoring the integs to use the `xz2` crate.

Simplified `TrustifyContext` a bit, too, and should avoid being rate-limited by github in the future. The unit tests should also be faster, since we're no longer installing PG for every single test.