### PR TITLE
Add some corner case tests for SPDX, and fix a discovered issue

### DIFF
--- a/etc/test-data/spdx/double-ref.json
+++ b/etc/test-data/spdx/double-ref.json
@@ -1,0 +1,100 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2023-11-01T13:30:00Z",
+    "creators": [
+      "Trustify"
+    ],
+    "comment": "This is an example for an SBOM with two refs to the same package. Based upon an existing SBOM.",
+    "licenseListVersion": "3.8"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": [
+    "SPDXRef-A"
+  ],
+  "documentNamespace": "uri:just-an-example",
+  "name": "loop",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-A",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "foo",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/A@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "A",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    },
+    {
+      "SPDXID": "SPDXRef-B",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "B",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/B@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "bar",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    },
+    {
+      "SPDXID": "SPDXRef-C",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "B",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:cargo/C@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "bar",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-B",
+      "relationshipType": "CONTAINED_BY",
+      "spdxElementId": "SPDXRef-A"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-C",
+      "relationshipType": "CONTAINED_BY",
+      "spdxElementId": "SPDXRef-B"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-A",
+      "relationshipType": "DEV_DEPENDENCY_OF",
+      "spdxElementId": "SPDXRef-C"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2"
+}

--- a/etc/test-data/spdx/loop.json
+++ b/etc/test-data/spdx/loop.json
@@ -1,0 +1,100 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2023-11-01T13:30:00Z",
+    "creators": [
+      "Trustify"
+    ],
+    "comment": "This is an example for an SBOM with looping refs. Based upon an existing SBOM.",
+    "licenseListVersion": "3.8"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": [
+    "SPDXRef-A"
+  ],
+  "documentNamespace": "uri:just-an-example",
+  "name": "loop",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-A",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "foo",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:cargo/A@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "A",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    },
+    {
+      "SPDXID": "SPDXRef-B",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "B",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:cargo/B@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "bar",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    },
+    {
+      "SPDXID": "SPDXRef-C",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "baz",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:cargo/C@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "C",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-A",
+      "relationshipType": "CONTAINED_BY",
+      "spdxElementId": "SPDXRef-B"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-B",
+      "relationshipType": "CONTAINED_BY",
+      "spdxElementId": "SPDXRef-C"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-C",
+      "relationshipType": "CONTAINED_BY",
+      "spdxElementId": "SPDXRef-A"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2"
+}

