### PR TITLE
chore: avoiding relative path

### DIFF
--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -12,7 +12,7 @@ use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use trustify_module_storage::service::fs::FileSystemBackend;
-use trustify_test_context::TrustifyContext;
+use trustify_test_context::{document_bytes, TrustifyContext};
 
 #[test_context(TrustifyContext, skip_teardown)]
 #[test(actix_web::test)]
@@ -587,7 +587,7 @@ async fn contextual_status(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     let ingestor = IngestorService::new(Graph::new(db.clone()), storage);
 
     // ingest an advisory
-    let data = include_bytes!("../../../../../etc/test-data/csaf/rhsa-2024_3666.json");
+    let data = document_bytes("csaf/rhsa-2024_3666.json").await?;
     let data = ReaderStream::new(&data[..]);
 
     ingestor

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -13,7 +13,7 @@ use trustify_auth::authorizer::Authorizer;
 use trustify_common::{id::Id, model::PaginatedResults};
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::model::IngestResult;
-use trustify_test_context::TrustifyContext;
+use trustify_test_context::{document_bytes, TrustifyContext};
 use uuid::Uuid;
 
 async fn query<S, B>(app: &S, id: &str, q: &str) -> PaginatedResults<SbomPackage>
@@ -80,10 +80,7 @@ where
 
     let request = TestRequest::post()
         .uri("/api/v1/sbom")
-        .set_payload(
-            ctx.document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json")
-                .await?,
-        )
+        .set_payload(document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json").await?)
         .to_request();
 
     let response = actix_web::test::call_service(&app, request).await;

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -20,7 +20,7 @@ use trustify_module_ingestor::graph::{
     Graph,
 };
 use trustify_module_ingestor::service::Discard;
-use trustify_test_context::TrustifyContext;
+use trustify_test_context::{document_bytes, TrustifyContext};
 
 pub struct WithContext {
     pub sbom: SbomContext,
@@ -60,7 +60,7 @@ where
     let start = Instant::now();
     let sbom = info_span!("parse json")
         .in_scope(|| async {
-            let bytes = ctx.document_bytes(sbom).await?;
+            let bytes = document_bytes(sbom).await?;
             p(&bytes[..])
         })
         .await?;

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -12,7 +12,7 @@ use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use trustify_module_storage::service::fs::FileSystemBackend;
-use trustify_test_context::TrustifyContext;
+use trustify_test_context::{document_bytes, document_stream, TrustifyContext};
 
 /// We re-ingest two versions of the same quarkus SBOM. However, as the quarkus SBOM doesn't have
 /// anything in common other than the filename (which doesn't matter), these are considered two
@@ -33,8 +33,7 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("quarkus/v1/quarkus-bom-2.13.8.Final-redhat-00004.json")
-                .await?,
+            document_stream("quarkus/v1/quarkus-bom-2.13.8.Final-redhat-00004.json").await?,
         )
         .await?;
 
@@ -46,8 +45,7 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("quarkus/v2/quarkus-bom-2.13.8.Final-redhat-00004.json")
-                .await?,
+            document_stream("quarkus/v2/quarkus-bom-2.13.8.Final-redhat-00004.json").await?,
         )
         .await?;
 
@@ -124,7 +122,7 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
+            document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
         )
         .await?;
 
@@ -139,7 +137,7 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("nhc/v2/nhc-0.4.z.json.xz").await?,
+            document_stream("nhc/v2/nhc-0.4.z.json.xz").await?,
         )
         .await?;
 
@@ -201,7 +199,7 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
+            document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
         )
         .await?;
 
@@ -217,7 +215,7 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
+            document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
         )
         .await?;
 
@@ -281,7 +279,7 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
+            document_stream("nhc/v1/nhc-0.4.z.json.xz").await?,
         )
         .await?;
 
