### PR TITLE
Include vulnerability information in SBOM details.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "7.0.6"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf338d20ba5bab309f55ce8df95d65ee19446f7737f06f4a64593ab2c6b546ad"
+checksum = "2b76aba2f176af685c2229633881a3adeae51f87ae1811781e73910b7001c93e"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-actix-web"
-version = "7.0.6"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50661e77b4c6c27ca018ad809d62fe40a02aa56b58fdc4eb333ceba56a024f1"
+checksum = "e5e18b994e3c34fcfd800847cf059dd9a9583f924ae640a6b0299886852d79ce"
 dependencies = [
  "actix",
  "actix-http",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "7.0.6"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc51fd6b7102acda72bc94e8ae1543844d5688ff394a6cf7c21f2a07fe2d64e4"
+checksum = "72e2e26a6b44bc61df3ca8546402cf9204c28e30c06084cc8e75cd5e34d4f150"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -613,15 +613,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.26.3",
- "syn 2.0.70",
+ "syn 2.0.71",
  "thiserror",
 ]
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.0.6"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75361eefd64e39f89bead4cb45fddbaf60ddb0e7b15fb7c852b6088bcd63071f"
+checksum = "f801451484b4977d6fe67b29030f81353cabdcbb754e5a064f39493582dac0cf"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.0.6"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f665d2d52b41c4ed1f01c43f3ef27a2fe0af2452ed5c8bc7ac9b1a8719afaa"
+checksum = "69117c43c01d81a69890a9f5dd6235f2f027ca8d1ec62d6d3c5e01ca0edb4f2b"
 dependencies = [
  "bytes",
  "indexmap 2.2.6",
@@ -660,7 +660,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -888,7 +888,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "syn_derive",
 ]
 
@@ -975,9 +975,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 dependencies = [
  "serde",
 ]
