### PR TITLE
chore: using cargo build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Format
         run: cargo fmt --check
-      - name: Check
-        run: cargo check
+      - name: Build
+        run: cargo build
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
       - name: Test


### PR DESCRIPTION
Hi folks I found this today during `cargo clean ; cargo build`

```
   Compiling trustify-trustd v0.1.0-alpha.11 (/home/heliofrota/Desktop/tc/trustify/trustd)
error: queries overflow the depth limit!
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`trustd`)
  = note: query depth increased by 130 when computing layout of `tracing::instrument::Instrumented<{async block@trustify_module_importer::server::Server::run::{closure#0}::{closure#0}}>`

error: could not compile `trustify-trustd` (bin "trustd") due to 1 previous error
```

> cargo build catches all Rust compilation errors.
cargo check only catches some subset of the possible compilation errors.
https://rust-lang.github.io/rfcs/3477-cargo-check-lang-policy.html#decision