### PR TITLE
fix: increase recursion limit

### DIFF
--- a/trustd/src/main.rs
+++ b/trustd/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use clap::Parser;
 use std::env;
 use std::process::{ExitCode, Termination};


### PR DESCRIPTION
I was getting

```
   Compiling trustify-trustd v0.1.0-alpha.11 (/Users/dejanb/workspace/github.com/trustification/trustify/trustd)
error: queries overflow the depth limit!
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`trustd`)
  = note: query depth increased by 130 when computing layout of `tracing::instrument::Instrumented<{async block@trustify_module_importer::server::Server::run::{closure#0}::{closure#0}}>`
  ```
trying to compile the latest main