@@ -1020,13 +1020,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -1119,7 +1118,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1141,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
 dependencies = [
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1347,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "csaf-walker"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8d67309213d541e2183f1010ca128de4081a7a8d53813f0eb86b667fe3898c"
+checksum = "a04c1233c69ee31067e7b53f4792484de4ad0e503fe07e4ec6a82cbeb794cf7d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1368,7 +1367,7 @@ dependencies = [
  "lazy_static",
  "log",
  "percent-encoding",
- "reqwest 0.12.5",
+ "reqwest",
  "sectxtlib",
  "sequoia-openpgp",
  "serde",
@@ -1428,7 +1427,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1455,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "cyclonedx-bom"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01cb9724b305286db6e472056328b0bb914d2e8fd9cb2b91330d2c5d8df9734"
+checksum = "4a114dd99ed051f1481d8d35acd455f77469f026b783fe08074763fdf1701506"
 dependencies = [
  "base64 0.21.7",
  "cyclonedx-bom-macros",
@@ -1486,7 +1485,7 @@ checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1534,7 +1533,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1556,7 +1555,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1605,7 +1604,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1643,7 +1642,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1693,7 +1692,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1809,7 +1808,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2098,7 +2097,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2504,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -2521,7 +2520,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2615,7 +2614,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2681,7 +2680,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
@@ -2829,7 +2828,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2945,7 +2944,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3096,7 +3095,6 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bytecount",
- "clap",
  "fancy-regex",
  "fraction",
  "getrandom",
@@ -3108,7 +3106,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "percent-encoding",
  "regex",
- "reqwest 0.11.27",
  "serde",
  "serde_json",
  "time",
@@ -3439,9 +3436,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3c2fcf089c060eb333302d80c5f3ffa8297abecf220f788e4a09ef85f59420"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3709,7 +3706,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3738,7 +3735,7 @@ dependencies = [
  "getrandom",
  "http 1.1.0",
  "rand",
- "reqwest 0.12.5",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3773,7 +3770,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "mime",
- "reqwest 0.12.5",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3835,7 +3832,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3999,7 +3996,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4135,7 +4132,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4226,7 +4223,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4314,7 +4311,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4364,9 +4361,9 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postgresql_archive"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f0cf535c25ddb9a0e608d5d21b7cf02f194a6691fcc8b1b0ced25c52c4b56"
+checksum = "dc32b35b2d740090aeb75a356a723b63b133ee2c8fc812d89422b547c896c620"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,7 +4374,7 @@ dependencies = [
  "lazy_static",
  "num-format",
  "regex",
- "reqwest 0.12.5",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -4395,9 +4392,9 @@ dependencies = [
 
 [[package]]
 name = "postgresql_commands"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a52814a0bd4ab19c916671d7116deec019480aa22fdb8e5822241f79d15839"
+checksum = "37e926e3b180bd7faa1bd306d2205b41cec3c1bd8578c7d6f11cd5e85c0dfd56"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -4407,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "postgresql_embedded"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8892e9101d247ab023333ad62019705c6262ecca849be65eefb13457cd4072"
+checksum = "887e1bd40466868d27fd6510c6337f37f3ae85e177ccce08da7c34321bd8ec74"
 dependencies = [
  "anyhow",
  "home",
@@ -4531,7 +4528,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4678,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4763,42 +4760,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
@@ -4811,7 +4772,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls",
@@ -4856,7 +4817,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.12.5",
+ "reqwest",
  "serde",
  "thiserror",
  "tower-service",
@@ -4876,7 +4837,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "parking_lot 0.11.2",
- "reqwest 0.12.5",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
  "tokio",
@@ -4886,16 +4847,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a37668dccbd75e045f26811891dd939f28c38d3b7ca572a4fce4bc462b83ec"
+checksum = "4e45dcad05dc210fdb0278d62a679eb768730af808f8cb552f810da89bdbe76d"
 dependencies = [
  "anyhow",
  "async-trait",
  "getrandom",
  "http 1.1.0",
- "matchit 0.8.3",
- "reqwest 0.12.5",
+ "matchit 0.8.4",
+ "reqwest",
  "reqwest-middleware",
  "tracing",
 ]
@@ -5041,7 +5002,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.70",
+ "syn 2.0.71",
  "unicode-ident",
 ]
 
@@ -5076,7 +5037,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.70",
+ "syn 2.0.71",
  "walkdir",
 ]
 
@@ -5247,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "sbom-walker"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77465ef162006a314761555240855a680d8d12f756f7d98790790b56144bd2d7"
+checksum = "41829468d3be20bbf0f1bc1417905951fb862115334e2c59801ed222041cac9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5226,7 @@ dependencies = [
  "humantime",
  "log",
  "parking_lot 0.12.3",
- "reqwest 0.12.5",
+ "reqwest",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -5309,7 +5270,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5338,7 +5299,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5396,7 +5357,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.70",
+ "syn 2.0.71",
  "unicode-ident",
 ]
 
@@ -5460,7 +5421,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "thiserror",
 ]
 
@@ -5523,9 +5484,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -5536,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5552,9 +5513,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "sequoia-openpgp"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b870b0275eeae174058fcf0ce5affccaaafeb7eceeabce8d6c7f51fbe6a41e2a"
+checksum = "13261ee216b44d932ef93b2d4a75d45199bef77864bcc5b77ecfc7bc0ecb02d6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5605,7 +5566,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5616,7 +5577,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5664,9 +5625,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5682,14 +5643,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.3"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6108,9 +6069,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static-files"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64712ea1e3e140010e1d9605872ba205afa2ab5bd38191cc6ebd248ae1f6a06b"
+checksum = "4e8590e848e1c53be9258210bcd4a8f4118e08988f03a4e2d63b62e4ad9f7ced"
 dependencies = [
  "change-detection",
  "mime_guess",
@@ -6215,7 +6176,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6237,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6255,7 +6216,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6278,7 +6239,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6397,7 +6358,7 @@ checksum = "78ea17a2dc368aeca6f554343ced1b1e31f76d63683fa8016e5844bd7a5144a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6419,27 +6380,27 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6527,9 +6488,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6562,7 +6523,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6722,7 +6683,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -6800,7 +6761,7 @@ dependencies = [
  "jsonpath-rust",
  "log",
  "openid",
- "reqwest 0.12.5",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -6834,7 +6795,7 @@ dependencies = [
  "postgresql_embedded",
  "rand",
  "regex",
- "reqwest 0.12.5",
+ "reqwest",
  "ring",
  "rstest",
  "sea-orm",
@@ -6905,7 +6866,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot 0.12.3",
  "prometheus",
- "reqwest 0.12.5",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -7137,7 +7098,7 @@ dependencies = [
  "hide",
  "log",
  "rand",
- "reqwest 0.12.5",
+ "reqwest",
  "test-context",
  "test-log",
  "tokio",
@@ -7201,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?tag=static-main#4ce3968f61098b160d82012d0744bde784ad60a0"
+source = "git+https://github.com/trustification/trustify-ui.git?tag=static-main#02a28f8a872f53970ee1213fc17316d63ea1af27"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7409,7 +7370,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.70",
+ "syn 2.0.71",
  "url",
 ]
 
@@ -7422,7 +7383,7 @@ dependencies = [
  "actix-web",
  "mime_guess",
  "regex",
- "reqwest 0.12.5",
+ "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -7469,7 +7430,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -7516,9 +7477,9 @@ dependencies = [
 
 [[package]]
 name = "walker-common"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbefe8beabb52e3aedefe8cd8f255af4779882060592850855827663e18b13eb"
+checksum = "d3b8b050d54f9f8a8aa996903cc5c4b1876850490d211f050639d58127d2057d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7539,7 +7500,7 @@ dependencies = [
  "log",
  "openid",
  "pem",
- "reqwest 0.12.5",
+ "reqwest",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -7595,7 +7556,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -7629,7 +7590,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7987,7 +7948,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "synstructure",
 ]
 
@@ -8008,7 +7969,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -8028,7 +7989,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
  "synstructure",
 ]
 
@@ -8057,7 +8018,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/common/src/cpe.rs
+++ b/common/src/cpe.rs
@@ -346,14 +346,14 @@ macro_rules! apply_fix {
 #[macro_export]
 macro_rules! impl_try_into_cpe {
     ($ty:ty) => {
-        impl TryInto<cpe::uri::OwnedUri> for &$ty {
-            type Error = cpe::error::CpeError;
+        impl TryInto<::cpe::uri::OwnedUri> for &$ty {
+            type Error = ::cpe::error::CpeError;
 
-            fn try_into(self) -> Result<cpe::uri::OwnedUri, Self::Error> {
+            fn try_into(self) -> Result<::cpe::uri::OwnedUri, Self::Error> {
                 use $crate::apply_fix;
                 use $crate::apply;
 
-                let mut cpe = Uri::builder();
+                let mut cpe = ::cpe::uri::Uri::builder();
 
                 apply!(cpe, self => part);
                 apply_fix!(cpe, self => vendor, product, version, update, edition);

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -4,6 +4,8 @@ pub mod chunk;
 pub mod limiter;
 pub mod query;
 
+pub mod multi_model;
+
 use anyhow::Context;
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{

--- a/common/src/db/multi_model.rs
+++ b/common/src/db/multi_model.rs
@@ -1,0 +1,89 @@
+use sea_orm::{
+    ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoSimpleExpr, Iterable, QueryResult,
+    QuerySelect, Select, SelectModel, Selector,
+};
+use sea_query::{ColumnRef, SimpleExpr};
+
+pub trait ColumnsPrefixed: Sized {
+    fn try_columns_prefixed<C, I>(self, prefix: &str, cols: I) -> Result<Self, DbErr>
+    where
+        C: ColumnTrait,
+        I: IntoIterator<Item = C>;
+}
+
+impl<T: QuerySelect> ColumnsPrefixed for T {
+    fn try_columns_prefixed<C, I>(mut self, prefix: &str, cols: I) -> Result<Self, DbErr>
+    where
+        C: ColumnTrait,
+        I: IntoIterator<Item = C>,
+    {
+        for col in cols.into_iter() {
+            if let SimpleExpr::Column(col_ref) = col.into_simple_expr() {
+                match col_ref {
+                    ColumnRef::Column(name)
+                    | ColumnRef::TableColumn(_, name)
+                    | ColumnRef::SchemaTableColumn(_, _, name) => {
+                        let mut prefixed = String::new();
+                        prefixed.push_str(prefix);
+                        prefixed.push_str(&name.to_string());
+
+                        self = self.column_as(col, prefixed);
+                    }
+                    ColumnRef::Asterisk => {
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                    }
+                    ColumnRef::TableAsterisk(_) => {
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                    }
+                }
+            } else {
+                return Err(DbErr::Custom("Unable to prefix column".to_string()));
+            }
+        }
+        Ok(self)
+    }
+}
+
+pub trait SelectIntoMultiModel: Sized {
+    fn try_model_columns<E: EntityTrait>(self, entity: E) -> Result<Self, DbErr>;
+
+    fn try_into_multi_model<M>(self) -> Result<Selector<SelectModel<M>>, DbErr>
+    where
+        M: FromQueryResultMultiModel;
+}
+
+impl<E: EntityTrait> SelectIntoMultiModel for Select<E> {
+    fn try_model_columns<O: EntityTrait>(self, entity: O) -> Result<Self, DbErr> {
+        let name = entity.module_name();
+        let prefix = format!("{name}$");
+        self.try_columns_prefixed(&prefix, O::Column::iter())
+    }
+
+    fn try_into_multi_model<M>(self) -> Result<Selector<SelectModel<M>>, DbErr>
+    where
+        M: FromQueryResultMultiModel,
+    {
+        let select = M::try_into_multi_model(self)?;
+        Ok(select.into_model::<M>())
+    }
+}
+
+pub trait FromQueryResultMultiModel: FromQueryResult {
+    fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr>;
+
+    fn from_query_result_multi_model<E: EntityTrait>(
+        res: &QueryResult,
+        entity: E,
+    ) -> Result<E::Model, DbErr> {
+        let name = entity.module_name();
+        let prefix = format!("{name}$");
+        E::Model::from_query_result(res, &prefix)
+    }
+
+    fn from_query_result_multi_model_optional<E: EntityTrait>(
+        res: &QueryResult,
+        entity: E,
+    ) -> Result<Option<E::Model>, DbErr> {
+        Ok(Self::from_query_result_multi_model(res, entity).ok())
+    }
+}

--- a/common/src/db/multi_model.rs
+++ b/common/src/db/multi_model.rs
@@ -23,10 +23,7 @@ impl<T: QuerySelect> ColumnsPrefixed for T {
                     ColumnRef::Column(name)
                     | ColumnRef::TableColumn(_, name)
                     | ColumnRef::SchemaTableColumn(_, _, name) => {
-                        let mut prefixed = String::new();
-                        prefixed.push_str(prefix);
-                        prefixed.push_str(&name.to_string());
-
+                        let prefixed = format!("{prefix}{}", name.to_string());
                         self = self.column_as(col, prefixed);
                     }
                     ColumnRef::Asterisk => {

--- a/entity/src/cpe.rs
+++ b/entity/src/cpe.rs
@@ -2,6 +2,7 @@ use cpe::{error::CpeError, uri::Uri};
 use sea_orm::{entity::prelude::*, Set};
 use std::fmt::{Debug, Display, Formatter};
 use trustify_common::cpe::{Component, Cpe, CpeType, Language};
+use trustify_common::impl_try_into_cpe;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "cpe")]
@@ -16,6 +17,8 @@ pub struct Model {
     pub edition: Option<String>,
     pub language: Option<String>,
 }
+
+impl_try_into_cpe!(Model);
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {

--- a/entity/src/qualified_purl.rs
+++ b/entity/src/qualified_purl.rs
@@ -22,7 +22,7 @@ pub enum Relation {
         from = "super::qualified_purl::Column::VersionedPurlId"
         to = "super::versioned_purl::Column::Id"
     )]
-    PackageVersion,
+    VersionedPurl,
     #[sea_orm(
         belongs_to = "super::sbom_package_purl_ref::Entity",
         from = "Column::Id",
@@ -33,7 +33,7 @@ pub enum Relation {
 
 impl Related<super::versioned_purl::Entity> for Entity {
     fn to() -> RelationDef {
-        Relation::PackageVersion.def()
+        Relation::VersionedPurl.def()
     }
 }
 

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -36,6 +36,37 @@ pub enum Relation {
     PackageRelatesToPackages,
 }
 
+pub struct SbomPurlsLink;
+
+impl Linked for SbomPurlsLink {
+    type FromEntity = Entity;
+    type ToEntity = super::qualified_purl::Entity;
+
+    fn link(&self) -> Vec<LinkDef> {
+        vec![
+            Relation::Packages.def(),
+            super::sbom_package::Relation::Purl.def(),
+            super::sbom_package_purl_ref::Relation::Purl.def(),
+        ]
+    }
+}
+
+pub struct SbomVersionedPurlsLink;
+
+impl Linked for SbomVersionedPurlsLink {
+    type FromEntity = Entity;
+    type ToEntity = super::base_purl::Entity;
+
+    fn link(&self) -> Vec<LinkDef> {
+        vec![
+            Relation::Packages.def(),
+            super::sbom_package::Relation::Purl.def(),
+            super::sbom_package_purl_ref::Relation::Purl.def(),
+            super::qualified_purl::Relation::VersionedPurl.def(),
+        ]
+    }
+}
+
 pub struct SbomNodeLink;
 
 impl Linked for SbomNodeLink {

--- a/modules/fundamental/src/purl/model/mod.rs
+++ b/modules/fundamental/src/purl/model/mod.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 pub mod details;
 pub mod summary;
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 pub struct BasePurlHead {
     /// The ID of the base PURL
     pub uuid: Uuid,
@@ -48,7 +48,7 @@ impl BasePurlHead {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 pub struct VersionedPurlHead {
     /// The ID of the versioned PURL
     pub uuid: Uuid,
@@ -78,7 +78,7 @@ impl VersionedPurlHead {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 pub struct PurlHead {
     /// The ID of the qualified PURL
     pub uuid: Uuid,

--- a/modules/fundamental/src/purl/model/summary/purl.rs
+++ b/modules/fundamental/src/purl/model/summary/purl.rs
@@ -2,17 +2,19 @@ use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
 use crate::Error;
 use sea_orm::{LoaderTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::paginated;
 use trustify_entity::{base_purl, qualified_purl, versioned_purl};
 use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema)]
 pub struct PurlSummary {
     #[serde(flatten)]
     pub head: PurlHead,
     pub base: BasePurlHead,
     pub version: VersionedPurlHead,
+    pub qualifiers: BTreeMap<String, String>,
 }
 
 impl PurlSummary {
@@ -47,12 +49,27 @@ impl PurlSummary {
                         base: BasePurlHead::from_entity(&package, tx).await?,
                         version: VersionedPurlHead::from_entity(&package, package_version, tx)
                             .await?,
+                        qualifiers: qualified_package.qualifiers.0.clone(),
                     })
                 }
             }
         }
 
         Ok(summaries)
+    }
+
+    pub async fn from_entity(
+        base_purl: &base_purl::Model,
+        versioned_purl: &versioned_purl::Model,
+        purl: &qualified_purl::Model,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        Ok(PurlSummary {
+            head: PurlHead::from_entity(base_purl, versioned_purl, purl, tx).await?,
+            base: BasePurlHead::from_entity(base_purl, tx).await?,
+            version: VersionedPurlHead::from_entity(base_purl, versioned_purl, tx).await?,
+            qualifiers: purl.qualifiers.0.clone(),
+        })
     }
 }
 

--- a/modules/fundamental/src/purl/model/summary/versioned_purl.rs
+++ b/modules/fundamental/src/purl/model/summary/versioned_purl.rs
@@ -40,4 +40,16 @@ impl VersionedPurlSummary {
 
         Ok(summaries)
     }
+
+    pub async fn from_entity(
+        base_purl: &base_purl::Model,
+        versioned_purl: &versioned_purl::Model,
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            head: VersionedPurlHead::from_entity(base_purl, versioned_purl, tx).await?,
+            base: BasePurlHead::from_entity(base_purl, tx).await?,
+            purls: vec![],
+        })
+    }
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -63,7 +63,12 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
         crate::sbom::model::SbomPackage,
         crate::sbom::model::SbomPackageRelation,
         crate::sbom::model::SbomSummary,
+        crate::sbom::model::details::SbomDetails,
+        crate::sbom::model::details::SbomAdvisory,
+        crate::sbom::model::details::SbomStatus,
+        crate::sbom::model::SbomHead,
         crate::sbom::model::Which,
+        crate::purl::model::details::purl::StatusContext,
         trustify_common::advisory::AdvisoryVulnerabilityAssertions,
         trustify_common::advisory::Assertion,
         trustify_common::purl::Purl,
@@ -165,7 +170,7 @@ pub async fn all_related(
         ("id" = string, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
     ),
     responses(
-        (status = 200, description = "Matching SBOM", body = SbomSummary),
+        (status = 200, description = "Matching SBOM", body = SbomDetails),
         (status = 404, description = "Matching SBOM not found"),
     ),
 )]

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -336,7 +336,7 @@ pub async fn download(
     let stream = ingestor
         .storage()
         .clone()
-        .retrieve(sbom.hashes.try_into()?)
+        .retrieve(sbom.head.hashes.try_into()?)
         .await
         .map_err(Error::Storage)?
         .map(|stream| stream.map_err(Error::Storage));

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -1,7 +1,7 @@
 use crate::advisory::model::AdvisoryHead;
 use crate::purl::model::details::purl::StatusContext;
 use crate::purl::model::summary::purl::PurlSummary;
-use crate::sbom::model::{SbomHead, SbomPackage, SbomPackagePurl};
+use crate::sbom::model::{SbomHead, SbomPackage};
 use crate::sbom::service::sbom::QueryCatcher;
 use crate::Error;
 use cpe::uri::OwnedUri;
@@ -129,7 +129,7 @@ impl SbomAdvisory {
                 id: each.sbom_package.node_id.clone(),
                 name: each.sbom_node.name.clone(),
                 version: each.sbom_package.version.clone(),
-                purl: vec![SbomPackagePurl::Summary(
+                purl: vec![
                     PurlSummary::from_entity(
                         &each.base_purl,
                         &each.versioned_purl,
@@ -137,7 +137,7 @@ impl SbomAdvisory {
                         tx,
                     )
                     .await?,
-                )],
+                ],
                 cpe: vec![],
             });
         }

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -1,0 +1,158 @@
+use crate::advisory::model::AdvisoryHead;
+use crate::purl::model::details::purl::StatusContext;
+use crate::purl::model::summary::purl::PurlSummary;
+use crate::sbom::model::{SbomHead, SbomPackage, SbomPackagePurl};
+use crate::sbom::service::sbom::QueryCatcher;
+use crate::Error;
+use cpe::uri::OwnedUri;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use time::OffsetDateTime;
+use trustify_common::cpe::CpeCompare;
+use trustify_common::db::ConnectionOrTransaction;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SbomDetails {
+    #[serde(flatten)]
+    pub head: SbomHead,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub published: Option<OffsetDateTime>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub described_by: Vec<SbomPackage>,
+    pub advisories: Vec<SbomAdvisory>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SbomAdvisory {
+    #[serde(flatten)]
+    pub head: AdvisoryHead,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<SbomStatus>,
+}
+
+impl SbomAdvisory {
+    pub async fn from_models(
+        described_by: &[SbomPackage],
+        statuses: &[QueryCatcher],
+        tx: &ConnectionOrTransaction<'_>,
+    ) -> Result<Vec<Self>, Error> {
+        let mut advisories = HashMap::new();
+
+        let sbom_cpes = described_by
+            .iter()
+            .flat_map(|each| each.cpe.iter())
+            .flat_map(|e| {
+                let e = e.replace(":*:", "::");
+                let e = e.replace(":*", "");
+                let result = cpe::uri::Uri::parse(&e);
+                result.ok().map(|wfn| wfn.as_uri().to_owned())
+            })
+            .collect::<Vec<_>>();
+
+        'status: for each in statuses {
+            let status_cpe = if let Some(status_cpe) = &each.context_cpe {
+                let status_cpe: Result<OwnedUri, _> = status_cpe.try_into();
+                if let Ok(status_cpe) = status_cpe {
+                    if sbom_cpes
+                        .iter()
+                        .any(|sbom_cpe| status_cpe.is_superset(sbom_cpe))
+                    {
+                        // status context is applicable, keep truckin'
+                    } else {
+                        // status context excludes this one, skip over
+                        continue 'status;
+                    }
+                    Some(status_cpe)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            // if we got here, then there's either no context or the context matches this SBOM
+            let advisory = if let Some(advisory) = advisories.get_mut(&each.advisory.id) {
+                advisory
+            } else {
+                advisories.insert(
+                    each.advisory.id,
+                    SbomAdvisory {
+                        head: AdvisoryHead::from_advisory(&each.advisory, None, tx).await?,
+                        status: vec![],
+                    },
+                );
+
+                advisories
+                    .get_mut(&each.advisory.id)
+                    .ok_or(Error::Data("Failed to build advisories".to_string()))?
+            };
+
+            let sbom_status = if let Some(status) = advisory.status.iter_mut().find(|status| {
+                if status.status == each.status.slug
+                    && status.vulnerability_id == each.vulnerability.id
+                {
+                    match (&status.context, &status_cpe) {
+                        (Some(StatusContext::Cpe(context_cpe)), Some(status_cpe)) => {
+                            *context_cpe == status_cpe.to_string()
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            }) {
+                status
+            } else {
+                let status = SbomStatus {
+                    vulnerability_id: each.vulnerability.id.clone(),
+                    status: each.status.slug.clone(),
+                    context: status_cpe
+                        .as_ref()
+                        .map(|e| StatusContext::Cpe(e.to_string())),
+                    packages: vec![],
+                };
+                advisory.status.push(status);
+                if let Some(status) = advisory.status.last_mut() {
+                    status
+                } else {
+                    return Err(Error::Data("failed to build advisory status".to_string()));
+                }
+            };
+
+            sbom_status.packages.push(SbomPackage {
+                id: each.sbom_package.node_id.clone(),
+                name: each.sbom_node.name.clone(),
+                version: each.sbom_package.version.clone(),
+                purl: vec![SbomPackagePurl::Summary(
+                    PurlSummary::from_entity(
+                        &each.base_purl,
+                        &each.versioned_purl,
+                        &each.qualified_purl,
+                        tx,
+                    )
+                    .await?,
+                )],
+                cpe: vec![],
+            });
+        }
+
+        Ok(advisories.values().cloned().collect::<Vec<_>>())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SbomStatus {
+    pub vulnerability_id: String,
+    pub status: String,
+    pub context: Option<StatusContext>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<SbomPackage>,
+}
+
+impl SbomStatus {}

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -10,8 +10,9 @@ use std::collections::HashMap;
 use time::OffsetDateTime;
 use trustify_common::cpe::CpeCompare;
 use trustify_common::db::ConnectionOrTransaction;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SbomDetails {
     #[serde(flatten)]
     pub head: SbomHead,
@@ -27,7 +28,7 @@ pub struct SbomDetails {
     pub advisories: Vec<SbomAdvisory>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct SbomAdvisory {
     #[serde(flatten)]
     pub head: AdvisoryHead,
@@ -146,7 +147,7 @@ impl SbomAdvisory {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct SbomStatus {
     pub vulnerability_id: String,
     pub status: String,

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -45,22 +45,9 @@ pub struct SbomPackage {
     pub name: String,
     pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub purl: Vec<SbomPackagePurl>,
+    pub purl: Vec<PurlSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cpe: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
-#[serde(untagged)]
-pub enum SbomPackagePurl {
-    String(String),
-    Summary(PurlSummary),
-}
-
-impl From<&str> for SbomPackagePurl {
-    fn from(value: &str) -> Self {
-        Self::String(value.to_string())
-    }
 }
 
 // TODO: think about a way to add CPE and PURLs too

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -1,3 +1,6 @@
+pub mod details;
+
+use crate::purl::model::summary::purl::PurlSummary;
 use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -6,7 +9,7 @@ use trustify_entity::{labels::Labels, relationship::Relationship};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
-pub struct SbomSummary {
+pub struct SbomHead {
     #[serde(with = "uuid::serde::urn")]
     pub id: Uuid,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -17,6 +20,12 @@ pub struct SbomSummary {
     pub labels: Labels,
 
     pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct SbomSummary {
+    #[serde(flatten)]
+    pub head: SbomHead,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(with = "time::serde::rfc3339::option")]
     pub published: Option<OffsetDateTime>,
@@ -36,9 +45,22 @@ pub struct SbomPackage {
     pub name: String,
     pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub purl: Vec<String>,
+    pub purl: Vec<SbomPackagePurl>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cpe: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[serde(untagged)]
+pub enum SbomPackagePurl {
+    String(String),
+    Summary(PurlSummary),
+}
+
+impl From<&str> for SbomPackagePurl {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
 }
 
 // TODO: think about a way to add CPE and PURLs too

--- a/modules/fundamental/src/sbom/service/mod.rs
+++ b/modules/fundamental/src/sbom/service/mod.rs
@@ -2,6 +2,9 @@ pub mod assertion;
 pub mod label;
 pub mod sbom;
 
+#[cfg(test)]
+mod test;
+
 use trustify_common::db::Database;
 
 pub struct SbomService {

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -1,0 +1,32 @@
+use crate::sbom::service::SbomService;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db::Transactional;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn sbom_details_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let results = ctx
+        .ingest_documents([
+            "cve/CVE-2024-29025.json",
+            "csaf/rhsa-2024-2705.json",
+            "spdx/quarkus-bom-3.2.11.Final-redhat-00001.json",
+            "spdx/quarkus-bom-3.2.12.Final-redhat-00002.json",
+        ])
+        .await?;
+
+    let service = SbomService::new(ctx.db.clone());
+
+    let id_3_2_12 = results[3].id.clone();
+
+    let details = service.fetch_sbom(id_3_2_12, Transactional::None).await?;
+
+    assert!(details.is_some());
+
+    let details = details.unwrap();
+
+    log::debug!("{}", serde_json::to_string_pretty(&details)?);
+
+    Ok(())
+}

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,8 +1,8 @@
 use crate::purl::model::details::purl::StatusContext;
 use crate::purl::model::PurlHead;
-use crate::sbom::model::SbomSummary;
+use crate::sbom::model::SbomHead;
 use crate::{advisory::model::AdvisoryHead, purl::model::BasePurlHead, Error};
-use cpe::uri::{OwnedUri, Uri};
+use cpe::uri::OwnedUri;
 use sea_orm::{
     ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait, QueryFilter, QuerySelect,
     RelationTrait,
@@ -10,7 +10,6 @@ use sea_orm::{
 use sea_query::{Asterisk, Expr, Func, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use time::OffsetDateTime;
 use trustify_common::db::VersionMatches;
 use trustify_common::id::Id;
 use trustify_common::{
@@ -186,9 +185,6 @@ impl VulnerabilityAdvisorySummary {
 
             let status_ids = statuses.iter().map(|e| e.id).collect::<Vec<_>>();
 
-            /*
-             */
-
             let sbom_purl_statuses = entity::sbom_package::Entity::find()
                 .join(JoinType::Join, entity::sbom_package::Relation::Node.def())
                 .join(
@@ -201,7 +197,7 @@ impl VulnerabilityAdvisorySummary {
                 )
                 .join(
                     JoinType::LeftJoin,
-                    entity::qualified_purl::Relation::PackageVersion.def(),
+                    entity::qualified_purl::Relation::VersionedPurl.def(),
                 )
                 .join(
                     JoinType::LeftJoin,
@@ -418,7 +414,7 @@ impl_try_into_cpe!(SbomStatusCatcher);
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SbomStatus {
     #[serde(flatten)]
-    pub head: SbomSummary,
+    pub head: SbomHead,
 
     pub version: Option<String>,
     #[serde(skip)]
@@ -503,15 +499,12 @@ impl SbomStatus {
                 }
 
                 SbomStatus {
-                    head: SbomSummary {
+                    head: SbomHead {
                         id: sbom_details.sbom_id,
                         hashes,
                         document_id: sbom_details.document_id,
                         labels: sbom_details.labels,
                         name: sbom_details.name,
-                        published: sbom_details.published,
-                        authors: sbom_details.authors,
-                        described_by: vec![],
                     },
                     version: sbom_details.sbom_version,
                     cpe: sbom_cpe,
@@ -519,15 +512,12 @@ impl SbomStatus {
                 }
             } else {
                 SbomStatus {
-                    head: SbomSummary {
+                    head: SbomHead {
                         id: sbom_id,
                         hashes: vec![],
                         document_id: "".to_string(),
                         labels: Default::default(),
                         name: "".to_string(),
-                        published: None,
-                        authors: vec![],
-                        described_by: vec![],
                     },
                     version: None,
                     cpe: None,
@@ -588,9 +578,6 @@ struct SbomDetailsCatcher {
     sha384: Option<String>,
     sha512: Option<String>,
     document_id: String,
-
-    published: Option<OffsetDateTime>,
-    authors: Vec<String>,
 
     name: String,
     sbom_version: Option<String>,

--- a/modules/fundamental/tests/sbom/cyclonedx.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx.rs
@@ -3,7 +3,7 @@ use test_context::test_context;
 use test_log::test;
 use trustify_common::db::Transactional;
 use trustify_common::model::Paginated;
-use trustify_module_fundamental::sbom::model::SbomPackage;
+use trustify_module_fundamental::sbom::model::{SbomPackage, SbomPackagePurl};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
@@ -23,9 +23,9 @@ async fn test_parse_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                     id: "pkg:maven/org.apache.zookeeper/zookeeper@3.9.2?type=jar".to_string(),
                     name: "zookeeper".to_string(),
                     version: Some("3.9.2".to_string()),
-                    purl: vec![
+                    purl: vec![SbomPackagePurl::String(
                         "pkg://maven/org.apache.zookeeper/zookeeper@3.9.2?type=jar".to_string()
-                    ],
+                    )],
                     cpe: vec![],
                 }]
             );

--- a/modules/fundamental/tests/sbom/graph.rs
+++ b/modules/fundamental/tests/sbom/graph.rs
@@ -7,6 +7,7 @@ use trustify_common::hashing::Digests;
 use trustify_common::purl::Purl;
 use trustify_common::sbom::SbomLocator;
 use trustify_entity::relationship::Relationship;
+use trustify_module_fundamental::sbom::model::SbomPackagePurl;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
@@ -334,7 +335,9 @@ async fn ingest_package_relates_to_package_dependency_of(
     assert_eq!(1, dependencies.len());
 
     assert_eq!(
-        vec!["pkg://maven/io.quarkus/quarkus-postgres@1.2.3"],
+        vec![SbomPackagePurl::String(
+            "pkg://maven/io.quarkus/quarkus-postgres@1.2.3".to_string()
+        )],
         dependencies[0].purl
     );
 
@@ -350,7 +353,9 @@ async fn ingest_package_relates_to_package_dependency_of(
     assert_eq!(1, dependencies.len());
 
     assert_eq!(
-        vec!["pkg://maven/io.quarkus/quarkus-sqlite@1.2.3"],
+        vec![SbomPackagePurl::String(
+            "pkg://maven/io.quarkus/quarkus-sqlite@1.2.3".to_string()
+        )],
         dependencies[0].purl
     );
 

--- a/modules/fundamental/tests/sbom/graph.rs
+++ b/modules/fundamental/tests/sbom/graph.rs
@@ -7,7 +7,8 @@ use trustify_common::hashing::Digests;
 use trustify_common::purl::Purl;
 use trustify_common::sbom::SbomLocator;
 use trustify_entity::relationship::Relationship;
-use trustify_module_fundamental::sbom::model::SbomPackagePurl;
+use trustify_module_fundamental::purl::model::summary::purl::PurlSummary;
+use trustify_module_fundamental::purl::model::PurlHead;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
@@ -334,12 +335,17 @@ async fn ingest_package_relates_to_package_dependency_of(
 
     assert_eq!(1, dependencies.len());
 
-    assert_eq!(
-        vec![SbomPackagePurl::String(
-            "pkg://maven/io.quarkus/quarkus-postgres@1.2.3".to_string()
-        )],
-        dependencies[0].purl
-    );
+    assert!(matches!(
+        &dependencies[0].purl[0],
+        PurlSummary {
+            head: PurlHead {
+                purl,
+                ..
+            },
+            ..
+        }
+        if *purl == Purl::from_str("pkg://maven/io.quarkus/quarkus-postgres@1.2.3")?
+    ));
 
     let dependencies = fetch
         .related_packages(
@@ -352,12 +358,17 @@ async fn ingest_package_relates_to_package_dependency_of(
 
     assert_eq!(1, dependencies.len());
 
-    assert_eq!(
-        vec![SbomPackagePurl::String(
-            "pkg://maven/io.quarkus/quarkus-sqlite@1.2.3".to_string()
-        )],
-        dependencies[0].purl
-    );
+    assert!(matches!(
+        &dependencies[0].purl[0],
+        PurlSummary {
+            head: PurlHead {
+                purl,
+                ..
+            },
+            ..
+        }
+        if *purl == Purl::from_str("pkg://maven/io.quarkus/quarkus-sqlite@1.2.3")?
+    ));
 
     Ok(())
 }

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -74,8 +74,8 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have different names
 
-    assert_eq!(sbom1.name, "quarkus-bom");
-    assert_eq!(sbom2.name, "quarkus-bom-2.13.8.Final-redhat-00004");
+    assert_eq!(sbom1.head.name, "quarkus-bom");
+    assert_eq!(sbom2.head.name, "quarkus-bom-2.13.8.Final-redhat-00004");
     assert_eq!(sbom1.described_by.len(), 1);
     assert_eq!(sbom2.described_by.len(), 1);
 
@@ -166,8 +166,8 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
     assert_eq!(sbom1.described_by.len(), 1);
     assert_eq!(sbom2.described_by.len(), 1);
 
@@ -246,8 +246,8 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
     assert_eq!(sbom1.described_by.len(), 1);
     assert_eq!(sbom2.described_by.len(), 1);
 
@@ -334,8 +334,8 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
     assert_eq!(sbom1.described_by.len(), 1);
     assert_eq!(sbom2.described_by.len(), 1);
 
@@ -417,8 +417,8 @@ async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.name, "registry.access.redhat.com/ubi9/ubi");
-    assert_eq!(sbom2.name, "registry.access.redhat.com/ubi9/ubi");
+    assert_eq!(sbom1.head.name, "registry.access.redhat.com/ubi9/ubi");
+    assert_eq!(sbom2.head.name, "registry.access.redhat.com/ubi9/ubi");
     assert_eq!(sbom1.described_by.len(), 1);
     assert_eq!(sbom2.described_by.len(), 1);
 


### PR DESCRIPTION
`/api/v1/sbom/{id}` produces a fuller SBOM details which includes SBOM -> advisory -> vulnerability information, for all statuses, which may include `fixed`, `not_affected`, `known_affected` etc.