### PR TITLE
Return simplified SBOM status for a given vulnerability.

### DIFF
--- a/entity/src/package_relates_to_package.rs
+++ b/entity/src/package_relates_to_package.rs
@@ -40,3 +40,9 @@ pub enum Relation {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+impl Related<super::sbom::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sbom.def()
+    }
+}

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -32,6 +32,8 @@ pub enum Relation {
     Files,
     #[sea_orm(has_one = "super::sbom_node::Entity")]
     Node,
+    #[sea_orm(has_many = "super::package_relates_to_package::Entity")]
+    PackageRelatesToPackages,
 }
 
 pub struct SbomNodeLink;
@@ -60,6 +62,12 @@ impl Related<super::sbom_file::Entity> for Entity {
 impl Related<super::sbom_node::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Node.def()
+    }
+}
+
+impl Related<super::package_relates_to_package::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::PackageRelatesToPackages.def()
     }
 }
 

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,18 +1,25 @@
 use crate::purl::model::details::purl::StatusContext;
 use crate::purl::model::PurlHead;
+use crate::sbom::model::SbomSummary;
 use crate::{advisory::model::AdvisoryHead, purl::model::BasePurlHead, Error};
-use cpe::uri::Uri;
+use cpe::uri::{OwnedUri, Uri};
 use sea_orm::{
     ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait, QueryFilter, QuerySelect,
     RelationTrait,
 };
-use sea_query::{Asterisk, Expr, Func, IntoColumnRef, JoinType, SimpleExpr};
+use sea_query::{Asterisk, Expr, Func, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use time::OffsetDateTime;
 use trustify_common::db::VersionMatches;
-use trustify_common::{db::ConnectionOrTransaction, purl::Purl};
+use trustify_common::id::Id;
+use trustify_common::{
+    cpe::CpeCompare, db::ConnectionOrTransaction, impl_try_into_cpe, purl::Purl,
+};
 use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
 use trustify_entity as entity;
+use trustify_entity::labels::Labels;
+use trustify_entity::relationship::Relationship;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -107,7 +114,7 @@ pub struct VulnerabilityAdvisorySummary {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cvss3_scores: Vec<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub statuses: HashMap<String, Vec<VulnerabilityAdvisoryStatus>>,
+    pub purls: HashMap<String, Vec<VulnerabilityAdvisoryStatus>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sboms: Vec<SbomStatus>,
 }
@@ -173,13 +180,16 @@ impl VulnerabilityAdvisorySummary {
                     entity::cpe::Column::Language,
                 ])
                 .distinct_on([entity::purl_status::Column::Id])
-                .into_model::<StatusCatcher>()
+                .into_model::<PurlStatusCatcher>()
                 .all(tx)
                 .await?;
 
             let status_ids = statuses.iter().map(|e| e.id).collect::<Vec<_>>();
 
