### PR TITLE
chore: tweak embedded database settings

### DIFF
--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -131,7 +131,8 @@ impl Database {
         log::debug!("connect to {}", url);
 
         let mut opt = ConnectOptions::new(url);
-        opt.min_connections(16);
+        opt.max_connections(300);
+        opt.min_connections(75);
         opt.sqlx_logging_level(log::LevelFilter::Trace);
 
         let db = sea_orm::Database::connect(opt).await?;

--- a/trustd/src/db.rs
+++ b/trustd/src/db.rs
@@ -68,10 +68,14 @@ impl Run {
         let db_dir = work_dir.join("postgres");
         let data_dir = work_dir.join("data");
         create_dir_all(&data_dir)?;
-        let configuration = HashMap::from([(
-            "shared_preload_libraries".to_string(),
-            "pg_stat_statements".to_string(),
-        )]);
+        let configuration = HashMap::from([
+            (
+                "shared_preload_libraries".to_string(),
+                "pg_stat_statements".to_string(),
+            ),
+            ("random_page_cost".to_string(), "1.1".to_string()),
+            ("max_connections".to_string(), "500".to_string()),
+        ]);
         let settings = postgresql_embedded::Settings {
             version: VersionReq::parse("=16.3.0")?,
             username: self.database.username.clone(),


### PR DESCRIPTION
Set the embedded_pg to more 'modern' settings:

From trustify we set

* db max conns = 300
* db min conns = 75

and in pg config
* **max_connections**=500

which lets the database 'breath'.

Additionally set **random_page_cost** to 1.1 because we all have SSD these days and the default setting of 4 is for _spinning rust_. There are a lot of pg configs that have dramatically conservative defaults which we can revisit but wanted to establish a baseline for the embedded_pg.