### PR TITLE
GraphQL: Retrieve CVEs by Sbom with impacted packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6910,6 +6910,7 @@ dependencies = [
  "actix-http",
  "actix-web",
  "anyhow",
+ "async-graphql",
  "bytes",
  "bytesize",
  "chrono",

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -52,15 +52,6 @@ impl AsRef<Transactional> for () {
     }
 }
 
-/*
-impl<'db> From<&'db DatabaseTransaction> for Transactional<'db> {
-    fn from(inner: &'db DatabaseTransaction) -> Self {
-        Self::Some(inner)
-    }
-}
-
- */
-
 #[derive(Clone)]
 pub enum ConnectionOrTransaction<'db> {
     Connection(&'db DatabaseConnection),

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -15,6 +15,7 @@ trustify-module-storage = { workspace = true }
 actix-http = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
+async-graphql = { workspace = true, features = ["uuid", "time"] }
 cpe = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -4,6 +4,7 @@ use crate::purl::model::summary::purl::PurlSummary;
 use crate::sbom::model::{SbomHead, SbomPackage};
 use crate::sbom::service::sbom::QueryCatcher;
 use crate::Error;
+use async_graphql::SimpleObject;
 use cpe::uri::OwnedUri;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -149,10 +150,12 @@ impl SbomAdvisory {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema, SimpleObject)]
+#[graphql(concrete(name = "SbomStatus", params()))]
 pub struct SbomStatus {
     pub vulnerability_id: String,
     pub status: String,
+    #[graphql(skip)]
     pub context: Option<StatusContext>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub packages: Vec<SbomPackage>,

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -1,6 +1,7 @@
 pub mod details;
 
 use crate::purl::model::summary::purl::PurlSummary;
+use async_graphql::SimpleObject;
 use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -39,12 +40,14 @@ pub struct SbomSummary {
 
 paginated!(SbomSummary);
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject)]
+#[graphql(concrete(name = "SbomPackage", params()))]
 pub struct SbomPackage {
     pub id: String,
     pub name: String,
     pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[graphql(skip)]
     pub purl: Vec<PurlSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cpe: Vec<String>,

--- a/modules/graphql/src/endpoints.rs
+++ b/modules/graphql/src/endpoints.rs
@@ -1,7 +1,6 @@
 use actix_web::{guard, web, HttpResponse, Result};
 use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_actix_web::GraphQL;
-use std::sync::Arc;
 use trustify_common::db::Database;
 use trustify_module_ingestor::graph::Graph;
 
@@ -13,10 +12,10 @@ async fn index_graphiql() -> Result<HttpResponse> {
         .body(GraphiQLSource::build().endpoint("/graphql").finish()))
 }
 