-            let sbom_statuses = entity::sbom_package::Entity::find()
+            /*
+             */
+
+            let sbom_purl_statuses = entity::sbom_package::Entity::find()
                 .join(JoinType::Join, entity::sbom_package::Relation::Node.def())
                 .join(
                     JoinType::LeftJoin,
@@ -189,29 +199,9 @@ impl VulnerabilityAdvisorySummary {
                     JoinType::LeftJoin,
                     entity::sbom_package_purl_ref::Relation::Purl.def(),
                 )
-                .column_as(
-                    SimpleExpr::Column(
-                        (
-                            entity::qualified_purl::Entity,
-                            entity::qualified_purl::Column::Id,
-                        )
-                            .into_column_ref(),
-                    ),
-                    "qualified_purl_id",
-                )
                 .join(
                     JoinType::LeftJoin,
                     entity::qualified_purl::Relation::PackageVersion.def(),
-                )
-                .column_as(
-                    SimpleExpr::Column(
-                        (
-                            entity::versioned_purl::Entity,
-                            entity::versioned_purl::Column::Version,
-                        )
-                            .into_column_ref(),
-                    ),
-                    "version",
                 )
                 .join(
                     JoinType::LeftJoin,
@@ -221,15 +211,35 @@ impl VulnerabilityAdvisorySummary {
                     JoinType::Join,
                     entity::base_purl::Relation::PurlStatus.def(),
                 )
-                .filter(entity::purl_status::Column::VulnerabilityId.eq(vulnerability_identifier))
-                .filter(entity::purl_status::Column::Id.is_in(status_ids))
                 .join(JoinType::Join, entity::purl_status::Relation::Status.def())
-                .column_as(entity::status::Column::Slug, "status")
-                .filter(entity::status::Column::Slug.ne("not_affected"))
                 .join(
                     JoinType::LeftJoin,
                     entity::purl_status::Relation::VersionRange.def(),
                 )
+                .join(
+                    JoinType::LeftJoin,
+                    entity::purl_status::Relation::ContextCpe.def(),
+                )
+                .column_as(
+                    Expr::col((
+                        entity::versioned_purl::Entity,
+                        entity::versioned_purl::Column::Version,
+                    )),
+                    "version",
+                )
+                .column_as(entity::status::Column::Slug, "status")
+                .column_as(entity::cpe::Column::Id, "cpe_id")
+                .columns([
+                    entity::cpe::Column::Part,
+                    entity::cpe::Column::Vendor,
+                    entity::cpe::Column::Product,
+                    entity::cpe::Column::Version,
+                    entity::cpe::Column::Update,
+                    entity::cpe::Column::Edition,
+                    entity::cpe::Column::Language,
+                ])
+                .filter(entity::purl_status::Column::VulnerabilityId.eq(vulnerability_identifier))
+                .filter(entity::purl_status::Column::Id.is_in(status_ids))
                 .filter(SimpleExpr::FunctionCall(
                     Func::cust(VersionMatches)
                         .arg(Expr::col((
@@ -250,8 +260,8 @@ impl VulnerabilityAdvisorySummary {
                 )
                 .await?,
                 cvss3_scores,
-                statuses: VulnerabilityAdvisoryStatus::from_models(&statuses, tx).await?,
-                sboms: SbomStatus::from_models(&sbom_statuses, tx).await?,
+                purls: VulnerabilityAdvisoryStatus::from_models(&statuses, tx).await?,
+                sboms: SbomStatus::from_models(&sbom_purl_statuses, tx).await?,
             });
         }
 
@@ -260,7 +270,7 @@ impl VulnerabilityAdvisorySummary {
 }
 
 #[derive(FromQueryResult, Debug)]
-struct StatusCatcher {
+struct PurlStatusCatcher {
     id: Uuid,
     status: String,
     package_uuid: Uuid,
@@ -271,7 +281,6 @@ struct StatusCatcher {
     low_inclusive: Option<bool>,
     high_version: Option<String>,
     high_inclusive: Option<bool>,
-    cpe_id: Option<Uuid>,
     part: Option<String>,
     vendor: Option<String>,
     product: Option<String>,
@@ -281,7 +290,9 @@ struct StatusCatcher {
     language: Option<String>,
 }
 
-impl StatusCatcher {
+impl_try_into_cpe!(PurlStatusCatcher);
+
+impl PurlStatusCatcher {
     pub fn purl(&self) -> Purl {
         Purl {
             ty: self.r#type.clone(),
@@ -352,7 +363,7 @@ impl StatusCatcher {
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityAdvisoryStatus {
-    pub package: BasePurlHead,
+    pub base_purl: BasePurlHead,
     pub version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<StatusContext>,
@@ -360,7 +371,7 @@ pub struct VulnerabilityAdvisoryStatus {
 
 impl VulnerabilityAdvisoryStatus {
     async fn from_models(
-        models: &Vec<StatusCatcher>,
+        models: &Vec<PurlStatusCatcher>,
         _tx: &ConnectionOrTransaction<'_>,
     ) -> Result<HashMap<String, Vec<Self>>, Error> {
         let mut statuses = HashMap::new();
@@ -368,54 +379,14 @@ impl VulnerabilityAdvisoryStatus {
         for each in models {
             let mut context = None;
 
-            if each.cpe_id.is_some() {
-                let mut cpe = Uri::builder();
-                if let Some(part) = each.part.as_ref() {
-                    if part != "*" {
-                        cpe.part(part);
-                    }
-                }
-                if let Some(vendor) = each.vendor.as_ref() {
-                    if vendor != "*" {
-                        cpe.vendor(vendor);
-                    }
-                }
-                if let Some(product) = each.product.as_ref() {
-                    if product != "*" {
-                        cpe.product(product);
-                    }
-                }
-                if let Some(version) = each.version.as_ref() {
-                    if version != "*" {
-                        cpe.version(version);
-                    }
-                }
-                if let Some(update) = each.update.as_ref() {
-                    if update != "*" {
-                        cpe.update(update);
-                    }
-                }
-                if let Some(edition) = each.edition.as_ref() {
-                    if edition != "*" {
-                        cpe.edition(edition);
-                    }
-                }
-                if let Some(language) = each.language.as_ref() {
-                    if language != "*" {
-                        cpe.language(language);
-                    }
-                }
-
-                if let Ok(cpe) = cpe.validate() {
-                    context = Some(StatusContext::Cpe(cpe.to_string()));
-                } else {
-                    println!("NO VALID");
-                }
+            let cpe: Result<OwnedUri, _> = each.try_into();
+            if let Ok(cpe) = cpe {
+                context = Some(StatusContext::Cpe(cpe.to_string()));
             }
 
             let status_entry = statuses.entry(each.status.clone()).or_insert(vec![]);
             status_entry.push(VulnerabilityAdvisoryStatus {
-                package: BasePurlHead {
+                base_purl: BasePurlHead {
                     uuid: each.package_uuid,
                     purl: each.purl(),
                 },
@@ -431,56 +402,170 @@ impl VulnerabilityAdvisoryStatus {
 #[derive(Debug, FromQueryResult)]
 struct SbomStatusCatcher {
     sbom_id: Uuid,
-    qualified_purl_id: Uuid,
     status: String,
+    cpe_id: Option<Uuid>,
+    part: Option<String>,
+    vendor: Option<String>,
+    product: Option<String>,
+    version: Option<String>,
+    update: Option<String>,
+    edition: Option<String>,
+    language: Option<String>,
 }
+
+impl_try_into_cpe!(SbomStatusCatcher);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SbomStatus {
-    pub id: Uuid,
-    pub status: HashMap<String, Vec<SbomPackageStatus>>,
+    #[serde(flatten)]
+    pub head: SbomSummary,
+
+    pub version: Option<String>,
+    #[serde(skip)]
+    cpe: Option<OwnedUri>,
+
+    pub status: HashSet<String>,
 }
 
 impl SbomStatus {
     async fn from_models(
-        models: &[SbomStatusCatcher],
+        sbom_purl_status: &[SbomStatusCatcher],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut sboms = HashMap::new();
 
-        for each in models {
-            let sbom_status = sboms.entry(each.sbom_id).or_insert(SbomStatus {
-                id: each.sbom_id,
-                status: HashMap::new(),
-            });
-
-            let particular_status = sbom_status
-                .status
-                .entry(each.status.clone())
-                .or_insert(Vec::new());
-
-            let purl = entity::qualified_purl::Entity::find_by_id(each.qualified_purl_id)
-                .one(tx)
-                .await?;
-
-            if let Some(purl) = purl {
-                let versioned_purl = purl
-                    .find_related(entity::versioned_purl::Entity)
+        for sbom_id in sbom_purl_status
+            .iter()
+            .map(|e| e.sbom_id)
+            .collect::<HashSet<_>>()
+        {
+            let sbom_status = if let Some(sbom_details) =
+                entity::package_relates_to_package::Entity::find()
+                    .filter(entity::package_relates_to_package::Column::SbomId.eq(sbom_id))
+                    .filter(
+                        entity::package_relates_to_package::Column::Relationship
+                            .eq(Relationship::DescribedBy),
+                    )
+                    .join(
+                        JoinType::LeftJoin,
+                        entity::package_relates_to_package::Relation::Left.def(),
+                    )
+                    .join(
+                        JoinType::LeftJoin,
+                        entity::sbom_node::Relation::Package.def(),
+                    )
+                    .join(
+                        JoinType::LeftJoin,
+                        entity::sbom_package::Relation::Cpe.def(),
+                    )
+                    .join(
+                        JoinType::LeftJoin,
+                        entity::sbom_package_cpe_ref::Relation::Cpe.def(),
+                    )
+                    .join(JoinType::Join, entity::sbom_package::Relation::Sbom.def())
+                    .column_as(entity::sbom_package::Column::Version, "sbom_version")
+                    .column(entity::sbom_node::Column::Name)
+                    .columns([
+                        entity::sbom::Column::SbomId,
+                        entity::sbom::Column::Sha256,
+                        entity::sbom::Column::Sha384,
+                        entity::sbom::Column::Sha512,
+                        entity::sbom::Column::Labels,
+                        entity::sbom::Column::DocumentId,
+                        entity::sbom::Column::Published,
+                        entity::sbom::Column::Authors,
+                    ])
+                    .column_as(entity::cpe::Column::Id, "cpe_id")
+                    .columns([
+                        entity::cpe::Column::Part,
+                        entity::cpe::Column::Vendor,
+                        entity::cpe::Column::Product,
+                        entity::cpe::Column::Version,
+                        entity::cpe::Column::Update,
+                        entity::cpe::Column::Edition,
+                        entity::cpe::Column::Language,
+                    ])
+                    .into_model::<SbomDetailsCatcher>()
                     .one(tx)
-                    .await?;
+                    .await?
+            {
+                let sbom_cpe: Result<OwnedUri, _> = (&sbom_details).try_into();
+                let sbom_cpe = sbom_cpe.ok();
 
-                if let Some(versioned_purl) = versioned_purl {
-                    let base_purl = versioned_purl
-                        .find_related(entity::base_purl::Entity)
-                        .one(tx)
-                        .await?;
+                let mut hashes = vec![Id::Sha256(sbom_details.sha256)];
 
-                    if let Some(base_purl) = base_purl {
-                        particular_status.push(SbomPackageStatus::Purl(
-                            PurlHead::from_entity(&base_purl, &versioned_purl, &purl, tx).await?,
-                        ))
+                if let Some(hash) = sbom_details.sha384 {
+                    hashes.push(Id::Sha384(hash));
+                }
+
+                if let Some(hash) = sbom_details.sha512 {
+                    hashes.push(Id::Sha512(hash));
+                }
+
+                SbomStatus {
+                    head: SbomSummary {
+                        id: sbom_details.sbom_id,
+                        hashes,
+                        document_id: sbom_details.document_id,
+                        labels: sbom_details.labels,
+                        name: sbom_details.name,
+                        published: sbom_details.published,
+                        authors: sbom_details.authors,
+                        described_by: vec![],
+                    },
+                    version: sbom_details.sbom_version,
+                    cpe: sbom_cpe,
+                    status: Default::default(),
+                }
+            } else {
+                SbomStatus {
+                    head: SbomSummary {
+                        id: sbom_id,
+                        hashes: vec![],
+                        document_id: "".to_string(),
+                        labels: Default::default(),
+                        name: "".to_string(),
+                        published: None,
+                        authors: vec![],
+                        described_by: vec![],
+                    },
+                    version: None,
+                    cpe: None,
+                    status: Default::default(),
+                }
+            };
+
+            sboms.insert(sbom_id, sbom_status);
+        }
+
+        'status: for advisory_status in sbom_purl_status {
+            if let Some(sbom_status) = sboms.get_mut(&advisory_status.sbom_id) {
+                match (advisory_status.cpe_id, &sbom_status.cpe) {
+                    (Some(_advisory_cpe), Some(sbom_cpe)) => {
+                        let status_cpe: Result<OwnedUri, _> = advisory_status.try_into();
+
+                        if let Ok(status_cpe) = status_cpe {
+                            if status_cpe.is_superset(sbom_cpe) {
+                                // the status context *is* applicable, fall through
+                            } else {
+                                // the status context *is not* applicable, skip
+                                continue 'status;
+                            }
+                        } else {
+                            // status_cpe is malformed, skip
+                            continue 'status;
+                        }
+                    }
+                    (Some(_), None) => {
+                        // Advisory has context that does not apply to this sbom, skip
+                        continue 'status;
+                    }
+                    (None, _) => {
+                        // Advisory is not contextualized around a given CPE, fall through
                     }
                 }
+
+                sbom_status.status.insert(advisory_status.status.clone());
             }
         }
 
@@ -494,3 +579,30 @@ pub enum SbomPackageStatus {
     Cpe(),
     Purl(PurlHead),
 }
+
+#[derive(Debug, FromQueryResult)]
+struct SbomDetailsCatcher {
+    sbom_id: Uuid,
+
+    sha256: String,
+    sha384: Option<String>,
+    sha512: Option<String>,
+    document_id: String,
+
+    published: Option<OffsetDateTime>,
+    authors: Vec<String>,
+
+    name: String,
+    sbom_version: Option<String>,
+    labels: Labels,
+
+    part: Option<String>,
+    vendor: Option<String>,
+    product: Option<String>,
+    version: Option<String>,
+    update: Option<String>,
+    edition: Option<String>,
+    language: Option<String>,
+}
+
+impl_try_into_cpe!(SbomDetailsCatcher);

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -36,13 +36,13 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(cve_advisory.is_some());
     let cve_advisory = cve_advisory.unwrap();
 
-    let rustsec_statuses: Vec<_> = rustsec_advisory.statuses.keys().collect();
+    let rustsec_statuses: Vec<_> = rustsec_advisory.purls.keys().collect();
 
     assert_eq!(2, rustsec_statuses.len());
     assert!(rustsec_statuses.contains(&&"fixed".to_string()));
     assert!(rustsec_statuses.contains(&&"affected".to_string()));
 
-    let cve_statuses: Vec<_> = cve_advisory.statuses.keys().collect();
+    let cve_statuses: Vec<_> = cve_advisory.purls.keys().collect();
     assert_eq!(0, cve_statuses.len());
 
     Ok(())


### PR DESCRIPTION
All SBOMs referencing purls that have a status from an advisory are evaluated. If a given SBOM resolves to a set of statuses (which may be a combination of statuses, such as "fixed" *and* "not_affected") those should be considered the absolute status of that SBOM _per that advisory_.

For an SBOM that contains *no* status set, the status shall be interpreted as _possibly affected_ but otherwise not asserted either way.