### PR TITLE
Ingestion fixes, auto-create vulnerabilities using upsert

### DIFF
--- a/entity/src/cpe.rs
+++ b/entity/src/cpe.rs
@@ -120,6 +120,63 @@ pub struct CpeDto {
     pub language: Option<String>,
 }
 
+impl From<Model> for CpeDto {
+    fn from(value: Model) -> Self {
+        // turn into a model and destructure to ensure we don't miss any new fields
+
+        let Model {
+            id: _,
+            part,
+            vendor,
+            product,
+            version,
+            update,
+            edition,
+            language,
+        } = value;
+
+        Self {
+            part,
+            vendor,
+            product,
+            version,
+            update,
+            edition,
+            language,
+        }
+    }
+}
+
+impl From<Model> for (Uuid, CpeDto) {
+    fn from(value: Model) -> (Uuid, CpeDto) {
+        // turn into a model and destructure to ensure we don't miss any new fields
+
+        let Model {
+            id,
+            part,
+            vendor,
+            product,
+            version,
+            update,
+            edition,
+            language,
+        } = value;
+
+        (
+            id,
+            CpeDto {
+                part,
+                vendor,
+                product,
+                version,
+                update,
+                edition,
+                language,
+            },
+        )
+    }
+}
+
 macro_rules! apply {
     ($c: expr, $v:expr => $n:ident) => {
         if let Some($n) = &$v.$n {
@@ -212,29 +269,7 @@ mod test {
 
         log::info!("cpe: {model:#?}");
 
-        // now turn into a model and destructure to ensure we don't miss any new fields
-        let Model {
-            id,
-            part,
-            vendor,
-            product,
-            version,
-            update,
-            edition,
-            language,
-        } = model.try_into_model().unwrap();
-
-        // turn it into a DTO a read from the aggregate fields
-
-        let dto = CpeDto {
-            part,
-            vendor,
-            product,
-            version,
-            update,
-            edition,
-            language,
-        };
+        let (id, dto): (Uuid, CpeDto) = model.try_into_model().unwrap().into();
 
         // and turn it back into a CPE
 

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -86,6 +86,9 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
         .link_to_vulnerability("CVE-345", None, Transactional::None)
         .await?;
 
+    graph.ingest_vulnerability("CVE-123", (), ()).await?;
+    graph.ingest_vulnerability("CVE-345", (), ()).await?;
+
     let uri = "/api/v1/vulnerability";
 
     let request = TestRequest::get().uri(uri).to_request();

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,13 +1,17 @@
-use sea_orm::{prelude::*, EntityTrait, QueryFilter, QuerySelect};
-
-use crate::vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary};
-use crate::Error;
-use trustify_common::db::limiter::LimiterTrait;
-use trustify_common::db::query::{Filtering, Query};
-use trustify_common::db::Database;
-use trustify_common::db::Transactional;
-use trustify_common::model::{Paginated, PaginatedResults};
-use trustify_entity::{advisory_vulnerability, vulnerability};
+use crate::{
+    vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
+    Error,
+};
+use sea_orm::{prelude::*, EntityTrait, QueryFilter};
+use trustify_common::{
+    db::{
+        limiter::LimiterTrait,
+        query::{Filtering, Query},
+        Database, Transactional,
+    },
+    model::{Paginated, PaginatedResults},
+};
+use trustify_entity::vulnerability;
 
 pub struct VulnerabilityService {
     db: Database,
@@ -26,15 +30,11 @@ impl VulnerabilityService {
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
         let connection = self.db.connection(&tx);
 
-        let limiter = vulnerability::Entity::find()
-            .right_join(advisory_vulnerability::Entity)
-            .column_as(
-                advisory_vulnerability::Column::VulnerabilityId,
-                vulnerability::Column::Id,
-            )
-            .distinct_on([advisory_vulnerability::Column::VulnerabilityId])
-            .filtering(search)?
-            .limiting(&connection, paginated.offset, paginated.limit);
+        let limiter = vulnerability::Entity::find().filtering(search)?.limiting(
+            &connection,
+            paginated.offset,
+            paginated.limit,
+        );
 
         let total = limiter.total().await?;
 
@@ -61,26 +61,7 @@ impl VulnerabilityService {
                 VulnerabilityDetails::from_entity(&vulnerability, &connection).await?,
             ))
         } else {
-            // no root vulnerability has been ingested, so let's see if there's
-            // any advisories referencing it.
-
-            let advisory_vulns = advisory_vulnerability::Entity::find()
-                .filter(advisory_vulnerability::Column::VulnerabilityId.eq(identifier))
-                .all(&connection)
-                .await?;
-
-            if advisory_vulns.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(
-                    VulnerabilityDetails::from_advisory_vulnerabilities(
-                        identifier,
-                        &advisory_vulns,
-                        &connection,
-                    )
-                    .await?,
-                ))
-            }
+            Ok(None)
         }
     }
 }

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -5,12 +5,11 @@ use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DbErr, EntityTrait, ModelTrait, QueryFilter,
     QuerySelect, RelationTrait,
 };
