### PR TITLE
fix: remove non-normative data from advisory vulnerability

### DIFF
--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -10,7 +10,6 @@ use utoipa::ToSchema;
 pub struct AdvisoryVulnerabilityHead {
     #[serde(flatten)]
     pub head: VulnerabilityHead,
-    pub non_normative: VulnerabilityHead,
     pub severity: String,
     pub score: f64,
 }
@@ -47,14 +46,15 @@ impl AdvisoryVulnerabilityHead {
             .await?;
 
         if let Some(advisory_vuln) = advisory_vuln {
+            let head = if vulnerability.title.is_some() {
+                VulnerabilityHead::from_vulnerability_entity(vulnerability, tx).await?
+            } else {
+                VulnerabilityHead::from_advisory_vulnerability_entity(&advisory_vuln, vulnerability)
+            };
             Ok(AdvisoryVulnerabilityHead {
-                head: VulnerabilityHead::from_vulnerability_entity(vulnerability, tx).await?,
+                head,
                 severity: score.severity().to_string(),
                 score: score.value(),
-                non_normative: VulnerabilityHead::from_advisory_vulnerability_entity(
-                    &advisory_vuln,
-                    vulnerability,
-                ),
             })
         } else {
             Err(Error::Data(
@@ -97,14 +97,15 @@ impl AdvisoryVulnerabilityHead {
                 .one(tx)
                 .await?;
             if let Some(advisory_vuln) = advisory_vuln {
+                let head = if vuln.title.is_some() {
+                    VulnerabilityHead::from_vulnerability_entity(vuln, tx).await?
+                } else {
+                    VulnerabilityHead::from_advisory_vulnerability_entity(&advisory_vuln, vuln)
+                };
                 heads.push(AdvisoryVulnerabilityHead {
-                    head: VulnerabilityHead::from_vulnerability_entity(vuln, tx).await?,
+                    head,
                     severity: score.severity().to_string(),
                     score: score.value(),
-                    non_normative: VulnerabilityHead::from_advisory_vulnerability_entity(
-                        &advisory_vuln,
-                        vuln,
-                    ),
                 });
             }
         }

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -54,7 +54,7 @@ impl VulnerabilityDetails {
 
         Ok(VulnerabilityDetails {
             head: VulnerabilityHead {
-                non_normative: false,
+                normative: true,
                 identifier: vulnerability_identifier.to_string(),
                 title: None,
                 description: None,

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -19,7 +19,7 @@ fn is_false(val: &bool) -> bool {
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct VulnerabilityHead {
     #[serde(default, skip_serializing_if = "is_false")]
-    pub non_normative: bool,
+    pub normative: bool,
     pub identifier: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -67,7 +67,7 @@ impl VulnerabilityHead {
         description: Option<String>,
     ) -> Self {
         Self {
-            non_normative: false,
+            normative: true,
             identifier: entity.id.clone(),
             title: entity.title.clone(),
             description,
@@ -85,7 +85,7 @@ impl VulnerabilityHead {
         vuln: &vulnerability::Model,
     ) -> Self {
         Self {
-            non_normative: true,
+            normative: false,
             identifier: vuln.id.clone(),
             title: advisory_vulnerability.title.clone(),
             description: advisory_vulnerability.description.clone(),

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -69,11 +69,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let vuln = vuln.unwrap();
 
-    let vuln = serde_json::to_string_pretty(&vuln)?;
-
-    println!("{vuln}");
-
-    //assert_eq!(1, vuln.advisories.len());
+    assert_eq!(2, vuln.advisories.len());
 
     Ok(())
 }

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -276,19 +276,15 @@ mod tests {
         let db = ctx.db;
         let system = Graph::new(db);
 
-        println!("A");
         let cve1 = system
             .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
-        println!("B");
         let cve2 = system
             .ingest_vulnerability("CVE-123", (), Transactional::None)
             .await?;
-        println!("C");
         let cve3 = system
             .ingest_vulnerability("CVE-456", (), Transactional::None)
             .await?;
-        println!("D");
 
         assert_eq!(cve1.vulnerability.id, cve2.vulnerability.id);
         assert_ne!(cve1.vulnerability.id, cve3.vulnerability.id);


### PR DESCRIPTION
Fixes #543

If we have the CVE ingested, i.e. a Vulnerability record, we'll use its data and declare it "normative". Otherwise, we'll use the non-normative data from the advisory.
