### PR TITLE
Improve the SQL version comparisons:

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -54,6 +54,7 @@ mod m0000445_create_purl_status_cpe;
 mod m0000450_alter_cpe_uuidv5;
 mod m0000460_add_vulnerability_description_adv;
 mod m0000470_cascade_sbom_delete;
+mod m0000475_improve_version_comparison_fns;
 
 pub struct Migrator;
 
@@ -114,6 +115,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000450_alter_cpe_uuidv5::Migration),
             Box::new(m0000460_add_vulnerability_description_adv::Migration),
             Box::new(m0000470_cascade_sbom_delete::Migration),
+            Box::new(m0000475_improve_version_comparison_fns::Migration),
         ]
     }
 }

--- a/migration/src/m0000475_improve_version_comparison_fns.rs
+++ b/migration/src/m0000475_improve_version_comparison_fns.rs
@@ -1,0 +1,63 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000475_improve_version_comparison_fns/semver_cmp.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000475_improve_version_comparison_fns/semver_version_matches.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000475_improve_version_comparison_fns/version_matches.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000345_create_version_comparison_fns/semver_cmp.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000345_create_version_comparison_fns/semver_version_matches.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000345_create_version_comparison_fns/version_matches.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0000475_improve_version_comparison_fns/semver_cmp.sql
+++ b/migration/src/m0000475_improve_version_comparison_fns/semver_cmp.sql
@@ -1,0 +1,128 @@
+
+create or replace function semver_cmp(left_p text, right_p text)
+    returns integer
+as
+$$
+declare
+    left_parts text[];
+    right_parts text[];
+
+    left_major bigint;
+    left_minor bigint;
+    left_patch bigint;
+    left_pre text;
+    left_build text;
+
+    right_major bigint;
+    right_minor bigint;
+    right_patch bigint;
+    right_pre text;
+    right_build text;
+
+    left_numeric bool;
+    right_numeric bool;
+
+    cur integer;
+
+begin
+
+    raise notice 'semver_cmp % %', left_p, right_p;
+
+    left_parts = regexp_split_to_array(left_p, E'\\+');
+    left_build = left_parts[2];
+
+    left_parts = regexp_split_to_array(left_parts[1], E'-');
+    left_pre = left_parts[2];
+
+    left_parts = regexp_split_to_array(left_parts[1], E'\\.');
+    left_major = left_parts[1]::decimal;
+    left_minor = left_parts[2]::decimal;
+    left_patch = left_parts[3]::decimal;
+
+    right_parts = regexp_split_to_array(right_p, E'\\+');
+    right_build = right_parts[2];
+
+    right_parts = regexp_split_to_array(right_parts[1], E'-');
+    right_pre = right_parts[2];
+
+    right_parts = regexp_split_to_array(right_parts[1], E'\\.');
+    right_major = right_parts[1]::decimal;
+    right_minor = right_parts[2]::decimal;
+    right_patch = right_parts[3]::decimal;
+
+    if left_major > right_major then
+        return +1;
+    elsif left_major < right_major then
+        return -1;
+    end if;
+
+    if left_minor > right_minor then
+        return +1;
+    elsif left_minor < right_minor then
+        return -1;
+    end if;
+
+    if left_patch > right_patch then
+        return +1;
+    elsif left_patch < right_patch then
+        return -1;
+    end if;
+
+    if left_pre is null and right_pre is not null then
+        return +1;
+    elsif left_pre is not null and right_pre is null then
+        return -1;
+    elsif left_pre is not null and right_pre is not null then
+        left_parts = regexp_split_to_array(left_pre, E'\\.');
+        right_parts = regexp_split_to_array(right_pre, E'\\.');
+        -- do the hard work
+
+        cur := 0;
+        loop
+            cur := cur + 1;
+
+            left_pre := left_parts[cur];
+            right_pre := right_parts[cur];
+
+            if left_pre is null and right_pre is null then
+                return 0;
+            end if;
+
+            if left_pre is null and right_pre is not null then
+                return -1;
+            elsif left_pre is not null and right_pre is null then
+                return +1;
+            end if;
+
+            left_numeric := is_numeric(left_pre);
+            right_numeric := is_numeric(right_pre);
+
+            if left_numeric and right_numeric then
+                if left_pre::bigint < right_pre::bigint then
+                    return -1;
+                elsif left_pre::bigint > right_pre::bigint then
+                    return +1;
+                end if;
+            else
+                if left_pre < right_pre then
+                    return -1;
+                elsif left_pre > right_pre then
+                    return +1;
+                end if;
+            end if;
+
+            if cur > 10 then
+                exit;
+            end if;
+        end loop;
+    else
+        return 0;
+    end if;
+
+    return null;
+exception
+    when others then
+        return null;
+end
+$$
+    language 'plpgsql';

