### PR TITLE
feat: add trustd subcommand to export openapi spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5666,6 +5666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6765,7 +6778,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tracing",
@@ -6978,7 +6991,7 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha2",
  "tempfile",
  "test-context",
@@ -7032,7 +7045,7 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "spdx-expression",
  "spdx-rs",
  "test-context",
@@ -7301,6 +7314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7357,6 +7376,7 @@ dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_json",
+ "serde_yaml 0.9.34+deprecated",
  "utoipa-gen",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,7 @@ rand = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
-utoipa = { workspace = true, features = ["actix_extras"] }
+utoipa = { workspace = true, features = ["actix_extras", "yaml"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web"] }
 
 garage-door = { workspace = true, optional = true }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "garage-door")]
 mod embedded_oidc;
-mod openapi;
+pub mod openapi;
 mod sample_data;
 
 pub use sample_data::sample_data;

--- a/trustd/src/main.rs
+++ b/trustd/src/main.rs
@@ -6,6 +6,7 @@ use std::process::{ExitCode, Termination};
 use tokio::task::{spawn_local, LocalSet};
 
 mod db;
+mod openapi;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(clap::Subcommand, Debug)]
@@ -14,6 +15,8 @@ pub enum Command {
     Api(trustify_server::Run),
     /// Manage the database
     Db(db::Run),
+    /// Access OpenAPI related information of the API server
+    Openapi(openapi::Run),
 }
 
 #[derive(clap::Parser, Debug)]
@@ -33,6 +36,7 @@ impl Trustd {
         match self.command {
             Some(Command::Api(run)) => run.run().await,
             Some(Command::Db(run)) => run.run().await,
+            Some(Command::Openapi(run)) => run.run().await,
             None => pm_mode().await,
         }
     }

--- a/trustd/src/openapi.rs
+++ b/trustd/src/openapi.rs
@@ -1,0 +1,57 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{anyhow, Error, Result};
+
+use trustify_server::openapi::openapi;
+
+#[derive(clap::Args, Debug)]
+pub struct Run {
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Command {
+    Export(Export),
+}
+
+impl Run {
+    pub async fn run(self) -> Result<ExitCode> {
+        use Command::*;
+        match self.command {
+            Export(export) => export.run().await,
+        }
+    }
+}
+
+#[derive(clap::Args, Debug)]
+pub struct Export {
+    /// The file the openapi spec should be exported to
+    #[arg(long, env)]
+    pub file: PathBuf,
+}
+
+impl Export {
+    pub async fn run(self) -> Result<ExitCode> {
+        let doc = match self.file.file_name() {
+            Some(name) => {
+                let name = name.to_string_lossy();
+                if name.is_empty() {
+                    Err(anyhow!("Invalid file name"))
+                } else if name.ends_with(".yml") || name.ends_with(".yaml") {
+                    openapi().to_yaml().map_err(Error::new)
+                } else {
+                    openapi().to_pretty_json().map_err(Error::new)
+                }
+            }
+            None => Err(anyhow!("Invalid file name")),
+        }?;
+
+        match fs::write(self.file, doc) {
+            Ok(_) => Ok(ExitCode::SUCCESS),
+            Err(e) => Err(e.into()),
+        }
+    }
+}


### PR DESCRIPTION
Usage:

```
trustd openapi export --file test.json
```


* defaults to json format
* exports as yaml if file ends with ‘yaml’ or ‘yml’