### PR TITLE
refactor: simplify tests by incorporating more TrustifyContext

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -126,6 +126,7 @@ pub async fn upload(
     let fmt = Format::from_bytes(&bytes)?;
     let payload = ReaderStream::new(&*bytes);
     let result = service.ingest(labels, issuer, fmt, payload).await?;
+    log::info!("Uploaded Advisory: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }
 

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::advisory::model::AdvisoryHead;
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
@@ -9,22 +9,17 @@ use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
     PrivilegesRequired, Scope, UserInteraction,
 };
-use trustify_module_ingestor::graph::{
-    advisory::{
-        advisory_vulnerability::{VersionInfo, VersionSpec},
-        AdvisoryInformation,
-    },
-    Graph,
+use trustify_module_ingestor::graph::advisory::{
+    advisory_vulnerability::{VersionInfo, VersionSpec},
+    AdvisoryInformation,
 };
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn all_advisories(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let graph = Arc::new(Graph::new(db.clone()));
-
-    let advisory = graph
+async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-1",
             ("source", "http://redhat.com/"),
@@ -60,7 +55,7 @@ async fn all_advisories(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    graph
+    ctx.graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -76,7 +71,7 @@ async fn all_advisories(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let fetch = AdvisoryService::new(db);
+    let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
         .fetch_advisories(q(""), Paginated::default(), ())
         .await?;
@@ -85,15 +80,13 @@ async fn all_advisories(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn all_advisories_filtered_by_average_score(
-    ctx: TrustifyContext,
+    ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let graph = Arc::new(Graph::new(db.clone()));
-
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-1",
             ("source", "http://redhat.com/"),
@@ -129,7 +122,7 @@ async fn all_advisories_filtered_by_average_score(
         )
         .await?;
 
-    graph
+    ctx.graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -145,7 +138,7 @@ async fn all_advisories_filtered_by_average_score(
         )
         .await?;
 
-    let fetch = AdvisoryService::new(db);
+    let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
         .fetch_advisories(q("average_score>8"), Paginated::default(), ())
         .await?;
@@ -154,15 +147,13 @@ async fn all_advisories_filtered_by_average_score(
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn all_advisories_filtered_by_average_severity(
-    ctx: TrustifyContext,
+    ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let graph = Arc::new(Graph::new(db.clone()));
-
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-1",
             ("source", "http://redhat.com/"),
@@ -198,7 +189,7 @@ async fn all_advisories_filtered_by_average_severity(
         )
         .await?;
 
-    graph
+    ctx.graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -214,7 +205,7 @@ async fn all_advisories_filtered_by_average_severity(
         )
         .await?;
 
-    let fetch = AdvisoryService::new(db);
+    let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
         .fetch_advisories(q("average_severity>=critical"), Paginated::default(), ())
         .await?;
@@ -225,15 +216,13 @@ async fn all_advisories_filtered_by_average_severity(
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let graph = Arc::new(Graph::new(db.clone()));
-
+async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digests = Digests::digest("RHSA-1");
 
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-1",
             ("source", "http://redhat.com/"),
@@ -295,7 +284,7 @@ async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    graph
+    ctx.graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -311,7 +300,7 @@ async fn single_advisory(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let fetch = AdvisoryService::new(db);
+    let fetch = AdvisoryService::new(ctx.db.clone());
     let jenny256 = Id::sha256(&digests.sha256);
     let jenny384 = Id::sha384(&digests.sha384);
     let jenny512 = Id::sha512(&digests.sha512);

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -1,21 +1,16 @@
 use actix_web::cookie::time::OffsetDateTime;
-use std::sync::Arc;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::query::Query;
 use trustify_common::hashing::Digests;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
-use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn all_organizations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let graph = Arc::new(Graph::new(db.clone()));
-
-    graph
+async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.graph
         .ingest_advisory(
             "CPIC-1",
             ("source", "http://captpickles.com/"),
@@ -31,7 +26,7 @@ async fn all_organizations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::organization::service::OrganizationService::new(db);
+    let service = crate::organization::service::OrganizationService::new(ctx.db.clone());
 
     let orgs = service
         .fetch_organizations(Query::default(), Paginated::default(), ())

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -7,18 +7,14 @@ use test_log::test;
 use trustify_common::db::query::Query;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::product::ProductInformation;
-use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn all_products(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = &ctx.db;
-    let graph = Graph::new(db.clone());
+async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
 
-    let app = caller(&ctx).await?;
-
-    graph
+    ctx.graph
         .ingest_product(
             "Trusted Profile Analyzer",
             ProductInformation {
@@ -28,7 +24,7 @@ async fn all_products(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    graph
+    ctx.graph
         .ingest_product(
             "AMQ Broker",
             ProductInformation {
@@ -51,15 +47,12 @@ async fn all_products(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn one_product(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = &ctx.db;
-    let graph = Graph::new(db.clone());
+async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
 
-    let app = caller(&ctx).await?;
-
-    graph
+    ctx.graph
         .ingest_product(
             "Trusted Profile Analyzer",
             ProductInformation {
@@ -69,7 +62,7 @@ async fn one_product(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(db.clone());
+    let service = crate::product::service::ProductService::new(ctx.db.clone());
 
     let products = service
         .fetch_products(Query::default(), Paginated::default(), ())

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -8,18 +8,15 @@ use crate::test::{caller, CallService};
 use actix_web::test::TestRequest;
 use serde_json::Value;
 use std::str::FromStr;
-use std::sync::Arc;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::{Database, Transactional};
+use trustify_common::db::Transactional;
 use trustify_common::model::PaginatedResults;
 use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
 
-async fn setup(db: &Database) -> Result<(), anyhow::Error> {
-    let graph = Arc::new(Graph::new(db.clone()));
-
+async fn setup(graph: &Graph) -> Result<(), anyhow::Error> {
     let log4j = graph
         .ingest_package(&Purl::from_str("pkg:maven/org.apache/log4j")?, ())
         .await?;
@@ -71,11 +68,11 @@ async fn setup(db: &Database) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn types(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type";
 
@@ -99,11 +96,11 @@ async fn types(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn r#type(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn r#type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven";
 
@@ -130,11 +127,11 @@ async fn r#type(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn type_package(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn type_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j";
 
@@ -164,11 +161,11 @@ async fn type_package(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn type_package_version(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
@@ -191,11 +188,11 @@ async fn type_package_version(ctx: TrustifyContext) -> Result<(), anyhow::Error>
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn package(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
@@ -221,11 +218,11 @@ async fn package(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn version(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
@@ -241,11 +238,11 @@ async fn version(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn base(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn base(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j";
     let request = TestRequest::get().uri(uri).to_request();
@@ -260,11 +257,11 @@ async fn base(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn base_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn base_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/base?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
@@ -275,11 +272,11 @@ async fn base_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn qualified_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
@@ -290,11 +287,11 @@ async fn qualified_packages(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn qualified_packages_filtering(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.db).await?;
-    let app = caller(&ctx).await?;
+async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    setup(&ctx.graph).await?;
+    let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl?q=type=maven";
     let request = TestRequest::get().uri(uri).to_request();

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -312,6 +312,7 @@ pub async fn upload(
     let payload = ReaderStream::new(&*bytes);
 
     let result = service.ingest(labels, None, fmt, payload).await?;
+    log::info!("Uploaded SBOM: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }
 

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1,44 +1,47 @@
-use crate::{configure, sbom::model::SbomPackage, test::CallService};
-use actix_http::{Request, StatusCode};
-use actix_web::{
-    body::MessageBody,
-    dev::{Service, ServiceResponse},
-    test::TestRequest,
-    web, App, Error,
+use crate::{
+    sbom::model::SbomPackage,
+    test::{caller, CallService},
 };
-use futures_util::future::LocalBoxFuture;
+use actix_http::StatusCode;
+use actix_web::test::TestRequest;
 use test_context::test_context;
 use test_log::test;
-use trustify_auth::authorizer::Authorizer;
 use trustify_common::{id::Id, model::PaginatedResults};
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::model::IngestResult;
 use trustify_test_context::{document_bytes, TrustifyContext};
 use uuid::Uuid;
 
-async fn query<S, B>(app: &S, id: &str, q: &str) -> PaginatedResults<SbomPackage>
-where
-    S: Service<Request, Response = ServiceResponse<B>, Error = Error>,
-    B: MessageBody,
-{
-    let uri = format!("/api/v1/sbom/{id}/packages?q={}", urlencoding::encode(q));
-    let req = TestRequest::get().uri(&uri).to_request();
-    actix_web::test::call_and_read_body_json(app, req).await
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn upload(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let app = caller(ctx).await?;
+
+    let request = TestRequest::post()
+        .uri("/api/v1/sbom")
+        .set_payload(document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json").await?)
+        .to_request();
+
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let result: IngestResult = actix_web::test::read_body_json(response).await;
+    log::debug!("ID: {result:?}");
+    assert!(matches!(result.id, Id::Uuid(_)));
+
+    Ok(())
 }
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let app = actix_web::test::init_service(
-        App::new()
-            .service(
-                web::scope("/api")
-                    .configure(|config| configure(config, ctx.db.clone(), ctx.storage.clone())),
-            )
-            .app_data(web::Data::new(Authorizer::new(None))),
-    )
-    .await;
+    async fn query(app: &impl CallService, id: &str, q: &str) -> PaginatedResults<SbomPackage> {
+        let uri = format!("/api/v1/sbom/{id}/packages?q={}", urlencoding::encode(q));
+        let req = TestRequest::get().uri(&uri).to_request();
+        app.call_and_read_body_json(req).await
+    }
 
+    let app = caller(ctx).await?;
     let id = ctx
         .ingest_document("zookeeper-3.9.2-cyclonedx.json")
         .await?
@@ -61,88 +64,39 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// This will upload [`DOC`], and then call the test function, providing the upload id of the document.
-async fn with_upload<F>(ctx: &TrustifyContext, f: F) -> anyhow::Result<()>
-where
-    for<'a> F: FnOnce(IngestResult, &'a dyn CallService) -> LocalBoxFuture<'a, anyhow::Result<()>>,
-{
-    let app = actix_web::test::init_service(
-        App::new()
-            .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
-            .service(
-                web::scope("/api")
-                    .configure(|svc| configure(svc, ctx.db.clone(), ctx.storage.clone())),
-            ),
-    )
-    .await;
-
-    // upload
-
-    let request = TestRequest::post()
-        .uri("/api/v1/sbom")
-        .set_payload(document_bytes("quarkus-bom-2.13.8.Final-redhat-00004.json").await?)
-        .to_request();
-
-    let response = actix_web::test::call_service(&app, request).await;
-
-    log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::CREATED);
-    let result: IngestResult = actix_web::test::read_body_json(response).await;
-
-    log::debug!("ID: {result:?}");
-    assert!(matches!(result.id, Id::Uuid(_)));
-
-    f(result, &app).await?;
-
-    // download
-
-    Ok(())
-}
-
 /// Test setting labels
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn set_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    with_upload(ctx, |result, app| {
-        Box::pin(async move {
-            // update labels
+    let app = caller(ctx).await?;
+    let result = ctx
+        .ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
+        .await?;
+    let request = TestRequest::patch()
+        .uri(&format!("/api/v1/sbom/{}/label", result.id))
+        .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
+        .to_request();
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
-            let request = TestRequest::patch()
-                .uri(&format!("/api/v1/sbom/{}/label", result.id))
-                .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
-                .to_request();
-
-            let response = app.call_service(request).await;
-
-            log::debug!("Code: {}", response.status());
-            assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-            Ok(())
-        })
-    })
-    .await
+    Ok(())
 }
 
 /// Test setting labels, for a document that does not exists
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn set_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    with_upload(ctx, |_result, app| {
-        Box::pin(async move {
-            // update labels
+    let app = caller(ctx).await?;
+    ctx.ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
+        .await?;
+    let request = TestRequest::patch()
+        .uri(&format!("/api/v1/sbom/{}/label", Id::Uuid(Uuid::now_v7())))
+        .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
+        .to_request();
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-            let request = TestRequest::patch()
-                .uri(&format!("/api/v1/sbom/{}/label", Id::Uuid(Uuid::now_v7())))
-                .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
-                .to_request();
-
-            let response = app.call_service(request).await;
-
-            log::debug!("Code: {}", response.status());
-            assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-            Ok(())
-        })
-    })
-    .await
+    Ok(())
 }

--- a/modules/fundamental/src/test.rs
+++ b/modules/fundamental/src/test.rs
@@ -1,12 +1,19 @@
+use crate::configure;
 use actix_http::Request;
-use actix_web::dev::{Service, ServiceResponse};
-use actix_web::Error;
+use actix_web::{
+    dev::{Service, ServiceResponse},
+    web, App, Error,
+};
 use sea_orm::prelude::async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use trustify_auth::authorizer::Authorizer;
+use trustify_test_context::TrustifyContext;
 
 /// A trait wrapping an `impl Service` in a way that we can pass it as a reference.
 #[async_trait(?Send)]
 pub trait CallService {
     async fn call_service(&self, s: Request) -> ServiceResponse;
+    async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T;
 }
 
 #[async_trait(?Send)]
@@ -17,4 +24,20 @@ where
     async fn call_service(&self, r: Request) -> ServiceResponse {
         actix_web::test::call_service(self, r).await
     }
+    async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T {
+        actix_web::test::call_and_read_body_json(self, r).await
+    }
+}
+
+pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService> {
+    Ok(actix_web::test::init_service(
+        App::new()
+            .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
+            .app_data(web::Data::new(Authorizer::new(None)))
+            .service(
+                web::scope("/api")
+                    .configure(|svc| configure(svc, ctx.db.clone(), ctx.storage.clone())),
+            ),
+    )
+    .await)
 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -15,18 +15,15 @@ use trustify_cvss::cvss3::{
 };
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
 use trustify_module_ingestor::graph::vulnerability::VulnerabilityInformation;
-use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = &ctx.db;
-    let graph = Graph::new(db.clone());
+async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
 
-    let app = caller(&ctx).await?;
-
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "CAPT-1",
             ("source", "http://captpickles.com/"),
@@ -62,7 +59,8 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
         )
         .await?;
 
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -82,8 +80,8 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
         .link_to_vulnerability("CVE-345", None, Transactional::None)
         .await?;
 
-    graph.ingest_vulnerability("CVE-123", (), ()).await?;
-    graph.ingest_vulnerability("CVE-345", (), ()).await?;
+    ctx.graph.ingest_vulnerability("CVE-123", (), ()).await?;
+    ctx.graph.ingest_vulnerability("CVE-345", (), ()).await?;
 
     let uri = "/api/v1/vulnerability";
 
@@ -99,15 +97,13 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = &ctx.db;
-    let graph = Graph::new(db.clone());
+async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
 
-    let app = caller(&ctx).await?;
-
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-1",
             ("source", "http://redhat.com/"),
@@ -144,7 +140,8 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let advisory = graph
+    let advisory = ctx
+        .graph
         .ingest_advisory(
             "RHSA-2",
             ("source", "http://redhat.com/"),
@@ -164,7 +161,7 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
         .link_to_vulnerability("CVE-345", None, Transactional::None)
         .await?;
 
-    graph
+    ctx.graph
         .ingest_vulnerability(
             "CVE-123",
             VulnerabilityInformation {

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -1,7 +1,6 @@
-use crate::vulnerability::endpoints::configure;
+use crate::test::{caller, CallService};
 use crate::vulnerability::model::VulnerabilitySummary;
 use actix_web::test::TestRequest;
-use actix_web::{web, App};
 use jsonpath_rust::JsonPathQuery;
 use serde_json::{json, Value};
 use test_context::test_context;
@@ -22,13 +21,10 @@ use trustify_test_context::TrustifyContext;
 #[test_context(TrustifyContext, skip_teardown)]
 #[test(actix_web::test)]
 async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
+    let db = &ctx.db;
     let graph = Graph::new(db.clone());
 
-    let app = actix_web::test::init_service(
-        App::new().service(web::scope("/api").configure(|config| configure(config, db))),
-    )
-    .await;
+    let app = caller(&ctx).await?;
 
     let advisory = graph
         .ingest_advisory(
@@ -94,7 +90,7 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
     let request = TestRequest::get().uri(uri).to_request();
 
     let response: PaginatedResults<VulnerabilitySummary> =
-        actix_web::test::call_and_read_body_json(&app, request).await;
+        app.call_and_read_body_json(request).await;
 
     log::debug!("{:#?}", response);
 
@@ -106,13 +102,10 @@ async fn all_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> 
 #[test_context(TrustifyContext, skip_teardown)]
 #[test(actix_web::test)]
 async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
+    let db = &ctx.db;
     let graph = Graph::new(db.clone());
 
-    let app = actix_web::test::init_service(
-        App::new().service(web::scope("/api").configure(|config| configure(config, db))),
-    )
-    .await;
+    let app = caller(&ctx).await?;
 
     let advisory = graph
         .ingest_advisory(
@@ -187,7 +180,7 @@ async fn one_vulnerability(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
 
     let uri = "/api/v1/vulnerability/CVE-123";
     let request = TestRequest::get().uri(uri).to_request();
-    let response: Value = actix_web::test::call_and_read_body_json(&app, request).await;
+    let response: Value = app.call_and_read_body_json(request).await;
 
     log::debug!("{:#?}", response);
 

--- a/modules/fundamental/tests/sbom/graph.rs
+++ b/modules/fundamental/tests/sbom/graph.rs
@@ -10,14 +10,12 @@ use trustify_entity::relationship::Relationship;
 use trustify_module_fundamental::purl::model::summary::purl::PurlSummary;
 use trustify_module_fundamental::purl::model::PurlHead;
 use trustify_module_fundamental::sbom::service::SbomService;
-use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::TrustifyContext;
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn ingest_sboms(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db);
+async fn ingest_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let system = &ctx.graph;
 
     let sbom_v1 = system
         .ingest_sbom(
@@ -63,13 +61,12 @@ async fn ingest_sboms(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn ingest_and_fetch_sboms_describing_purls(
-    ctx: TrustifyContext,
+    ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db);
+    let system = &ctx.graph;
 
     let sbom_v1 = system
         .ingest_sbom(
@@ -134,13 +131,12 @@ async fn ingest_and_fetch_sboms_describing_purls(
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn ingest_and_locate_sboms_describing_cpes(
-    ctx: TrustifyContext,
+    ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db);
+    let system = &ctx.graph;
 
     let sbom_v1 = system
         .ingest_sbom(
@@ -205,11 +201,10 @@ async fn ingest_and_locate_sboms_describing_cpes(
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn transitive_dependency_of(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db);
+async fn transitive_dependency_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let system = &ctx.graph;
 
     let sbom1 = system
         .ingest_sbom(
@@ -277,14 +272,13 @@ async fn transitive_dependency_of(ctx: TrustifyContext) -> Result<(), anyhow::Er
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn ingest_package_relates_to_package_dependency_of(
-    ctx: TrustifyContext,
+    ctx: &TrustifyContext,
 ) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db.clone());
-    let fetch = SbomService::new(db);
+    let system = &ctx.graph;
+    let fetch = SbomService::new(ctx.db.clone());
 
     let sbom1 = system
         .ingest_sbom(
@@ -373,11 +367,10 @@ async fn ingest_package_relates_to_package_dependency_of(
     Ok(())
 }
 
-#[test_context(TrustifyContext, skip_teardown)]
+#[test_context(TrustifyContext)]
 #[test(tokio::test)]
-async fn sbom_vulnerabilities(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-    let db = ctx.db;
-    let system = Graph::new(db);
+async fn sbom_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let system = &ctx.graph;
 
     log::debug!("{:?}", system);
 


### PR DESCRIPTION
Expanded CallService to return json and added a `caller` helper to return an impl of it, i.e. an App::new configured with the fundamental endpoints. Replaced the `with_upload` async closures with calls to `caller` and `ctx.ingest_document`. Added an explicit test for SBOM uploading in lieu of `with_upload`.