-pub fn configure(svc: &mut web::ServiceConfig, db: Database, graph: Arc<Graph>) {
+pub fn configure(svc: &mut web::ServiceConfig, db: Database, graph: Graph) {
     let schema = Schema::build(RootQuery::default(), EmptyMutation, EmptySubscription)
-        .data::<Arc<Graph>>(graph)
-        .data::<Arc<Database>>(Arc::new(db))
+        .data::<Graph>(graph)
+        .data::<Database>(db)
         .finish();
 
     svc.service(

--- a/modules/graphql/src/lib.rs
+++ b/modules/graphql/src/lib.rs
@@ -2,6 +2,7 @@ pub mod advisory;
 pub mod endpoints;
 pub mod organization;
 pub mod sbom;
+pub mod sbomstatus;
 pub mod vulnerability;
 
 use async_graphql::MergedObject;
@@ -12,4 +13,5 @@ pub struct RootQuery(
     organization::OrganizationQuery,
     sbom::SbomQuery,
     vulnerability::VulnerabilityQuery,
+    sbomstatus::SbomStatusQuery,
 );

--- a/modules/graphql/src/sbom.rs
+++ b/modules/graphql/src/sbom.rs
@@ -1,4 +1,4 @@
-use async_graphql::*;
+use async_graphql::{Context, FieldError, FieldResult, Object};
 use std::sync::Arc;
 use trustify_common::db::Transactional;
 use trustify_entity::labels::Labels;

--- a/modules/graphql/src/sbom.rs
+++ b/modules/graphql/src/sbom.rs
@@ -1,4 +1,4 @@
-use async_graphql::{Context, FieldError, FieldResult, Object};
+use async_graphql::*;
 use std::sync::Arc;
 use trustify_common::db::Transactional;
 use trustify_entity::labels::Labels;

--- a/modules/graphql/src/sbomstatus.rs
+++ b/modules/graphql/src/sbomstatus.rs
@@ -1,0 +1,34 @@
+use actix_web::web;
+use async_graphql::{Context, FieldResult, Object};
+use std::sync::Arc;
+use trustify_common::db::{Database, Transactional};
+use trustify_common::id::Id;
+use trustify_module_fundamental::sbom::model::details::SbomStatus;
+use trustify_module_fundamental::sbom::service::SbomService;
+use uuid::Uuid;
+
+#[derive(Default)]
+pub struct SbomStatusQuery;
+
+#[Object]
+impl SbomStatusQuery {
+    async fn cves_by_sbom<'a>(&self, ctx: &Context<'a>, id: Uuid) -> FieldResult<Vec<SbomStatus>> {
+        let db = ctx.data::<Arc<Database>>()?;
+        let service = SbomService::new((*(Arc::clone(db))).clone());
+        let sbom_service = web::Data::new(service);
+
+        let sbom_details: Option<trustify_module_fundamental::sbom::model::details::SbomDetails> =
+            match sbom_service
+                .fetch_sbom(Id::Uuid(id), Transactional::None)
+                .await
+            {
+                Ok(sbom) => sbom,
+                _ => None,
+            };
+
+        match sbom_details {
+            Some(sbom) => Ok(sbom.advisories[0].status.clone()),
+            None => Ok(vec![]),
+        }
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -295,7 +295,7 @@ fn configure(
     auth: Option<Arc<Authenticator>>,
     ui: Arc<UiResources>,
 ) {
-    let graph = Arc::new(Graph::new(db.clone()));
+    let graph = Graph::new(db.clone());
 
     // set global request limits
 
@@ -347,7 +347,7 @@ fn configure(
                 trustify_module_graphql::endpoints::configure_graphiql(svc);
             }),
     );
-    svc.app_data(web::Data::from(graph))
+    svc.app_data(graph)
         .service(web::scope("/api").wrap(new_auth(auth)).configure(|svc| {
             trustify_module_importer::endpoints::configure(svc, db.clone());
 


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/TC-1643

Because GraphQL types have to be either a primitive type or an already defined type the following two types are not yet defined and have been skipped for now :
- `StatusContext`
- `PurlSummary` of `SbomPackage`

`StatusContext` will be address using a wrapper : https://async-graphql.github.io/async-graphql/en/define_enum.html#wrapping-a-remote-enum
For the latter, this will imply defining all the sub-structures.

Here is an example of this query for a given SBOM uuid :
```
# curl -s localhost:8080/graphql -H "Content-Type: application/json" -d '{ "query": "{cvesBySbom(id: \"urn:uuid:0190e3b6-df89-79d0-8ef2-8a3c1051aecb\") {vulnerabilityId, status, packages {id, name, version}}}" }' 


  "data": {
    "cvesBySbom": [
      {
        "vulnerabilityId": "CVE-2024-2700",
        "status": "not_affected",
        "packages": [
          {
            "id": "SPDXRef-a8990972-32d2-44a6-b479-743788c3454a",
            "name": "virtual-list",
            "version": "24.0.5"
          },
          {
            "id": "SPDXRef-e09632af-8ea9-43fa-a4ff-d45c24a6aa80",
            "name": "quarkus-bootstrap-core",
            "version": "3.2.11.Final-redhat-00001"
          },
          {
            "id": "SPDXRef-02643e66-272c-45ec-a0ca-1918956a6384",
            "name": "path-to-regexp",
            "version": "2.4.0"
          },
          {
            "id": "SPDXRef-e11799e4-63c6-4f83-a0d5-0e164bd523d3",
            "name": "quarkus-extension-processor",
            "version": "3.2.11.Final-redhat-00001"
          },
          {
            "id": "SPDXRef-a035f8b3-63f7-4952-b1fe-47551779cd89",
            "name": "microprofile-health-api",
            "version": "4.0.1.redhat-00002"
          },
          {
            "id": "SPDXRef-da4e7a55-8bdb-4b6a-9f7f-6aa48e0fe909",
            "name": "quarkus-micrometer",
            "version": "3.2.11.Final-redhat-00001"
          },
          {
            "id": "SPDXRef-0f38e3d6-ee65-461e-a3a4-2f73ddd96a05",
            "name": "opentelemetry-extension-annotations",
            "version": "1.18.0.redhat-00001"
          },
          {
            "id": "SPDXRef-887f111b-aa92-4b7b-a53b-496d8ab01bdc",
            "name": "mssqlserver",
            "version": "1.18.3"
          },
          {
            "id": "SPDXRef-5f87878c-6859-4cf1-9b18-e422c78d2cd8",
            "name": "istack-commons-runtime",
            "version": "4.1.2.redhat-00003"
          },
../...
       {
            "id": "SPDXRef-172e8649-e4a2-4c4e-857f-770761b485a8",
            "name": "jakarta.interceptor-api",
            "version": "2.1.0.redhat-00002"
          }
        ]
      },
      {
        "vulnerabilityId": "CVE-2024-29025",
        "status": "fixed",
        "packages": [
          {
            "id": "SPDXRef-8ca68978-8302-46cb-b0ea-8912a06428ce",
            "name": "netty-codec-http",
            "version": "4.1.100.Final-redhat-00001"
          }
        ]
      }
    ]
  }
}


```