--- a/etc/test-data/spdx/self-package.json
+++ b/etc/test-data/spdx/self-package.json
@@ -1,0 +1,45 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2023-11-01T13:30:00Z",
+    "creators": [
+      "Trustify"
+    ],
+    "comment": "This is an example for an SBOM with looping refs. Based upon an existing SBOM.",
+    "licenseListVersion": "3.8"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "uri:just-an-example",
+  "name": "loop",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-A",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "foo",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:cargo/A@0.0.0",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "A",
+      "originator": "NOASSERTION",
+      "packageFileName": "NOASSERTION",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "1"
+    }
+  ],
+  "relationships" : [
+    {
+      "spdxElementId" : "SPDXRef-A",
+      "relatedSpdxElement" : "SPDXRef-A",
+      "relationshipType" : "DESCRIBES"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2"
+}

--- a/etc/test-data/spdx/self.json
+++ b/etc/test-data/spdx/self.json
@@ -1,0 +1,23 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2023-11-01T13:30:00Z",
+    "creators": [
+      "Trustify"
+    ],
+    "comment": "This is an example for an SBOM with looping refs. Based upon an existing SBOM.",
+    "licenseListVersion": "3.8"
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "uri:just-an-example",
+  "name": "loop",
+  "packages": [],
+  "relationships" : [
+    {
+      "spdxElementId" : "SPDXRef-DOCUMENT",
+      "relatedSpdxElement" : "SPDXRef-DOCUMENT",
+      "relationshipType" : "DESCRIBES"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2"
+}

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -2,13 +2,12 @@ mod label;
 #[cfg(test)]
 mod test;
 
-use crate::Error::Internal;
 use crate::{
     sbom::{
         model::{SbomPackageReference, Which},
         service::SbomService,
     },
-    Error,
+    Error::{self, Internal},
 };
 use actix_web::{delete, get, post, web, HttpResponse, Responder};
 use futures_util::TryStreamExt;
@@ -311,7 +310,7 @@ pub async fn related(
             paginated,
             related.which,
             match &related.reference {
-                None => SbomPackageReference::Root,
+                None => SbomPackageReference::All,
                 Some(id) => SbomPackageReference::Package(id),
             },
             related.relationship,

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -53,8 +53,8 @@ pub struct SbomPackage {
 // TODO: think about a way to add CPE and PURLs too
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum SbomPackageReference<'a> {
-    /// Reference the root of an SBOM
-    Root,
+    /// Reference all packages of the SBOM.
+    All,
     /// Reference a package inside an SBOM, by its node id.
     Package(&'a str),
 }
@@ -67,7 +67,7 @@ impl<'a> From<&'a str> for SbomPackageReference<'a> {
 
 impl<'a> From<()> for SbomPackageReference<'a> {
     fn from(_value: ()) -> Self {
-        Self::Root
+        Self::All
     }
 }
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -287,7 +287,7 @@ impl SbomService {
             Default::default(),
             paginated,
             Which::Right,
-            SbomPackageReference::Root,
+            SbomPackageReference::All,
             Some(Relationship::DescribedBy),
             tx,
         )
@@ -390,7 +390,7 @@ impl SbomService {
         // filter for reference
 
         query = match reference.into() {
-            SbomPackageReference::Root => {
+            SbomPackageReference::All => {
                 // sbom - add join to sbom table
                 query.join(JoinType::Join, sbom_node::Relation::Sbom.def())
             }

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -1,3 +1,4 @@
+mod corner_cases;
 mod perf;
 
 use super::*;

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -47,7 +47,7 @@ async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(packages.total, 1);
 
     let packages = service
-        .related_packages(id, None, SbomPackageReference::Root, ())
+        .related_packages(id, None, SbomPackageReference::All, ())
         .await?;
 
     log::info!("Packages: {packages:#?}");
@@ -86,7 +86,7 @@ async fn double_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(packages.len(), 3);
 
     let packages = service
-        .related_packages(id, None, SbomPackageReference::Root, ())
+        .related_packages(id, None, SbomPackageReference::All, ())
         .await?;
 
     log::info!("Packages: {packages:#?}");
@@ -125,7 +125,7 @@ async fn self_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(packages.len(), 0);
 
     let packages = service
-        .related_packages(id, None, SbomPackageReference::Root, ())
+        .related_packages(id, None, SbomPackageReference::All, ())
         .await?;
 
     log::info!("Packages: {packages:#?}");
@@ -164,7 +164,7 @@ async fn self_ref_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(packages.len(), 1);
 
     let packages = service
-        .related_packages(id, None, SbomPackageReference::Root, ())
+        .related_packages(id, None, SbomPackageReference::All, ())
         .await?;
 
     log::info!("Packages: {packages:#?}");

--- a/modules/fundamental/tests/sbom/spdx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/spdx/corner_cases.rs
@@ -95,3 +95,89 @@ async fn double_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     Ok(())
 }
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn self_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("spdx/self.json").await?;
+
+    let Id::Uuid(id) = result.id else {
+        bail!("must be an id")
+    };
+    let sbom = ctx
+        .graph
+        .get_sbom_by_id(id, ())
+        .await?
+        .expect("must be found");
+
+    let service = SbomService::new(ctx.db.clone());
+    let packages = service
+        .fetch_sbom_packages(id, Default::default(), Default::default(), ())
+        .await?;
+
+    assert_eq!(packages.total, 0);
+
+    let purl = Purl::try_from("pkg:cargo/A@0.0.0").expect("must parse");
+    let packages = sbom
+        .related_packages_transitively(Relationship::VARIANTS, &purl, ())
+        .await?;
+
+    assert_eq!(packages.len(), 0);
+
+    let packages = service
+        .related_packages(id, None, SbomPackageReference::Root, ())
+        .await?;
+
+    log::info!("Packages: {packages:#?}");
+
+    assert_eq!(packages.len(), 0);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn self_ref_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("spdx/self-package.json").await?;
+
+    let Id::Uuid(id) = result.id else {
+        bail!("must be an id")
+    };
+    let sbom = ctx
+        .graph
+        .get_sbom_by_id(id, ())
+        .await?
+        .expect("must be found");
+
+    let service = SbomService::new(ctx.db.clone());
+    let packages = service
+        .fetch_sbom_packages(id, Default::default(), Default::default(), ())
+        .await?;
+
+    assert_eq!(packages.total, 1);
+
+    let purl = Purl::try_from("pkg:cargo/A@0.0.0").expect("must parse");
+    let packages = sbom
+        .related_packages_transitively(Relationship::VARIANTS, &purl, ())
+        .await?;
+
+    assert_eq!(packages.len(), 1);
+
+    let packages = service
+        .related_packages(id, None, SbomPackageReference::Root, ())
+        .await?;
+
+    log::info!("Packages: {packages:#?}");
+
+    assert_eq!(packages.len(), 1);
+
+    let packages = service
+        .related_packages(id, None, SbomPackageReference::Package("SPDXRef-A"), ())
+        .await?;
+
+    log::info!("Packages: {packages:#?}");
+
+    assert_eq!(packages.len(), 1);
+
+    Ok(())
+}

--- a/modules/fundamental/tests/spdx.rs
+++ b/modules/fundamental/tests/spdx.rs
@@ -1,0 +1,97 @@
+#![allow(clippy::expect_used)]
+
+use anyhow::bail;
+use strum::VariantArray;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::{id::Id, purl::Purl};
+use trustify_entity::relationship::Relationship;
+use trustify_module_fundamental::sbom::model::SbomPackageReference;
+use trustify_module_fundamental::sbom::service::SbomService;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn infinite_loop(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = SbomService::new(ctx.db.clone());
+
+    let result = ctx.ingest_document("spdx/loop.json").await?;
+
+    let Id::Uuid(id) = result.id else {
+        bail!("must be an id")
+    };
+
+    let sbom = ctx
+        .graph
+        .get_sbom_by_id(id, ())
+        .await?
+        .expect("must be found");
+
+    let packages = service
+        .fetch_sbom_packages(id, Default::default(), Default::default(), ())
+        .await?;
+
+    assert_eq!(packages.total, 3);
+
+    let purl = Purl::try_from("pkg:cargo/A@0.0.0").expect("must parse");
+    let packages = sbom
+        .related_packages_transitively(Relationship::VARIANTS, &purl, ())
+        .await?;
+
+    assert_eq!(packages.len(), 3);
+
+    let packages = service
+        .describes_packages(id, Default::default(), ())
+        .await?;
+
+    assert_eq!(packages.total, 1);
+
+    let packages = service
+        .related_packages(id, None, SbomPackageReference::Root, ())
+        .await?;
+
+    log::info!("Packages: {packages:#?}");
+
+    assert_eq!(packages.len(), 3);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn double_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("spdx/double-ref.json").await?;
+
+    let Id::Uuid(id) = result.id else {
+        bail!("must be an id")
+    };
+    let sbom = ctx
+        .graph
+        .get_sbom_by_id(id, ())
+        .await?
+        .expect("must be found");
+
+    let service = SbomService::new(ctx.db.clone());
+    let packages = service
+        .fetch_sbom_packages(id, Default::default(), Default::default(), ())
+        .await?;
+
+    assert_eq!(packages.total, 3);
+
+    let purl = Purl::try_from("pkg:cargo/A@0.0.0").expect("must parse");
+    let packages = sbom
+        .related_packages_transitively(Relationship::VARIANTS, &purl, ())
+        .await?;
+
+    assert_eq!(packages.len(), 3);
+
+    let packages = service
+        .related_packages(id, None, SbomPackageReference::Root, ())
+        .await?;
+
+    log::info!("Packages: {packages:#?}");
+
+    assert_eq!(packages.len(), 3);
+
+    Ok(())
+}

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -60,10 +60,7 @@ impl TrustifyContext {
         let format = Format::from_bytes(&bytes)?;
         let stream = ReaderStream::new(bytes.as_ref());
 
-        self.ingestor
-            .ingest((), None, format, stream)
-            .await
-            .map_err(|e| e.into())
+        Ok(self.ingestor.ingest((), None, format, stream).await?)
     }
 }
 


### PR DESCRIPTION
This fixes the two issues of https://github.com/trustification/trustify/discussions/555 but removing duplicated during the conversion and by renaming the enum variant to `All`, which better reflects what it currently does.