-use sea_query::{Condition, JoinType};
+use sea_query::JoinType;
 use std::fmt::{Debug, Formatter};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::db::{chunk::EntityChunkedIter, Transactional};
-use trustify_entity as entity;
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 use uuid::Uuid;
 
@@ -140,8 +139,7 @@ impl Graph {
         &self,
         tx: TX,
     ) -> Result<Vec<VulnerabilityContext>, Error> {
-        Ok(entity::vulnerability::Entity::find()
-            .filter(Condition::all())
+        Ok(vulnerability::Entity::find()
             .all(&self.connection(&tx))
             .await?
             .into_iter()

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -109,32 +109,18 @@ impl Graph {
     }
 
     #[instrument(skip(self, tx), err)]
-    pub async fn get_vulnerability<TX: AsRef<Transactional>>(
+    pub async fn get_vulnerability(
         &self,
         identifier: &str,
-        tx: TX,
+        tx: impl AsRef<Transactional>,
     ) -> Result<Option<VulnerabilityContext>, Error> {
-        let vuln = vulnerability::Entity::find_by_id(identifier)
-            .one(&self.connection(&tx))
-            .await?;
-
-        if let Some(vuln) = vuln {
-            return Ok(Some(VulnerabilityContext::new(self, vuln)));
-        }
-
-        Ok(advisory_vulnerability::Entity::find()
-            .filter(advisory_vulnerability::Column::VulnerabilityId.eq(identifier))
-            .left_join(vulnerability::Entity)
-            .column_as(
-                advisory_vulnerability::Column::VulnerabilityId,
-                vulnerability::Column::Id,
-            )
-            .into_model::<vulnerability::Model>()
+        Ok(vulnerability::Entity::find_by_id(identifier)
             .one(&self.connection(&tx))
             .await?
             .map(|vuln| VulnerabilityContext::new(self, vuln)))
     }
 
+    #[instrument(skip(self, tx), err)]
     pub async fn get_vulnerabilities<TX: AsRef<Transactional>>(
         &self,
         tx: TX,

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -2,10 +2,9 @@
 
 use crate::{graph::advisory::AdvisoryContext, graph::error::Error, graph::Graph};
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DbErr, EntityTrait, ModelTrait, QueryFilter,
-    QuerySelect, RelationTrait,
+    ActiveValue::Set, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
 };
-use sea_query::JoinType;
+use sea_query::{JoinType, OnConflict};
 use std::fmt::{Debug, Formatter};
 use time::OffsetDateTime;
 use tracing::instrument;
@@ -13,7 +12,7 @@ use trustify_common::db::{chunk::EntityChunkedIter, Transactional};
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 use uuid::Uuid;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct VulnerabilityInformation {
     pub title: Option<String>,
     pub published: Option<OffsetDateTime>,
@@ -45,67 +44,48 @@ impl From<()> for VulnerabilityInformation {
 }
 
 impl Graph {
-    #[instrument(skip(self, information, tx), err)]
-    pub async fn ingest_vulnerability<
-        I: Into<VulnerabilityInformation>,
-        TX: AsRef<Transactional>,
-    >(
+    #[instrument(skip(self, tx), err)]
+    pub async fn ingest_vulnerability(
         &self,
         identifier: &str,
-        information: I,
-        tx: TX,
+        information: impl Into<VulnerabilityInformation> + Debug,
+        tx: impl AsRef<Transactional>,
     ) -> Result<VulnerabilityContext, Error> {
-        // TODO: consider transforming into upsert
         let information = information.into();
-        if let Some(found) = self.get_vulnerability(identifier, &tx).await? {
-            if information.has_data() {
-                // we should update with the details.
-                let mut entity = vulnerability::ActiveModel::from(found.vulnerability);
-                entity.title = Set(information.title.clone());
-                entity.published = Set(information.published);
-                entity.modified = Set(information.modified);
-                entity.withdrawn = Set(information.withdrawn);
+        let db = self.connection(&tx);
 
-                match entity.update(&self.connection(&tx)).await {
-                    Ok(model) => Ok(VulnerabilityContext::new(&found.graph, model)),
-                    Err(err) => {
-                        if let DbErr::RecordNotUpdated = err {
-                            // there turns out to not be a row in the DB, so
-                            // attempt an insert instead of an update.
-                            let entity = vulnerability::ActiveModel {
-                                id: Set(identifier.to_string()),
-                                title: Set(information.title),
-                                published: Set(information.published),
-                                modified: Set(information.modified),
-                                withdrawn: Set(information.withdrawn),
-                                cwe: Default::default(),
-                            };
-
-                            let model = entity.insert(&self.connection(&tx)).await?;
-                            Ok(VulnerabilityContext::new(&found.graph, model))
-                        } else {
-                            Err(Error::from(err))
-                        }
-                    }
-                }
-            } else {
-                Ok(found)
+        let mut on_conflict = OnConflict::columns([vulnerability::Column::Id]);
+        let on_conflict = match information.has_data() {
+            true => on_conflict.update_columns([
+                vulnerability::Column::Title,
+                vulnerability::Column::Published,
+                vulnerability::Column::Modified,
+                vulnerability::Column::Withdrawn,
+                vulnerability::Column::Cwe,
+            ]),
+            false => {
+                // we "update" the ID column (which actually stays the same) so that we can use the
+                // "returning" statement later on with `.exec_with_returning`.
+                on_conflict.update_columns([vulnerability::Column::Id])
             }
-        } else {
-            let entity = vulnerability::ActiveModel {
-                id: Set(identifier.to_string()),
-                title: Set(information.title),
-                published: Set(information.published),
-                modified: Set(information.modified),
-                withdrawn: Set(information.withdrawn),
-                cwe: Set(information.cwe),
-            };
-
-            Ok(VulnerabilityContext::new(
-                self,
-                entity.insert(&self.connection(&tx)).await?,
-            ))
         }
+        .to_owned();
+
+        let entity = vulnerability::ActiveModel {
+            id: Set(identifier.to_string()),
+            title: Set(information.title),
+            published: Set(information.published),
+            modified: Set(information.modified),
+            withdrawn: Set(information.withdrawn),
+            cwe: Set(information.cwe),
+        };
+
+        let result = vulnerability::Entity::insert(entity)
+            .on_conflict(on_conflict)
+            .exec_with_returning(&db)
+            .await?;
+
+        Ok(VulnerabilityContext::new(self, result))
     }
 
     #[instrument(skip(self, tx), err)]
@@ -289,10 +269,8 @@ mod tests {
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn get_advisories_from_cve(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-        let db = ctx.db;
-        let system = Graph::new(db);
-
-        let advisory1 = system
+        let advisory1 = ctx
+            .graph
             .ingest_advisory(
                 "GHSA-1",
                 ("source", "http://ghsa.io/GHSA-1"),
@@ -302,7 +280,8 @@ mod tests {
             )
             .await?;
 
-        let advisory2 = system
+        let advisory2 = ctx
+            .graph
             .ingest_advisory(
                 "RHSA-1",
                 ("source", "http://rhsa.io/RHSA-1"),
@@ -312,7 +291,8 @@ mod tests {
             )
             .await?;
 
-        let _advisory3 = system
+        let _advisory3 = ctx
+            .graph
             .ingest_advisory(
                 "SNYK-1",
                 ("source", "http://snyk.io/SNYK-1"),
@@ -330,11 +310,16 @@ mod tests {
             .link_to_vulnerability("CVE-8675309", None, Transactional::None)
             .await?;
 
-        let cve = system
+        ctx.graph
+            .ingest_vulnerability("CVE-8675309", (), Transactional::None)
+            .await?;
+
+        let cve = ctx
+            .graph
             .get_vulnerability("CVE-8675309", Transactional::None)
             .await?;
 
-        assert!(cve.is_some());
+        assert!(cve.is_some(), "there should be some CVE");
 
         let cve = cve.unwrap();
 

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -42,7 +42,6 @@ impl PurlStatusCreator {
     pub fn add_all(&mut self, csaf: &Csaf, ps: &Option<Vec<ProductIdT>>, status: &'static str) {
         for r in ps.iter().flatten() {
             if let Some((cpe, Some(purl))) = resolve_identifier(csaf, r) {
-                //println!("ADD {:#?} --  {:#?}", cpe, purl);
                 let mut purl = Purl::from(purl.clone());
                 purl.qualifiers.clear();
 

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -102,6 +102,8 @@ impl<'g> CsafLoader<'g> {
         tx: TX,
     ) -> Result<(), Error> {
         if let Some(cve_id) = &vulnerability.cve {
+            self.graph.ingest_vulnerability(&cve_id, (), &tx).await?;
+
             let advisory_vulnerability = advisory
                 .link_to_vulnerability(
                     cve_id,
@@ -120,8 +122,6 @@ impl<'g> CsafLoader<'g> {
                     &tx,
                 )
                 .await?;
-
-            log::debug!("{advisory_vulnerability:?}");
 
             if let Some(product_status) = &vulnerability.product_status {
                 self.ingest_product_statuses(csaf, &advisory_vulnerability, product_status, &tx)

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -102,7 +102,7 @@ impl<'g> CsafLoader<'g> {
         tx: TX,
     ) -> Result<(), Error> {
         if let Some(cve_id) = &vulnerability.cve {
-            self.graph.ingest_vulnerability(&cve_id, (), &tx).await?;
+            self.graph.ingest_vulnerability(cve_id, (), &tx).await?;
 
             let advisory_vulnerability = advisory
                 .link_to_vulnerability(

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -70,6 +70,8 @@ impl<'g> OsvLoader<'g> {
         }
 
         for cve_id in cve_ids {
+            self.graph.ingest_vulnerability(&cve_id, (), &tx).await?;
+
             let advisory_vuln = advisory
                 .link_to_vulnerability(
                     &cve_id,

--- a/modules/ingestor/tests/csaf.rs
+++ b/modules/ingestor/tests/csaf.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+
 use anyhow::bail;
 use std::time::Instant;
 use test_context::test_context;

--- a/modules/ingestor/tests/cve.rs
+++ b/modules/ingestor/tests/cve.rs
@@ -19,6 +19,12 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             .get_advisory_by_id(id, ())
             .await?
             .expect("must be found");
+
+        assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+
+        let vulns = ctx.graph.get_vulnerabilities(()).await?;
+        assert_eq!(vulns.len(), 1);
+
         let vuln = ctx
             .graph
             .get_vulnerability("CVE-2021-32714", ())
@@ -26,9 +32,7 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             .expect("Must be found");
 
         let descriptions = vuln.descriptions("en", ()).await?;
-
         assert_eq!(descriptions.len(), 1);
-        assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
 
         Ok(())
     }

--- a/modules/ingestor/tests/cve.rs
+++ b/modules/ingestor/tests/cve.rs
@@ -4,58 +4,44 @@ use anyhow::bail;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::id::Id;
+use trustify_module_ingestor::model::IngestResult;
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn reingest_cve(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    async fn assert(ctx: &TrustifyContext, result: IngestResult) -> anyhow::Result<()> {
+        let Id::Uuid(id) = result.id else {
+            bail!("must be an id")
+        };
+        let adv = ctx
+            .graph
+            .get_advisory_by_id(id, ())
+            .await?
+            .expect("must be found");
+        let vuln = ctx
+            .graph
+            .get_vulnerability("CVE-2021-32714", ())
+            .await?
+            .expect("Must be found");
+
+        let descriptions = vuln.descriptions("en", ()).await?;
+
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+
+        Ok(())
+    }
+
     // ingest once
 
     let result = ctx.ingest_document("cve/CVE-2021-32714.json").await?;
-
-    let Id::Uuid(id) = result.id else {
-        bail!("must be an id")
-    };
-    let adv = ctx
-        .graph
-        .get_advisory_by_id(id, ())
-        .await?
-        .expect("must be found");
-    let vuln = ctx
-        .graph
-        .get_vulnerability("CVE-2021-32714", ())
-        .await?
-        .expect("Must be found");
-
-    let descriptions = vuln.descriptions("en", ()).await?;
-
-    assert_eq!(descriptions.len(), 1);
-    assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+    assert(ctx, result).await?;
 
     // ingest second time
 
     let result = ctx.ingest_document("cve/CVE-2021-32714.json").await?;
-
-    let Id::Uuid(id) = result.id else {
-        bail!("must be an id")
-    };
-    let adv = ctx
-        .graph
-        .get_advisory_by_id(id, ())
-        .await?
-        .expect("must be found");
-    let vuln = ctx
-        .graph
-        .get_vulnerability("CVE-2021-32714", ())
-        .await?
-        .expect("Must be found");
-
-    let descriptions = vuln.descriptions("en", ()).await?;
-
-    // must still be one
-
-    assert_eq!(descriptions.len(), 1);
-    assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+    assert(ctx, result).await?;
 
     // done
 

--- a/modules/ingestor/tests/osv.rs
+++ b/modules/ingestor/tests/osv.rs
@@ -9,7 +9,7 @@ use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn reingest_osv(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn assert(ctx: &TrustifyContext, result: IngestResult) -> anyhow::Result<()> {
         let Id::Uuid(id) = result.id else {
             bail!("must be an id")

--- a/modules/ingestor/tests/osv.rs
+++ b/modules/ingestor/tests/osv.rs
@@ -1,33 +1,15 @@
+#![allow(clippy::expect_used)]
+
 use anyhow::bail;
-use std::time::Instant;
 use test_context::test_context;
 use test_log::test;
-use tracing::instrument;
 use trustify_common::id::Id;
 use trustify_module_ingestor::model::IngestResult;
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
-#[instrument]
-async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
-    let start = Instant::now();
-
-    let result = ctx.ingest_document("csaf/cve-2023-33201.json").await?;
-
-    let ingest_time = start.elapsed();
-
-    log::info!("ingest: {}", humantime::Duration::from(ingest_time));
-
-    assert!(matches!(result.id, Id::Uuid(_)));
-
-    Ok(())
-}
-
-#[test_context(TrustifyContext, skip_teardown)]
-#[test(tokio::test)]
-#[instrument]
-async fn reingest(ctx: TrustifyContext) -> anyhow::Result<()> {
+async fn reingest_osv(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn assert(ctx: &TrustifyContext, result: IngestResult) -> anyhow::Result<()> {
         let Id::Uuid(id) = result.id else {
             bail!("must be an id")
@@ -44,7 +26,7 @@ async fn reingest(ctx: TrustifyContext) -> anyhow::Result<()> {
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].advisory_vulnerability.vulnerability_id,
-            "CVE-2023-33201"
+            "CVE-2021-32714"
         );
 
         let all = ctx.graph.get_vulnerabilities(()).await?;
@@ -52,11 +34,11 @@ async fn reingest(ctx: TrustifyContext) -> anyhow::Result<()> {
 
         let vuln = ctx
             .graph
-            .get_vulnerability("CVE-2023-33201", ())
+            .get_vulnerability("CVE-2021-32714", ())
             .await?
             .expect("Must be found");
 
-        assert_eq!(vuln.vulnerability.id, "CVE-2023-33201");
+        assert_eq!(vuln.vulnerability.id, "CVE-2021-32714");
 
         let descriptions = vuln.descriptions("en", ()).await?;
         assert_eq!(descriptions.len(), 0);
@@ -64,15 +46,17 @@ async fn reingest(ctx: TrustifyContext) -> anyhow::Result<()> {
         Ok(())
     }
 
-    // ingest the first time
+    // ingest once
 
-    let result = ctx.ingest_document("csaf/cve-2023-33201.json").await?;
-    assert(&ctx, result).await?;
+    let result = ctx.ingest_document("osv/RUSTSEC-2021-0079.json").await?;
+    assert(ctx, result).await?;
 
-    // ingest a second time
+    // ingest second time
 
-    let result = ctx.ingest_document("csaf/cve-2023-33201.json").await?;
-    assert(&ctx, result).await?;
+    let result = ctx.ingest_document("osv/RUSTSEC-2021-0079.json").await?;
+    assert(ctx, result).await?;
+
+    // done
 
     Ok(())
 }

--- a/modules/ingestor/tests/spdx.rs
+++ b/modules/ingestor/tests/spdx.rs
@@ -1,0 +1,91 @@
+#![allow(clippy::expect_used)]
+
+use anyhow::bail;
+use sea_orm::EntityTrait;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::{cpe::Cpe, id::Id};
+use trustify_entity::{cpe::CpeDto, sbom};
+use trustify_module_ingestor::model::IngestResult;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    async fn assert(ctx: &TrustifyContext, result: IngestResult) -> anyhow::Result<()> {
+        let Id::Uuid(id) = result.id else {
+            bail!("must be an id")
+        };
+        let sbom = ctx
+            .graph
+            .get_sbom_by_id(id, ())
+            .await?
+            .expect("must be found");
+
+        // check CPEs
+
+        let cpes = sbom.describes_cpe22s(()).await?;
+        assert_eq!(
+            cpes.into_iter()
+                .map(|cpe| CpeDto::from(cpe.cpe))
+                .filter_map(|cpe| Cpe::try_from(cpe).ok())
+                .collect::<Vec<_>>(),
+            vec![]
+        );
+
+        // check purls
+
+        let purls = sbom.describes_purls(()).await?;
+        assert_eq!(
+            purls
+                .into_iter()
+                .map(|purl| purl.qualified_package.id)
+                .collect::<Vec<_>>(),
+            vec![]
+        );
+
+        // get product
+
+        let product = sbom.get_product(()).await?.expect("must have a product");
+        assert_eq!(product.product.product.name, "quarkus-bom");
+
+        let products = ctx.graph.get_products(()).await?;
+        assert_eq!(products.len(), 1);
+
+        // get orgs, expect one
+
+        let orgs = ctx.graph.get_organizations(()).await?;
+        assert_eq!(orgs.len(), 1);
+
+        // get all sboms, expect one
+
+        let sboms = ctx
+            .graph
+            .locate_many_sboms(sbom::Entity::find(), ())
+            .await?;
+
+        assert_eq!(sboms.len(), 1);
+
+        // done
+
+        Ok(())
+    }
+
+    // ingest once
+
+    let result = ctx
+        .ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
+        .await?;
+    assert(ctx, result).await?;
+
+    // ingest second time
+
+    let result = ctx
+        .ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
+        .await?;
+    assert(ctx, result).await?;
+
+    // done
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a few tests for re-ingesting documents. It also fixes issues alongside those. Most notably, it auto-creates vulnerabilities and switches the creation of those to an upsert model.