### PR TITLE
chore: enables with-uuid feature

### DIFF
--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -9,7 +9,7 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-sea-orm-migration = { workspace = true, features = ["runtime-tokio-rustls", "sqlx-postgres"] }
+sea-orm-migration = { workspace = true, features = ["runtime-tokio-rustls", "sqlx-postgres", "with-uuid"] }
 tokio = { workspace = true, features = ["full"] }
 trustify-cvss = { workspace = true }
 


### PR DESCRIPTION
I found this while using this tool https://github.com/taiki-e/cargo-hack?tab=readme-ov-file#--each-feature

"_This is useful to check that each feature is working properly_"

The build error: https://gist.github.com/helio-frota/a35c47dda223e471b8b307ecdc991c47

As `sea-orm-migration` https://crates.io/crates/sea-orm-migration/0.12.15/dependencies is using `sea-orm` as dependency, I suspect that in some circumstance it needs to be enabled. 

although it is not in any of these three: https://doc.rust-lang.org/cargo/reference/resolver.html?highlight=feature#feature-resolver-version-2