### PR TITLE
ci: generate cyclonedx sboms during the build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,6 +181,8 @@ jobs:
         run: |
           cargo binstall cross -y
 
+      - run: mkdir -p upload
+
       - name: Build | Build
         shell: bash
         env:
@@ -216,6 +218,18 @@ jobs:
 
           ${CMD} build ${OPTS}
 
+      - name: Install cargo-cyclonedx
+        shell: bash
+        run: |
+          cargo binstall -y cargo-cyclonedx
+
+      - name: Create SBOM
+        shell: bash
+        run: |
+          cargo cyclonedx -v --spec-version 1.5 --format json --describe binaries --target "${{ matrix.target }}"
+          
+          mv trustd/trustd_bin.cdx.json "upload/${{ env.dirname }}.cdx.json"
+
       - name: Move binary
         shell: bash
         run: |
@@ -235,8 +249,6 @@ jobs:
           # stage for upload
           mv -v "${SRC}" "pack/${dirname}/${download_binary_name}${{ matrix.ext }}"
           cp LICENSE "pack/${dirname}/"
-
-      - run: mkdir -p upload
 
       - name: Archive (zip)
         if: matrix.archive == 'zip'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,9 +52,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup cargo-binstall
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Setup cargo-workspaces
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo binstall -y cargo-workspaces
       - name: Set version
@@ -168,16 +172,22 @@ jobs:
 
       - name: Setup cargo-binstall (Linux)
         if: runner.os != 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
       - name: Setup cargo-binstall (Windows)
         if: runner.os == 'Windows'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
       - name: Setup Cross
         if: matrix.cross == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo binstall cross -y
 
@@ -220,6 +230,8 @@ jobs:
 
       - name: Install cargo-cyclonedx
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo binstall -y cargo-cyclonedx
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ target
 /data
 .trustify
 
+*.cdx.json
+
 /flamegraph*.svg
 /perf.data*


### PR DESCRIPTION
Also: use GITHUB_TOKEN for `cargo binstall` to avoid GH API rate limits

Closes #534