@@ -300,7 +298,7 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             stream::once({
                 // re-serialize file (non-pretty)
                 let json: Value =
-                    serde_json::from_slice(&ctx.document_bytes("nhc/v1/nhc-0.4.z.json.xz").await?)?;
+                    serde_json::from_slice(&document_bytes("nhc/v1/nhc-0.4.z.json.xz").await?)?;
 
                 let result = serde_json::to_vec(&json).map(Bytes::from);
 
@@ -372,7 +370,7 @@ async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("syft-ubi-example/v1.json.xz").await?,
+            document_stream("syft-ubi-example/v1.json.xz").await?,
         )
         .await?;
 
@@ -388,7 +386,7 @@ async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "test"),
             None,
             Format::SPDX,
-            ctx.document_stream("syft-ubi-example/v2.json.xz").await?,
+            document_stream("syft-ubi-example/v2.json.xz").await?,
         )
         .await?;
 

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -110,7 +110,7 @@ async fn test_parse_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let db = &ctx.db;
     let graph = Graph::new(db.clone());
-    let data = ctx.document_bytes("spdx/broken-refs.json").await?;
+    let data = document_bytes("spdx/broken-refs.json").await?;
     let (storage, _tmp) = FileSystemBackend::for_test().await?;
     let ingestor = IngestorService::new(graph, storage);
     let sbom = SbomService::new(db.clone());

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -184,7 +184,7 @@ mod test {
     use test_context::test_context;
     use test_log::test;
     use trustify_common::db::Transactional;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
@@ -192,8 +192,8 @@ mod test {
         let db = ctx.db;
         let graph = Graph::new(db);
 
-        let data = include_bytes!("../../../../../../etc/test-data/csaf/CVE-2023-20862.json");
-        let digests = Digests::digest(data);
+        let data = document_bytes("csaf/CVE-2023-20862.json").await?;
+        let digests = Digests::digest(&data);
 
         let loader = CsafLoader::new(&graph);
         loader
@@ -273,8 +273,8 @@ mod test {
         let graph = Graph::new(db);
         let loader = CsafLoader::new(&graph);
 
-        let data = include_bytes!("../../../../../../etc/test-data/csaf/rhsa-2024_3666.json");
-        let digests = Digests::digest(data);
+        let data = document_bytes("csaf/rhsa-2024_3666.json").await?;
+        let digests = Digests::digest(&data);
 
         loader.load(("source", "test"), &data[..], &digests).await?;
 

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -169,7 +169,7 @@ mod test {
     use test_log::test;
     use trustify_common::db::Transactional;
     use trustify_common::hashing::Digests;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
@@ -177,8 +177,8 @@ mod test {
         let db = ctx.db;
         let graph = Graph::new(db);
 
-        let data = include_bytes!("../../../../../../etc/test-data/mitre/CVE-2024-28111.json");
-        let digests = Digests::digest(data);
+        let data = document_bytes("mitre/CVE-2024-28111.json").await?;
+        let digests = Digests::digest(&data);
 
         let loaded_vulnerability = graph.get_vulnerability("CVE-2024-28111", ()).await?;
         assert!(loaded_vulnerability.is_none());

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -291,7 +291,7 @@ mod test {
     use crate::graph::Graph;
     use trustify_common::db::Transactional;
     use trustify_common::hashing::Digests;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     use crate::service::advisory::osv::loader::OsvLoader;
 
@@ -301,8 +301,8 @@ mod test {
         let db = ctx.db;
         let graph = Graph::new(db);
 
-        let data = include_bytes!("../../../../../../etc/test-data/osv/RUSTSEC-2021-0079.json");
-        let digests = Digests::digest(data);
+        let data = document_bytes("osv/RUSTSEC-2021-0079.json").await?;
+        let digests = Digests::digest(&data);
 
         let loaded_vulnerability = graph
             .get_vulnerability("CVE-2021-32714", Transactional::None)

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -150,19 +150,23 @@ fn masked<N: Mask>(mask: N, bytes: &[u8]) -> Result<Option<String>, Error> {
 mod test {
     use super::*;
     use test_log::test;
+    use trustify_test_context::document_bytes;
 
     #[test(tokio::test)]
     async fn detection() -> Result<(), anyhow::Error> {
-        let csaf = include_bytes!("../../../../etc/test-data/csaf/CVE-2023-20862.json");
-        assert!(matches!(Format::from_bytes(csaf), Ok(Format::CSAF)));
-        let osv = include_bytes!("../../../../etc/test-data/osv/RUSTSEC-2021-0079.json");
-        assert!(matches!(Format::from_bytes(osv), Ok(Format::OSV)));
-        let cve = include_bytes!("../../../../etc/test-data/mitre/CVE-2024-27088.json");
-        assert!(matches!(Format::from_bytes(cve), Ok(Format::CVE)));
-        let cyclone = include_bytes!("../../../../etc/test-data/zookeeper-3.9.2-cyclonedx.json");
-        assert!(matches!(Format::from_bytes(cyclone), Ok(Format::CycloneDX)));
-        let spdx = include_bytes!("../../../../etc/test-data/ubi9-9.2-755.1697625012.json");
-        assert!(matches!(Format::from_bytes(spdx), Ok(Format::SPDX)));
+        let csaf = document_bytes("csaf/CVE-2023-20862.json").await?;
+        assert!(matches!(Format::from_bytes(&csaf), Ok(Format::CSAF)));
+        let osv = document_bytes("osv/RUSTSEC-2021-0079.json").await?;
+        assert!(matches!(Format::from_bytes(&osv), Ok(Format::OSV)));
+        let cve = document_bytes("mitre/CVE-2024-27088.json").await?;
+        assert!(matches!(Format::from_bytes(&cve), Ok(Format::CVE)));
+        let cyclone = document_bytes("zookeeper-3.9.2-cyclonedx.json").await?;
+        assert!(matches!(
+            Format::from_bytes(&cyclone),
+            Ok(Format::CycloneDX)
+        ));
+        let spdx = document_bytes("ubi9-9.2-755.1697625012.json").await?;
+        assert!(matches!(Format::from_bytes(&spdx), Ok(Format::SPDX)));
         Ok(())
     }
 }

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -77,14 +77,14 @@ mod test {
     use test_context::test_context;
     use test_log::test;
     use trustify_module_storage::service::fs::FileSystemBackend;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn ingest_cyclonedx(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         let db = ctx.db;
         let graph = Graph::new(db);
-        let data = include_bytes!("../../../../../etc/test-data/zookeeper-3.9.2-cyclonedx.json");
+        let data = document_bytes("zookeeper-3.9.2-cyclonedx.json").await?;
 
         let (storage, _tmp) = FileSystemBackend::for_test().await?;
 
@@ -94,8 +94,8 @@ mod test {
             .ingest(
                 ("source", "test"),
                 None,
-                Format::sbom_from_bytes(data)?,
-                stream::iter([Ok::<_, Infallible>(Bytes::from_static(data))]),
+                Format::sbom_from_bytes(&data)?,
+                stream::iter([Ok::<_, Infallible>(Bytes::copy_from_slice(&data))]),
             )
             .await
             .expect("must ingest");

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -71,14 +71,14 @@ mod test {
     use test_context::test_context;
     use test_log::test;
     use trustify_module_storage::service::fs::FileSystemBackend;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn ingest_spdx(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         let db = ctx.db.clone();
         let graph = Graph::new(db);
-        let data = include_bytes!("../../../../../etc/test-data/ubi9-9.2-755.1697625012.json");
+        let data = document_bytes("ubi9-9.2-755.1697625012.json").await?;
 
         let (storage, _tmp) = FileSystemBackend::for_test().await?;
 
@@ -88,8 +88,8 @@ mod test {
             .ingest(
                 ("source", "test"),
                 None,
-                Format::sbom_from_bytes(data)?,
-                stream::iter([Ok::<_, Infallible>(Bytes::from_static(data))]),
+                Format::sbom_from_bytes(&data)?,
+                stream::iter([Ok::<_, Infallible>(Bytes::copy_from_slice(&data))]),
             )
             .await
             .expect("must ingest");


### PR DESCRIPTION
Using .cargo/config.toml creating an env var
called WORKSPACE_ROOT