### PR TITLE
Adding a criterion based benchmark for csaf ingestion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1065,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1137,33 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1314,6 +1353,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2367,6 +2444,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "handlebars"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3160,17 @@ checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3874,6 +3972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "openid"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,6 +4582,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,6 +4918,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -6693,6 +6845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7124,6 +7286,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "cpe",
+ "criterion",
  "cyclonedx-bom",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,8 +1467,7 @@ dependencies = [
 [[package]]
 name = "csaf"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27cd52df4e45d45d30c254c75bcb1700e11722181b350f9fb4427a7beefcc1bc"
+source = "git+https://github.com/chirino/csaf-rs?rev=414896904bc5e5287fd88b1daef5c27f70503d01#414896904bc5e5287fd88b1daef5c27f70503d01"
 dependencies = [
  "chrono",
  "cpe",
@@ -7287,6 +7286,7 @@ dependencies = [
  "chrono",
  "cpe",
  "criterion",
+ "csaf",
  "cyclonedx-bom",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7293,6 +7293,7 @@ dependencies = [
  "humantime",
  "jsonpath-rust",
  "log",
+ "packageurl",
  "sea-orm",
  "sea-query",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ base64 = "0.22"
 biscuit = "0.7"
 bytes = "1.5"
 bytesize = "1.3"
+criterion = "0.5.1"
 chrono = { version = "0.4.35", default-features = false }
 clap = "4"
 concat-idents = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,3 +165,5 @@ postgresql_embedded = { version = "0.14.0", default-features = false, features =
 
 # required due to https://github.com/KenDJohnson/cpe-rs/pull/15
 cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
+# required due to https://github.com/voteblake/csaf-rs/pull/29
+csaf = { git = "https://github.com/chirino/csaf-rs", rev = "414896904bc5e5287fd88b1daef5c27f70503d01" }

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -53,6 +53,7 @@ trustify-test-context = { workspace = true }
 urlencoding = { workspace = true }
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
 csaf = { workspace = true }
+packageurl = { workspace = true }
 
 [[bench]]
 name = "bench"

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -51,3 +51,9 @@ tokio-util = { workspace = true }
 trustify-cvss = { workspace = true }
 trustify-test-context = { workspace = true }
 urlencoding = { workspace = true }
+criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "bench"
+path = "benches/bench.rs"
+harness = false

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -52,6 +52,7 @@ trustify-cvss = { workspace = true }
 trustify-test-context = { workspace = true }
 urlencoding = { workspace = true }
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
+csaf = { workspace = true }
 
 [[bench]]
 name = "bench"

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -1,40 +1,115 @@
-use criterion::{criterion_group, criterion_main};
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 pub(crate) mod trustify_benches {
-    use criterion::Criterion;
+    use std::future::Future;
     use std::io;
+    use std::io::Error;
+    use std::ops::Add;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use bytes::Bytes;
+    use criterion::{black_box, Criterion};
+    use csaf::Csaf;
+    use futures_util::stream;
+    use futures_util::stream::Once;
+    use sea_orm::ConnectionTrait;
     use test_context::AsyncTestContext;
     use tokio::runtime::Runtime;
 
+    use trustify_common::db::Transactional;
     use trustify_entity::labels::Labels;
     use trustify_module_ingestor::service::Format;
-    use trustify_test_context::{document_stream, TrustifyContext};
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
-    fn setup_runtime_and_ctx() -> (Runtime, TrustifyContext) {
+    pub fn ingestion(c: &mut Criterion) {
+        let (runtime, ctx) = setup_runtime_and_ctx();
+        c.bench_function("ingestion_csaf", |b| {
+            b.to_async(&runtime).iter_custom(|count| {
+                let ctx = ctx.clone();
+                async move {
+                    reset_db(&ctx).await;
+
+                    let mut duration = Duration::default();
+                    for i in 0..count {
+                        let stream =
+                            document_stream_generated_from("csaf/cve-2023-33201.json", i).await;
+
+                        let start = Instant::now();
+                        black_box(
+                            ctx.ingestor
+                                .ingest::<_, io::Error>(
+                                    Labels::default(),
+                                    None,
+                                    Format::CSAF,
+                                    stream,
+                                )
+                                .await
+                                .expect("ingest ok"),
+                        );
+                        duration = duration.add(start.elapsed())
+                    }
+
+                    duration
+                }
+            });
+        });
+    }
+
+    async fn document_stream_generated_from(
+        path: &str,
+        rev: u64,
+    ) -> Once<impl Future<Output = Result<Bytes, Error>> + Sized> {
+        let payload = document_bytes(path).await.expect("load ok");
+        let mut doc: Csaf = serde_json::from_slice(payload.as_ref()).expect("parse ok");
+        doc.document.tracking.id = format!("{}-{}", doc.document.tracking.id, rev);
+        let data = serde_json::to_vec_pretty(&doc).expect("serialize ok");
+        stream::once(async { Ok(Bytes::from(data)) })
+    }
+
+    fn setup_runtime_and_ctx() -> (Runtime, Arc<TrustifyContext>) {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
         let ctx = runtime.block_on(async { TrustifyContext::setup().await });
-        (runtime, ctx)
+        (runtime, Arc::new(ctx))
     }
 
-    pub fn ingestion(c: &mut Criterion) {
-        let (runtime, ctx) = setup_runtime_and_ctx();
-        c.bench_function("ingestion_csaf", |b| {
-            b.to_async(&runtime).iter(|| async {
-                // todo: how do we reset the deb so we can re-import the doc?
-                let payload = document_stream("csaf/cve-2023-33201.json")
-                    .await
-                    .expect("load ok");
-                ctx.ingestor
-                    .ingest::<_, io::Error>(Labels::default(), None, Format::CSAF, payload)
-                    .await
-                    .expect("ingest ok");
-            });
-        });
+    async fn reset_db(ctx: &Arc<TrustifyContext>) {
+        // reset DB tables to a clean state...
+        for table in [
+            "advisory",
+            "base_purl",
+            "versioned_purl",
+            "qualified_purl",
+            "cvss3",
+            "cpe",
+            "version_range",
+            "vulnerability",
+        ] {
+            ctx.db
+                .clone()
+                .connection(&Transactional::None)
+                .execute_unprepared(format!("DELETE FROM {table} WHERE 1=1").as_str())
+                .await
+                .expect("DELETE ok");
+        }
+        ctx.db
+            .clone()
+            .connection(&Transactional::None)
+            .execute_unprepared("VACUUM ANALYZE")
+            .await
+            .expect("vacuum analyze ok");
     }
 }
-criterion_group!(benches, trustify_benches::ingestion);
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().measurement_time(Duration::from_secs(15));
+  targets = trustify_benches::ingestion
+}
 criterion_main!(benches);

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -1,0 +1,40 @@
+use criterion::{criterion_group, criterion_main};
+
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+pub(crate) mod trustify_benches {
+    use criterion::Criterion;
+    use std::io;
+    use test_context::AsyncTestContext;
+    use tokio::runtime::Runtime;
+
+    use trustify_entity::labels::Labels;
+    use trustify_module_ingestor::service::Format;
+    use trustify_test_context::{document_stream, TrustifyContext};
+
+    fn setup_runtime_and_ctx() -> (Runtime, TrustifyContext) {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let ctx = runtime.block_on(async { TrustifyContext::setup().await });
+        (runtime, ctx)
+    }
+
+    pub fn ingestion(c: &mut Criterion) {
+        let (runtime, ctx) = setup_runtime_and_ctx();
+        c.bench_function("ingestion_csaf", |b| {
+            b.to_async(&runtime).iter(|| async {
+                // todo: how do we reset the deb so we can re-import the doc?
+                let payload = document_stream("csaf/cve-2023-33201.json")
+                    .await
+                    .expect("load ok");
+                ctx.ingestor
+                    .ingest::<_, io::Error>(Labels::default(), None, Format::CSAF, payload)
+                    .await
+                    .expect("ingest ok");
+            });
+        });
+    }
+}
+criterion_group!(benches, trustify_benches::ingestion);
+criterion_main!(benches);

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -8,14 +8,21 @@ pub(crate) mod trustify_benches {
     use std::io;
     use std::io::Error;
     use std::ops::Add;
+    use std::str::FromStr;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use bytes::Bytes;
+    use cpe::cpe::Cpe;
+    use cpe::uri::OwnedUri;
     use criterion::{black_box, Criterion};
+    use csaf::definitions::{BranchesT, ProductIdentificationHelper};
+    use csaf::product_tree::ProductTree;
+    use csaf::vulnerability::Vulnerability;
     use csaf::Csaf;
     use futures_util::stream;
     use futures_util::stream::Once;
+    use packageurl::PackageUrl;
     use sea_orm::ConnectionTrait;
     use test_context::AsyncTestContext;
     use tokio::runtime::Runtime;
@@ -31,10 +38,12 @@ pub(crate) mod trustify_benches {
             b.to_async(&runtime).iter_custom(|count| {
                 let ctx = ctx.clone();
                 async move {
+                    log::info!("db reset...");
                     reset_db(&ctx).await;
 
                     let mut duration = Duration::default();
                     for i in 0..count {
+                        log::info!("inserting document {}...", i);
                         let stream =
                             document_stream_generated_from("csaf/cve-2023-33201.json", i).await;
 
@@ -50,7 +59,7 @@ pub(crate) mod trustify_benches {
                                 .await
                                 .expect("ingest ok"),
                         );
-                        duration = duration.add(start.elapsed())
+                        duration = duration.add(start.elapsed());
                     }
 
                     duration
@@ -66,6 +75,73 @@ pub(crate) mod trustify_benches {
         let payload = document_bytes(path).await.expect("load ok");
         let mut doc: Csaf = serde_json::from_slice(payload.as_ref()).expect("parse ok");
         doc.document.tracking.id = format!("{}-{}", doc.document.tracking.id, rev);
+
+        fn rev_branches(branches: &mut Option<BranchesT>, rev: u64) {
+            if let Some(BranchesT(branches)) = branches {
+                for branch in branches.iter_mut() {
+                    if let Some(product) = &mut branch.product {
+                        rev_product_helper(&mut product.product_identification_helper, rev);
+                    }
+                    rev_branches(&mut branch.branches, rev);
+                }
+            }
+        }
+
+        fn rev_product_helper(helper: &mut Option<ProductIdentificationHelper>, rev: u64) {
+            if let Some(helper) = helper {
+                if let Some(cpe) = &mut helper.cpe {
+                    helper.cpe = Some(rev_cpe(cpe, rev))
+                }
+                if let Some(purl) = &mut helper.purl {
+                    helper.purl = Some(rev_purl(purl.clone(), rev));
+                }
+            }
+        }
+
+        fn rev_purl(from: PackageUrl, rev: u64) -> PackageUrl {
+            let name = from.name();
+            let new_name = format!("{}-{}", name, rev);
+            PackageUrl::from_str(
+                from.to_string()
+                    .replacen(name, new_name.as_str(), 1)
+                    .as_str(),
+            )
+            .unwrap()
+        }
+        fn rev_cpe(cpe: &OwnedUri, rev: u64) -> OwnedUri {
+            let uri = format!("{:0}", cpe);
+            let mut uri = cpe::uri::Uri::parse(uri.as_str()).unwrap();
+            let x = format!("{}_{}", uri.product(), rev);
+            uri.set_product(x.as_str()).unwrap();
+            uri.to_owned()
+        }
+        fn rev_product_tree(product_tree: &mut ProductTree, rev: u64) {
+            rev_branches(&mut product_tree.branches, rev);
+            for relationships in product_tree.relationships.iter_mut() {
+                for relationship in relationships.iter_mut() {
+                    // rev_product_id(&mut relationship.full_product_name.product_id, rev);
+                    rev_product_helper(
+                        &mut relationship.full_product_name.product_identification_helper,
+                        rev,
+                    );
+                }
+            }
+        }
+        fn rev_vulnerability(vulnerability: &mut Vulnerability, rev: u64) {
+            for cve in vulnerability.cve.iter_mut() {
+                *cve = format!("{}-{}", cve, rev);
+            }
+        }
+
+        for product_tree in doc.product_tree.iter_mut() {
+            rev_product_tree(product_tree, rev);
+        }
+        for vulnerabilities in doc.vulnerabilities.iter_mut() {
+            for vulnerability in vulnerabilities.iter_mut() {
+                rev_vulnerability(vulnerability, rev);
+            }
+        }
+
         let data = serde_json::to_vec_pretty(&doc).expect("serialize ok");
         stream::once(async { Ok(Bytes::from(data)) })
     }
@@ -109,7 +185,12 @@ pub(crate) mod trustify_benches {
 
 criterion_group! {
   name = benches;
-  config = Criterion::default().measurement_time(Duration::from_secs(15));
+  // since insertion takes so long, we need to reduce the sample
+  // size and increase the time so that we can get a few iterations
+  // in between db resets.
+  config = Criterion::default()
+    .measurement_time(Duration::from_secs(15))
+    .sample_size(10);
   targets = trustify_benches::ingestion
 }
 criterion_main!(benches);


### PR DESCRIPTION
if you run `cargo bench` with this patch you can then 

```
open target/criterion/report/index.html
```

to view the benchmark report.  If you re-run the benchmark, it will show you perf difference compared to the previous run.