--- a/migration/src/m0000475_improve_version_comparison_fns/semver_version_matches.sql
+++ b/migration/src/m0000475_improve_version_comparison_fns/semver_version_matches.sql
@@ -1,0 +1,53 @@
+
+create or replace function semver_version_matches(version_p text, range_p version_range)
+    returns bool
+as
+$$
+declare
+    low_end integer;
+    high_end integer;
+begin
+    if range_p.low_version is not null then
+        low_end := semver_cmp(version_p, range_p.low_version);
+    end if;
+
+    if low_end is not null then
+        if range_p.low_inclusive then
+            if low_end < 0 then
+                return false;
+            end if;
+        else
+            if low_end <= 0 then
+                return false;
+            end if;
+        end if;
+
+    end if;
+
+
+    if range_p.high_version is not null then
+        high_end := semver_cmp(version_p, range_p.high_version);
+    end if;
+
+    if high_end is not null then
+        if range_p.high_inclusive then
+            if high_end > 0 then
+                return false;
+            end if;
+        else
+            if high_end >= 0 then
+                return false;
+            end if;
+        end if;
+    end if;
+
+    if low_end is null and high_end is null then
+        return false;
+    end if;
+
+    return true;
+
+end
+$$
+    language 'plpgsql';
+

--- a/migration/src/m0000475_improve_version_comparison_fns/version_matches.sql
+++ b/migration/src/m0000475_improve_version_comparison_fns/version_matches.sql
@@ -1,0 +1,23 @@
+
+
+create or replace function version_matches(version_p text, range_p version_range)
+    returns bool
+as
+$$
+declare
+begin
+    raise notice '%', range_p;
+    return case
+        when range_p.version_scheme_id = 'semver'
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            then semver_version_matches(version_p, range_p)
+        -- TODO when all other version schemes...
+        else
+            -- semver_version_matches(version_p, range_p)
+            FALSE
+    end;
+
+end
+$$
+    language 'plpgsql';

--- a/migration/tests/semver.rs
+++ b/migration/tests/semver.rs
@@ -262,3 +262,39 @@ async fn test_version_matches(ctx: TrustifyContext) -> Result<(), anyhow::Error>
 
     Ok(())
 }
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_version_matches_datelike(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    assert!(
+        version_matches(
+            &ctx.db,
+            "7.1.0-0.20231218164901.0660a66.el9",
+            VersionRange::Range(
+                Version::Inclusive("7.1.0-0.20231218164901.0660a66.el9"),
+                Version::Exclusive("8.1.0-0.20231218164901.0660a66.el9"),
+            )
+        )
+        .await?
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_version_matches_shalike(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    assert!(
+        !version_matches(
+            &ctx.db,
+            "sha256:cab90a3a2eb5bdff7a1420a6d89c64a8d32b1be7bd3ec311e483d2c3b9a47307",
+            VersionRange::Range(
+                Version::Inclusive("7.1.0-0.20231218164901.0660a66.el9"),
+                Version::Exclusive("8.1.0-0.20231218164901.0660a66.el9"),
+            )
+        )
+        .await?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
- use bigger ints for jackholes who version stuff like 202410298675309.
- if a version cmp fails (because a sha:xxx "version" was given) don't fail, just false.

In theory fixes #466.