### PR TITLE
Add cargo xtask validate-openapi command that can be used to validate the generated openapi spec.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,3 +47,5 @@ jobs:
         run: cargo test -- --nocapture
         env:
           RUST_LOG: info,sqlx=error,sea_orm=error
+      - name: Validate Generated Openapi Spec
+        run: cargo xtask validate-openapi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7962,6 +7962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
+name = "xtask"
+version = "0.1.0-alpha.11"
+dependencies = [
+ "anyhow",
+ "clap",
+ "trustify-server",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "server",
     "trustd",
     "test-context",
+    "xtask",
 ]
 
 [workspace.dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0-alpha.11"
+edition = "2021"
+publish = false
+
+[dependencies]
+trustify-server = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,28 @@
+#![allow(clippy::unwrap_used)]
+
+use clap::{Parser, Subcommand};
+
+mod openapi;
+
+#[derive(Debug, Parser)]
+pub struct Xtask {
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Xtask {
+    pub fn run(self) -> anyhow::Result<()> {
+        match self.command {
+            Command::ValidateOpenapi(command) => command.run(),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    ValidateOpenapi(openapi::Validate),
+}
+
+fn main() -> anyhow::Result<()> {
+    Xtask::parse().run()
+}

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -17,7 +17,9 @@ impl Validate {
         } else if command_exists("docker") {
             "docker"
         } else {
-            return Err(anyhow!("Neither podman nor docker is installed"));
+            return Err(anyhow!(
+                "This task requires podman or docker to be installed."
+            ));
         };
 
         let out_dir = env::temp_dir();

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+use std::process::Command;
+use std::{env, fs};
+
+use anyhow::anyhow;
+use clap::Parser;
+
+use trustify_server::openapi::openapi;
+
+#[derive(Debug, Parser)]
+pub struct Validate {}
+
+impl Validate {
+    pub fn run(self) -> anyhow::Result<()> {
+        let command = if command_exists("podman") {
+            "podman"
+        } else if command_exists("docker") {
+            "docker"
+        } else {
+            return Err(anyhow!("Neither podman nor docker is installed"));
+        };
+
+        let out_dir = env::temp_dir();
+        let openapi_yaml = Path::new(&out_dir).join("openapi.yaml");
+
+        println!("Generating openapi.yaml at {:?}", openapi_yaml);
+
+        let doc = openapi()
+            .to_yaml()
+            .map_err(|_| anyhow!("Failed to convert openapi spec to yaml"))?;
+
+        fs::write(openapi_yaml, doc).map_err(|_| anyhow!("Failed to write openapi spec"))?;
+
+        // run the openapi generator validator container
+        if Command::new(command)
+            .args([
+                "run",
+                "--rm",
+                "-v",
+                ".:/src",
+                "docker.io/openapitools/openapi-generator-cli:v7.7.0",
+                "validate",
+                "-i",
+                "/src/openapi.yaml",
+            ])
+            .current_dir(out_dir.to_str().unwrap())
+            .status()
+            .map_err(|_| anyhow!("Failed to validate openapi.yaml"))?
+            .success()
+        {
+            Ok(())
+        } else {
+            Err(anyhow!("Failed to validate openapi.yaml"))
+        }
+    }
+}
+
+fn command_exists(cmd: &str) -> bool {
+    match Command::new("which").arg(cmd).output() {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
+}


### PR DESCRIPTION
Run with:

```
cargo xtask validate-openapi
```