### PR TITLE
Remove queries from within inner loops, for vulnerability details

### DIFF
--- a/common/src/db/multi_model.rs
+++ b/common/src/db/multi_model.rs
@@ -1,8 +1,8 @@
 use sea_orm::{
-    ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoSimpleExpr, Iterable, QueryResult,
-    QuerySelect, Select, SelectModel, Selector,
+    ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoIdentity, IntoSimpleExpr, Iterable,
+    QueryResult, QuerySelect, Select, SelectModel, Selector,
 };
-use sea_query::{ColumnRef, SimpleExpr};
+use sea_query::{ColumnRef, Expr, SimpleExpr};
 
 pub trait ColumnsPrefixed: Sized {
     fn try_columns_prefixed<C, I>(self, prefix: &str, cols: I) -> Result<Self, DbErr>
@@ -44,6 +44,12 @@ impl<T: QuerySelect> ColumnsPrefixed for T {
 pub trait SelectIntoMultiModel: Sized {
     fn try_model_columns<E: EntityTrait>(self, entity: E) -> Result<Self, DbErr>;
 
+    fn try_model_columns_from_alias<E: EntityTrait>(
+        self,
+        entity: E,
+        table_alias: &str,
+    ) -> Result<Self, DbErr>;
+
     fn try_into_multi_model<M>(self) -> Result<Selector<SelectModel<M>>, DbErr>
     where
         M: FromQueryResultMultiModel;
@@ -54,6 +60,37 @@ impl<E: EntityTrait> SelectIntoMultiModel for Select<E> {
         let name = entity.module_name();
         let prefix = format!("{name}$");
         self.try_columns_prefixed(&prefix, O::Column::iter())
+    }
+
+    fn try_model_columns_from_alias<O: EntityTrait>(
+        mut self,
+        _entity: O,
+        table_alias: &str,
+    ) -> Result<Self, DbErr> {
+        let prefix = format!("{table_alias}$");
+        for simple_col in O::Column::iter() {
+            if let SimpleExpr::Column(col_ref) = simple_col.into_simple_expr() {
+                match col_ref {
+                    ColumnRef::Column(name)
+                    | ColumnRef::TableColumn(_, name)
+                    | ColumnRef::SchemaTableColumn(_, _, name) => {
+                        let prefixed = format!("{prefix}{}", name.clone().to_string());
+                        self = self
+                            .column_as(Expr::col((table_alias.into_identity(), name)), prefixed);
+                    }
+                    ColumnRef::Asterisk => {
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                    }
+                    ColumnRef::TableAsterisk(_) => {
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                    }
+                }
+            } else {
+                return Err(DbErr::Custom("Unable to prefix column".to_string()));
+            }
+        }
+
+        Ok(self)
     }
 
     fn try_into_multi_model<M>(self) -> Result<Selector<SelectModel<M>>, DbErr>
@@ -70,17 +107,24 @@ pub trait FromQueryResultMultiModel: FromQueryResult {
 
     fn from_query_result_multi_model<E: EntityTrait>(
         res: &QueryResult,
+        alias: &str,
         entity: E,
     ) -> Result<E::Model, DbErr> {
-        let name = entity.module_name();
-        let prefix = format!("{name}$");
+        let prefix = if alias.is_empty() {
+            let name = entity.module_name();
+            format!("{name}$")
+        } else {
+            format!("{alias}$")
+        };
+
         E::Model::from_query_result(res, &prefix)
     }
 
     fn from_query_result_multi_model_optional<E: EntityTrait>(
         res: &QueryResult,
+        alias: &str,
         entity: E,
     ) -> Result<Option<E::Model>, DbErr> {
-        Ok(Self::from_query_result_multi_model(res, entity).ok())
+        Ok(Self::from_query_result_multi_model(res, alias, entity).ok())
     }
 }

--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -44,6 +44,22 @@ impl From<Model> for cvss3::Cvss3Base {
     }
 }
 
+impl From<&Model> for cvss3::Cvss3Base {
+    fn from(value: &Model) -> Self {
+        Self {
+            minor_version: value.minor_version as u8,
+            av: value.av.into(),
+            ac: value.ac.into(),
+            pr: value.pr.into(),
+            ui: value.ui.into(),
+            s: value.s.into(),
+            c: value.c.into(),
+            i: value.i.into(),
+            a: value.a.into(),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
     #[sea_orm(
@@ -85,7 +101,7 @@ impl Related<advisory_vulnerability::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_av")]
 pub enum AttackVector {
     #[sea_orm(string_value = "n")]
@@ -120,7 +136,7 @@ impl From<cvss3::AttackVector> for AttackVector {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ac")]
 pub enum AttackComplexity {
     #[sea_orm(string_value = "l")]
@@ -147,7 +163,7 @@ impl From<cvss3::AttackComplexity> for AttackComplexity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_pr")]
 pub enum PrivilegesRequired {
     #[sea_orm(string_value = "n")]
@@ -178,7 +194,7 @@ impl From<cvss3::PrivilegesRequired> for PrivilegesRequired {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ui")]
 pub enum UserInteraction {
     #[sea_orm(string_value = "n")]
@@ -205,7 +221,7 @@ impl From<cvss3::UserInteraction> for UserInteraction {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_s")]
 pub enum Scope {
     #[sea_orm(string_value = "u")]
@@ -232,7 +248,7 @@ impl From<cvss3::Scope> for Scope {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_c")]
 pub enum Confidentiality {
     #[sea_orm(string_value = "n")]
@@ -263,7 +279,7 @@ impl From<cvss3::Confidentiality> for Confidentiality {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_i")]
 pub enum Integrity {
     #[sea_orm(string_value = "n")]
@@ -294,7 +310,7 @@ impl From<cvss3::Integrity> for Integrity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_a")]
 pub enum Availability {
     #[sea_orm(string_value = "n")]

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -29,6 +29,19 @@ pub enum Relation {
 
     #[sea_orm(has_many = "super::cvss3::Entity")]
     Cvss3,
+
+    #[sea_orm(has_many = "super::purl_status::Entity")]
+    PurlStatuses,
+}
+
+impl Related<super::purl_status::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::PurlStatuses.def()
+    }
+
+    fn via() -> Option<RelationDef> {
+        Some(Relation::AdvisoryVulnerability.def())
+    }
 }
 
 impl Related<advisory::Entity> for Entity {

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -677,15 +677,15 @@ pub struct QueryCatcher {
 impl FromQueryResult for QueryCatcher {
     fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
         Ok(Self {
-            advisory: Self::from_query_result_multi_model(res, advisory::Entity)?,
-            vulnerability: Self::from_query_result_multi_model(res, vulnerability::Entity)?,
-            base_purl: Self::from_query_result_multi_model(res, base_purl::Entity)?,
-            versioned_purl: Self::from_query_result_multi_model(res, versioned_purl::Entity)?,
-            qualified_purl: Self::from_query_result_multi_model(res, qualified_purl::Entity)?,
-            sbom_package: Self::from_query_result_multi_model(res, sbom_package::Entity)?,
-            sbom_node: Self::from_query_result_multi_model(res, sbom_node::Entity)?,
-            context_cpe: Self::from_query_result_multi_model_optional(res, cpe::Entity)?,
-            status: Self::from_query_result_multi_model(res, status::Entity)?,
+            advisory: Self::from_query_result_multi_model(res, "", advisory::Entity)?,
+            vulnerability: Self::from_query_result_multi_model(res, "", vulnerability::Entity)?,
+            base_purl: Self::from_query_result_multi_model(res, "", base_purl::Entity)?,
+            versioned_purl: Self::from_query_result_multi_model(res, "", versioned_purl::Entity)?,
+            qualified_purl: Self::from_query_result_multi_model(res, "", qualified_purl::Entity)?,
+            sbom_package: Self::from_query_result_multi_model(res, "", sbom_package::Entity)?,
+            sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
+            context_cpe: Self::from_query_result_multi_model_optional(res, "", cpe::Entity)?,
+            status: Self::from_query_result_multi_model(res, "", status::Entity)?,
         })
     }
 }

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -30,19 +30,21 @@ pub struct VulnerabilityDetails {
 
 impl VulnerabilityDetails {
     pub async fn from_advisory_vulnerabilities(
-        vulnerability_identifier: &str,
+        vulnerability: &vulnerability::Model,
         advisory_vulnerabilities: &[advisory_vulnerability::Model],
+        vuln_cvss3s: &[cvss3::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let advisories = VulnerabilityAdvisorySummary::from_entities(
-            vulnerability_identifier,
+            vulnerability,
             advisory_vulnerabilities,
+            vuln_cvss3s,
             tx,
         )
         .await?;
 
         let cvss3 = cvss3::Entity::find()
-            .filter(trustify_entity::cvss3::Column::VulnerabilityId.eq(vulnerability_identifier))
+            .filter(trustify_entity::cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
@@ -59,7 +61,7 @@ impl VulnerabilityDetails {
         Ok(VulnerabilityDetails {
             head: VulnerabilityHead {
                 normative: true,
-                identifier: vulnerability_identifier.to_string(),
+                identifier: vulnerability.id.clone(),
                 title: None,
                 description: None,
                 published: None,
@@ -84,17 +86,18 @@ impl VulnerabilityDetails {
             .all(tx)
             .await?;
 
-        let advisories = VulnerabilityAdvisorySummary::from_entities(
-            &vulnerability.id,
-            &advisory_vulnerabilities,
-            tx,
-        )
-        .await?;
-
         let cvss3 = cvss3::Entity::find()
             .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
+
+        let advisories = VulnerabilityAdvisorySummary::from_entities(
+            vulnerability,
+            &advisory_vulnerabilities,
+            &cvss3,
+            tx,
+        )
+        .await?;
 
         let total_score = cvss3
             .iter()
@@ -157,8 +160,9 @@ impl VulnerabilityDetails {
                 average_severity: average_score.map(|score| score.severity().to_string()),
                 average_score: average_score.map(|score| score.value()),
                 advisories: VulnerabilityAdvisorySummary::from_entities(
-                    &vulnerability.id,
+                    vulnerability,
                     advisory_vulnerabilities,
+                    &cvss3,
                     tx,
                 )
                 .await?,

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -4,23 +4,19 @@ use crate::sbom::model::SbomHead;
 use crate::{advisory::model::AdvisoryHead, purl::model::BasePurlHead, Error};
 use cpe::uri::OwnedUri;
 use sea_orm::{
-    ColumnTrait, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait, QueryFilter, QuerySelect,
-    RelationTrait,
+    ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoIdentity, LoaderTrait, ModelTrait,
+    QueryFilter, QueryResult, QuerySelect, RelationTrait, Select,
 };
-use sea_query::{Asterisk, Expr, Func, JoinType, SimpleExpr};
+use sea_query::{Asterisk, Expr, Func, IntoCondition, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use trustify_common::db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel};
 use trustify_common::db::VersionMatches;
-use trustify_common::id::Id;
 use trustify_common::memo::Memo;
-use trustify_common::{
-    cpe::CpeCompare, db::ConnectionOrTransaction, impl_try_into_cpe, purl::Purl,
-};
+use trustify_common::{cpe::CpeCompare, db::ConnectionOrTransaction, purl::Purl};
 use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
 use trustify_entity as entity;
-use trustify_entity::labels::Labels;
-use trustify_entity::organization;
-use trustify_entity::relationship::Relationship;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -36,13 +32,13 @@ pub struct VulnerabilityAdvisoryHead {
 
 impl VulnerabilityAdvisoryHead {
     pub async fn from_entity(
-        vulnerability_identifier: &str,
+        vulnerability: &entity::vulnerability::Model,
         advisory_vulnerability: &entity::advisory_vulnerability::Model,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let cvss3 = entity::cvss3::Entity::find()
             .filter(entity::cvss3::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
-            .filter(entity::cvss3::Column::VulnerabilityId.eq(vulnerability_identifier))
+            .filter(entity::cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
             .all(tx)
             .await?;
 
@@ -78,7 +74,9 @@ impl VulnerabilityAdvisoryHead {
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
 
-        let organizations = vuln_advisories.load_one(organization::Entity, tx).await?;
+        let organizations = vuln_advisories
+            .load_one(entity::organization::Entity, tx)
+            .await?;
 
         for (advisory, issuer) in vuln_advisories.iter().zip(organizations.into_iter()) {
             // filter all vulnerability cvss3 to those that pertain to only this advisory.
@@ -125,144 +123,153 @@ pub struct VulnerabilityAdvisorySummary {
 
 impl VulnerabilityAdvisorySummary {
     pub async fn from_entities(
-        vulnerability_identifier: &str,
+        vulnerability: &entity::vulnerability::Model,
         advisory_vulnerabilities: &[entity::advisory_vulnerability::Model],
+        vuln_cvss3: &[entity::cvss3::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let mut summaries = Vec::new();
-
-        let mut cvss3s = advisory_vulnerabilities
-            .load_many(
-                entity::cvss3::Entity::find()
-                    .filter(entity::cvss3::Column::VulnerabilityId.eq(vulnerability_identifier)),
-                tx,
+        let versioned_purl_query = entity::versioned_purl::Entity::find()
+            .join(
+                JoinType::Join,
+                entity::versioned_purl::Relation::BasePurl.def(),
             )
-            .await?;
-
-        for (advisory_vulnerability, mut cvss3) in
-            advisory_vulnerabilities.iter().zip(cvss3s.drain(..))
-        {
-            let cvss3_scores = cvss3
-                .drain(..)
-                .map(|e| Cvss3Base::from(e).to_string())
-                .collect();
-
-            let statuses = entity::purl_status::Entity::find()
-                .columns([
-                    entity::version_range::Column::LowVersion,
-                    entity::version_range::Column::LowInclusive,
-                    entity::version_range::Column::HighVersion,
-                    entity::version_range::Column::HighInclusive,
-                ])
-                .column_as(entity::status::Column::Slug, "status")
-                .columns([
-                    entity::base_purl::Column::Type,
-                    entity::base_purl::Column::Name,
-                    entity::base_purl::Column::Namespace,
-                ])
-                .left_join(entity::status::Entity)
-                .filter(entity::purl_status::Column::VulnerabilityId.eq(vulnerability_identifier))
-                .filter(
-                    entity::purl_status::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id),
-                )
-                .left_join(entity::base_purl::Entity)
-                .column_as(entity::base_purl::Column::Id, "package_uuid")
-                .join(
-                    JoinType::LeftJoin,
-                    entity::base_purl::Relation::VersionedPurls.def(),
-                )
-                .left_join(entity::version_range::Entity)
-                .left_join(entity::cpe::Entity)
-                .column_as(entity::cpe::Column::Id, "cpe_id")
-                .columns([
-                    entity::cpe::Column::Part,
-                    entity::cpe::Column::Vendor,
-                    entity::cpe::Column::Product,
-                    entity::cpe::Column::Version,
-                    entity::cpe::Column::Update,
-                    entity::cpe::Column::Edition,
-                    entity::cpe::Column::Language,
-                ])
-                .distinct_on([entity::purl_status::Column::Id])
-                .into_model::<PurlStatusCatcher>()
-                .all(tx)
-                .await?;
-
-            let status_ids = statuses.iter().map(|e| e.id).collect::<Vec<_>>();
-
-            let sbom_purl_statuses = entity::sbom_package::Entity::find()
-                .join(JoinType::Join, entity::sbom_package::Relation::Node.def())
-                .join(
-                    JoinType::LeftJoin,
-                    entity::sbom_package::Relation::Purl.def(),
-                )
-                .join(
-                    JoinType::LeftJoin,
-                    entity::sbom_package_purl_ref::Relation::Purl.def(),
-                )
-                .join(
-                    JoinType::LeftJoin,
-                    entity::qualified_purl::Relation::VersionedPurl.def(),
-                )
-                .join(
-                    JoinType::LeftJoin,
-                    entity::versioned_purl::Relation::BasePurl.def(),
-                )
-                .join(
-                    JoinType::Join,
-                    entity::base_purl::Relation::PurlStatus.def(),
-                )
-                .join(JoinType::Join, entity::purl_status::Relation::Status.def())
-                .join(
-                    JoinType::LeftJoin,
-                    entity::purl_status::Relation::VersionRange.def(),
-                )
-                .join(
-                    JoinType::LeftJoin,
-                    entity::purl_status::Relation::ContextCpe.def(),
-                )
-                .column_as(
-                    Expr::col((
+            .join(
+                JoinType::LeftJoin,
+                entity::base_purl::Relation::PurlStatus.def(),
+            )
+            .join(
+                JoinType::Join,
+                entity::purl_status::Relation::VersionRange.def(),
+            )
+            .join(JoinType::Join, entity::purl_status::Relation::Status.def())
+            .filter(entity::purl_status::Column::VulnerabilityId.eq(&vulnerability.id))
+            .filter(SimpleExpr::FunctionCall(
+                Func::cust(VersionMatches)
+                    .arg(Expr::col((
                         entity::versioned_purl::Entity,
                         entity::versioned_purl::Column::Version,
-                    )),
-                    "version",
-                )
-                .column_as(entity::status::Column::Slug, "status")
-                .column_as(entity::cpe::Column::Id, "cpe_id")
-                .columns([
-                    entity::cpe::Column::Part,
-                    entity::cpe::Column::Vendor,
-                    entity::cpe::Column::Product,
-                    entity::cpe::Column::Version,
-                    entity::cpe::Column::Update,
-                    entity::cpe::Column::Edition,
-                    entity::cpe::Column::Language,
-                ])
-                .filter(entity::purl_status::Column::VulnerabilityId.eq(vulnerability_identifier))
-                .filter(entity::purl_status::Column::Id.is_in(status_ids))
-                .filter(SimpleExpr::FunctionCall(
-                    Func::cust(VersionMatches)
-                        .arg(Expr::col((
-                            entity::versioned_purl::Entity,
-                            entity::versioned_purl::Column::Version,
-                        )))
-                        .arg(Expr::col((entity::version_range::Entity, Asterisk))),
-                ))
-                .into_model::<SbomStatusCatcher>()
-                .all(tx)
-                .await?;
+                    )))
+                    .arg(Expr::col((entity::version_range::Entity, Asterisk))),
+            ));
+
+        let sbom_status_query = entity::sbom_package_purl_ref::Entity::find()
+            .join(
+                JoinType::LeftJoin,
+                entity::sbom_package_purl_ref::Relation::Purl.def(),
+            )
+            .join(
+                JoinType::LeftJoin,
+                entity::qualified_purl::Relation::VersionedPurl.def(),
+            )
+            .join(
+                JoinType::LeftJoin,
+                entity::versioned_purl::Relation::BasePurl.def(),
+            )
+            .join(
+                JoinType::LeftJoin,
+                entity::base_purl::Relation::PurlStatus.def(),
+            )
+            .join(
+                JoinType::Join,
+                entity::purl_status::Relation::VersionRange.def(),
+            )
+            .join(JoinType::Join, entity::purl_status::Relation::Status.def())
+            .join_as(
+                JoinType::Join,
+                entity::purl_status::Relation::ContextCpe.def(),
+                "context_cpe".into_identity(),
+            )
+            .filter(entity::purl_status::Column::VulnerabilityId.eq(&vulnerability.id))
+            .filter(SimpleExpr::FunctionCall(
+                Func::cust(VersionMatches)
+                    .arg(Expr::col((
+                        entity::versioned_purl::Entity,
+                        entity::versioned_purl::Column::Version,
+                    )))
+                    .arg(Expr::col((entity::version_range::Entity, Asterisk))),
+            ))
+            .join(
+                JoinType::Join,
+                entity::sbom_package_purl_ref::Relation::Sbom.def(),
+            )
+            .join(
+                JoinType::LeftJoin,
+                entity::sbom::Relation::Node
+                    .def()
+                    .on_condition(|left, right| {
+                        Expr::col((right, entity::sbom_node::Column::SbomId))
+                            .eq(Expr::col((left, entity::sbom::Column::SbomId)))
+                            .into_condition()
+                    }),
+            )
+            .join(JoinType::Join, entity::sbom_node::Relation::Package.def())
+            .join(JoinType::Join, entity::sbom_package::Relation::Cpe.def())
+            .join(
+                JoinType::Join,
+                entity::sbom_package_cpe_ref::Relation::Cpe.def(),
+            )
+            .select_only()
+            .column_as(
+                SimpleExpr::FunctionCall(
+                    Func::cust("array_agg".into_identity())
+                        .arg(SimpleExpr::Custom("DISTINCT status.slug".to_string())),
+                ),
+                "statuses",
+            )
+            .column(entity::purl_status::Column::AdvisoryId)
+            .group_by(Expr::col((
+                "context_cpe".into_identity(),
+                "id".into_identity(),
+            )))
+            .group_by(entity::sbom::Column::SbomId)
+            .group_by(entity::sbom_node::Column::SbomId)
+            .group_by(entity::sbom_node::Column::NodeId)
+            .group_by(entity::purl_status::Column::AdvisoryId)
+            .group_by(entity::sbom_package::Column::SbomId)
+            .group_by(entity::sbom_package::Column::NodeId)
+            .group_by(entity::cpe::Column::Id);
+
+        let vuln_purl_statuses = versioned_purl_query
+            .join(
+                JoinType::LeftJoin,
+                entity::purl_status::Relation::ContextCpe.def(),
+            )
+            .try_into_multi_model::<PurlStatusCatcher>()?
+            .all(tx)
+            .await?;
+
+        let vuln_sbom_statuses = sbom_status_query
+            .try_into_multi_model::<SbomStatusCatcher>()?
+            .all(tx)
+            .await?;
+
+        let mut summaries = Vec::new();
+
+        for advisory_vulnerability in advisory_vulnerabilities {
+            let cvss3_scores = vuln_cvss3
+                .iter()
+                .filter(|e| e.advisory_id == advisory_vulnerability.advisory_id)
+                .map(|e| Cvss3Base::from(e.clone()).to_string())
+                .collect();
+
+            let purl_statuses = vuln_purl_statuses
+                .iter()
+                .filter(|e| e.purl_status.advisory_id == advisory_vulnerability.advisory_id);
+
+            let sbom_statuses = vuln_sbom_statuses
+                .iter()
+                .filter(|e| e.advisory_id == advisory_vulnerability.advisory_id);
 
             summaries.push(VulnerabilityAdvisorySummary {
                 head: VulnerabilityAdvisoryHead::from_entity(
-                    vulnerability_identifier,
+                    vulnerability,
                     advisory_vulnerability,
                     tx,
                 )
                 .await?,
                 cvss3_scores,
-                purls: VulnerabilityAdvisoryStatus::from_models(&statuses, tx).await?,
-                sboms: SbomStatus::from_models(&sbom_purl_statuses, tx).await?,
+                purls: VulnerabilityAdvisoryStatus::from_models(purl_statuses, tx).await?,
+                sboms: SbomStatus::from_models(sbom_statuses, tx).await?,
             });
         }
 
@@ -270,67 +277,84 @@ impl VulnerabilityAdvisorySummary {
     }
 }
 
-#[derive(FromQueryResult, Debug)]
+#[derive(Debug)]
 struct PurlStatusCatcher {
-    id: Uuid,
-    status: String,
-    package_uuid: Uuid,
-    r#type: String,
-    namespace: Option<String>,
-    name: String,
-    low_version: Option<String>,
-    low_inclusive: Option<bool>,
-    high_version: Option<String>,
-    high_inclusive: Option<bool>,
-    part: Option<String>,
-    vendor: Option<String>,
-    product: Option<String>,
-    version: Option<String>,
-    update: Option<String>,
-    edition: Option<String>,
-    language: Option<String>,
+    status: entity::status::Model,
+    purl_status: entity::purl_status::Model,
+    version_range: entity::version_range::Model,
+    cpe: entity::cpe::Model,
+
+    base_purl: entity::base_purl::Model,
 }
 
-impl_try_into_cpe!(PurlStatusCatcher);
+impl FromQueryResult for PurlStatusCatcher {
+    fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
+        Ok(Self {
+            status: Self::from_query_result_multi_model(res, "", entity::status::Entity)?,
+            purl_status: Self::from_query_result_multi_model(res, "", entity::purl_status::Entity)?,
+            version_range: Self::from_query_result_multi_model(
+                res,
+                "",
+                entity::version_range::Entity,
+            )?,
+            cpe: Self::from_query_result_multi_model(res, "", entity::cpe::Entity)?,
+            base_purl: Self::from_query_result_multi_model(res, "", entity::base_purl::Entity)?,
+        })
+    }
+}
+
+impl FromQueryResultMultiModel for PurlStatusCatcher {
+    fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr> {
+        select
+            .try_model_columns(entity::status::Entity)?
+            .try_model_columns(entity::purl_status::Entity)?
+            .try_model_columns(entity::version_range::Entity)?
+            .try_model_columns(entity::cpe::Entity)?
+            .try_model_columns(entity::base_purl::Entity)
+    }
+}
 
 impl PurlStatusCatcher {
     pub fn purl(&self) -> Purl {
         Purl {
-            ty: self.r#type.clone(),
-            namespace: self.namespace.clone(),
-            name: self.name.clone(),
+            ty: self.base_purl.r#type.clone(),
+            namespace: self.base_purl.namespace.clone(),
+            name: self.base_purl.name.clone(),
             version: None,
             qualifiers: Default::default(),
         }
     }
 
     pub fn version(&self) -> String {
-        match (&self.low_version, &self.high_version) {
+        match (
+            &self.version_range.low_version,
+            &self.version_range.high_version,
+        ) {
             (Some(low), Some(high)) if low == high => low.clone(),
             (Some(low), Some(high)) => {
                 let mut v = String::new();
-                v.push(Self::open_delim(self.low_inclusive));
+                v.push(Self::open_delim(self.version_range.low_inclusive));
                 v.push_str(low);
                 v.push(',');
                 v.push_str(high);
-                v.push(Self::close_delim(self.high_inclusive));
+                v.push(Self::close_delim(self.version_range.high_inclusive));
                 v
             }
 
             (Some(low), None) => {
                 let mut v = String::new();
-                v.push(Self::open_delim(self.low_inclusive));
+                v.push(Self::open_delim(self.version_range.low_inclusive));
                 v.push_str(low);
                 v.push(',');
-                v.push(Self::close_delim(self.high_inclusive));
+                v.push(Self::close_delim(self.version_range.high_inclusive));
                 v
             }
             (None, Some(high)) => {
                 let mut v = String::new();
-                v.push(Self::open_delim(self.low_inclusive));
+                v.push(Self::open_delim(self.version_range.low_inclusive));
                 v.push(',');
                 v.push_str(high);
-                v.push(Self::close_delim(self.high_inclusive));
+                v.push(Self::close_delim(self.version_range.high_inclusive));
                 v
             }
             (None, None) => "*".to_string(),
@@ -371,8 +395,8 @@ pub struct VulnerabilityAdvisoryStatus {
 }
 
 impl VulnerabilityAdvisoryStatus {
-    async fn from_models(
-        models: &Vec<PurlStatusCatcher>,
+    async fn from_models<'i, I: Iterator<Item = &'i PurlStatusCatcher>>(
+        models: I,
         _tx: &ConnectionOrTransaction<'_>,
     ) -> Result<HashMap<String, Vec<Self>>, Error> {
         let mut statuses = HashMap::new();
@@ -380,15 +404,15 @@ impl VulnerabilityAdvisoryStatus {
         for each in models {
             let mut context = None;
 
-            let cpe: Result<OwnedUri, _> = each.try_into();
+            let cpe: Result<OwnedUri, _> = (&each.cpe).try_into();
             if let Ok(cpe) = cpe {
                 context = Some(StatusContext::Cpe(cpe.to_string()));
             }
 
-            let status_entry = statuses.entry(each.status.clone()).or_insert(vec![]);
+            let status_entry = statuses.entry(each.status.slug.clone()).or_insert(vec![]);
             status_entry.push(VulnerabilityAdvisoryStatus {
                 base_purl: BasePurlHead {
-                    uuid: each.package_uuid,
+                    uuid: each.base_purl.id,
                     purl: each.purl(),
                 },
                 version: each.version(),
@@ -400,21 +424,50 @@ impl VulnerabilityAdvisoryStatus {
     }
 }
 
-#[derive(Debug, FromQueryResult)]
+#[derive(Debug)]
 struct SbomStatusCatcher {
-    sbom_id: Uuid,
-    status: String,
-    cpe_id: Option<Uuid>,
-    part: Option<String>,
-    vendor: Option<String>,
-    product: Option<String>,
-    version: Option<String>,
-    update: Option<String>,
-    edition: Option<String>,
-    language: Option<String>,
+    //purl_status: entity::purl_status::Model,
+    advisory_id: Uuid,
+    context_cpe: Option<entity::cpe::Model>,
+    sbom: entity::sbom::Model,
+    sbom_package: entity::sbom_package::Model,
+    sbom_node: entity::sbom_node::Model,
+    statuses: Vec<String>,
+    cpe: Option<entity::cpe::Model>,
 }
 
-impl_try_into_cpe!(SbomStatusCatcher);
+impl FromQueryResult for SbomStatusCatcher {
+    fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
+        Ok(Self {
+            advisory_id: res.try_get("", "advisory_id")?,
+            context_cpe: Self::from_query_result_multi_model_optional(
+                res,
+                "context_cpe",
+                entity::cpe::Entity,
+            )?,
+            sbom: Self::from_query_result_multi_model(res, "", entity::sbom::Entity)?,
+            sbom_package: Self::from_query_result_multi_model(
+                res,
+                "",
+                entity::sbom_package::Entity,
+            )?,
+            sbom_node: Self::from_query_result_multi_model(res, "", entity::sbom_node::Entity)?,
+            statuses: res.try_get("", "statuses")?,
+            cpe: Self::from_query_result_multi_model_optional(res, "", entity::cpe::Entity)?,
+        })
+    }
+}
+
+impl FromQueryResultMultiModel for SbomStatusCatcher {
+    fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr> {
+        select
+            .try_model_columns_from_alias(entity::cpe::Entity, "context_cpe")?
+            .try_model_columns(entity::sbom::Entity)?
+            .try_model_columns(entity::sbom_package::Entity)?
+            .try_model_columns(entity::sbom_node::Entity)?
+            .try_model_columns(entity::cpe::Entity)
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SbomStatus {
@@ -429,117 +482,36 @@ pub struct SbomStatus {
 }
 
 impl SbomStatus {
-    async fn from_models(
-        sbom_purl_status: &[SbomStatusCatcher],
+    async fn from_models<'i, I: IntoIterator<Item = &'i SbomStatusCatcher> + Clone>(
+        sbom_purl_status: I,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut sboms = HashMap::new();
 
-        for sbom_id in sbom_purl_status
-            .iter()
-            .map(|e| e.sbom_id)
-            .collect::<HashSet<_>>()
-        {
-            let sbom_status = if let Some(sbom_details) =
-                entity::package_relates_to_package::Entity::find()
-                    .filter(entity::package_relates_to_package::Column::SbomId.eq(sbom_id))
-                    .filter(
-                        entity::package_relates_to_package::Column::Relationship
-                            .eq(Relationship::DescribedBy),
-                    )
-                    .join(
-                        JoinType::LeftJoin,
-                        entity::package_relates_to_package::Relation::Left.def(),
-                    )
-                    .join(
-                        JoinType::LeftJoin,
-                        entity::sbom_node::Relation::Package.def(),
-                    )
-                    .join(
-                        JoinType::LeftJoin,
-                        entity::sbom_package::Relation::Cpe.def(),
-                    )
-                    .join(
-                        JoinType::LeftJoin,
-                        entity::sbom_package_cpe_ref::Relation::Cpe.def(),
-                    )
-                    .join(JoinType::Join, entity::sbom_package::Relation::Sbom.def())
-                    .column_as(entity::sbom_package::Column::Version, "sbom_version")
-                    .column(entity::sbom_node::Column::Name)
-                    .columns([
-                        entity::sbom::Column::SbomId,
-                        entity::sbom::Column::Sha256,
-                        entity::sbom::Column::Sha384,
-                        entity::sbom::Column::Sha512,
-                        entity::sbom::Column::Labels,
-                        entity::sbom::Column::DocumentId,
-                        entity::sbom::Column::Published,
-                        entity::sbom::Column::Authors,
-                    ])
-                    .column_as(entity::cpe::Column::Id, "cpe_id")
-                    .columns([
-                        entity::cpe::Column::Part,
-                        entity::cpe::Column::Vendor,
-                        entity::cpe::Column::Product,
-                        entity::cpe::Column::Version,
-                        entity::cpe::Column::Update,
-                        entity::cpe::Column::Edition,
-                        entity::cpe::Column::Language,
-                    ])
-                    .into_model::<SbomDetailsCatcher>()
-                    .one(tx)
-                    .await?
-            {
-                let sbom_cpe: Result<OwnedUri, _> = (&sbom_details).try_into();
-                let sbom_cpe = sbom_cpe.ok();
+        for status in sbom_purl_status.clone() {
+            if let Entry::Vacant(e) = sboms.entry(&status.sbom.sbom_id) {
+                let sbom_cpe = status.cpe.as_ref().and_then(|cpe| {
+                    let sbom_cpe: Result<OwnedUri, _> = cpe.try_into();
+                    sbom_cpe.ok()
+                });
 
-                let mut hashes = vec![Id::Sha256(sbom_details.sha256)];
-
-                if let Some(hash) = sbom_details.sha384 {
-                    hashes.push(Id::Sha384(hash));
-                }
-
-                if let Some(hash) = sbom_details.sha512 {
-                    hashes.push(Id::Sha512(hash));
-                }
-
-                SbomStatus {
-                    head: SbomHead {
-                        id: sbom_details.sbom_id,
-                        hashes,
-                        document_id: sbom_details.document_id,
-                        labels: sbom_details.labels,
-                        name: sbom_details.name,
-                    },
-                    version: sbom_details.sbom_version,
+                e.insert(SbomStatus {
+                    head: SbomHead::from_entity(&status.sbom, Some(status.sbom_node.clone()), tx)
+                        .await?,
+                    version: status.sbom_package.version.clone(),
                     cpe: sbom_cpe,
                     status: Default::default(),
-                }
-            } else {
-                SbomStatus {
-                    head: SbomHead {
-                        id: sbom_id,
-                        hashes: vec![],
-                        document_id: "".to_string(),
-                        labels: Default::default(),
-                        name: "".to_string(),
-                    },
-                    version: None,
-                    cpe: None,
-                    status: Default::default(),
-                }
-            };
-
-            sboms.insert(sbom_id, sbom_status);
+                });
+            }
         }
 
         'status: for advisory_status in sbom_purl_status {
-            if let Some(sbom_status) = sboms.get_mut(&advisory_status.sbom_id) {
-                match (advisory_status.cpe_id, &sbom_status.cpe) {
-                    (Some(_advisory_cpe), Some(sbom_cpe)) => {
-                        let status_cpe: Result<OwnedUri, _> = advisory_status.try_into();
+            if let Some(sbom_status) = sboms.get_mut(&advisory_status.sbom.sbom_id) {
+                match (&advisory_status.context_cpe, &sbom_status.cpe) {
+                    (Some(advisory_cpe), Some(sbom_cpe)) => {
+                        let advisory_cpe: Result<OwnedUri, _> = advisory_cpe.try_into();
 
-                        if let Ok(status_cpe) = status_cpe {
+                        if let Ok(status_cpe) = advisory_cpe {
                             if status_cpe.is_superset(sbom_cpe) {
                                 // the status context *is* applicable, fall through
                             } else {
@@ -560,11 +532,22 @@ impl SbomStatus {
                     }
                 }
 
-                sbom_status.status.insert(advisory_status.status.clone());
+                sbom_status
+                    .status
+                    .extend(advisory_status.statuses.iter().cloned());
             }
         }
 
-        Ok(sboms.values().cloned().collect())
+        Ok(sboms
+            .drain()
+            .filter_map(|(_, status)| {
+                if status.status.is_empty() {
+                    None
+                } else {
+                    Some(status)
+                }
+            })
+            .collect())
     }
 }
 
@@ -574,27 +557,3 @@ pub enum SbomPackageStatus {
     Cpe(),
     Purl(PurlHead),
 }
-
-#[derive(Debug, FromQueryResult)]
-struct SbomDetailsCatcher {
-    sbom_id: Uuid,
-
-    sha256: String,
-    sha384: Option<String>,
-    sha512: Option<String>,
-    document_id: String,
-
-    name: String,
-    sbom_version: Option<String>,
-    labels: Labels,
-
-    part: Option<String>,
-    vendor: Option<String>,
-    product: Option<String>,
-    version: Option<String>,
-    update: Option<String>,
-    edition: Option<String>,
-    language: Option<String>,
-}
-
-impl_try_into_cpe!(SbomDetailsCatcher);

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -128,32 +128,6 @@ impl VulnerabilityAdvisorySummary {
         vuln_cvss3: &[entity::cvss3::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        /*
-        let purl_status_query = entity::versioned_purl::Entity::find()
-            .join(
-                JoinType::Join,
-                entity::versioned_purl::Relation::BasePurl.def(),
-            )
-            .join(
-                JoinType::LeftJoin,
-                entity::base_purl::Relation::PurlStatus.def(),
-            )
-            .join(
-                JoinType::Join,
-                entity::purl_status::Relation::VersionRange.def(),
-            )
-            .join(JoinType::Join, entity::purl_status::Relation::Status.def())
-            .filter(entity::purl_status::Column::VulnerabilityId.eq(&vulnerability.id))
-            .filter(SimpleExpr::FunctionCall(
-                Func::cust(VersionMatches)
-                    .arg(Expr::col((
-                        entity::versioned_purl::Entity,
-                        entity::versioned_purl::Column::Version,
-                    )))
-                    .arg(Expr::col((entity::version_range::Entity, Asterisk))),
-            ));
-
-         */
         let purl_status_query = entity::purl_status::Entity::find()
             .left_join(entity::status::Entity)
             .filter(entity::purl_status::Column::VulnerabilityId.eq(&vulnerability.id))
@@ -242,8 +216,6 @@ impl VulnerabilityAdvisorySummary {
             .try_into_multi_model::<PurlStatusCatcher>()?
             .all(tx)
             .await?;
-
-        println!("{:#?}", vuln_purl_statuses);
 
         let vuln_sbom_statuses = sbom_status_query
             .try_into_multi_model::<SbomStatusCatcher>()?

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -128,7 +128,8 @@ impl VulnerabilityAdvisorySummary {
         vuln_cvss3: &[entity::cvss3::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
-        let versioned_purl_query = entity::versioned_purl::Entity::find()
+        /*
+        let purl_status_query = entity::versioned_purl::Entity::find()
             .join(
                 JoinType::Join,
                 entity::versioned_purl::Relation::BasePurl.def(),
@@ -151,6 +152,14 @@ impl VulnerabilityAdvisorySummary {
                     )))
                     .arg(Expr::col((entity::version_range::Entity, Asterisk))),
             ));
+
+         */
+        let purl_status_query = entity::purl_status::Entity::find()
+            .left_join(entity::status::Entity)
+            .filter(entity::purl_status::Column::VulnerabilityId.eq(&vulnerability.id))
+            .left_join(entity::base_purl::Entity)
+            .left_join(entity::version_range::Entity)
+            .left_join(entity::cpe::Entity);
 
         let sbom_status_query = entity::sbom_package_purl_ref::Entity::find()
             .join(
@@ -229,14 +238,12 @@ impl VulnerabilityAdvisorySummary {
             .group_by(entity::sbom_package::Column::NodeId)
             .group_by(entity::cpe::Column::Id);
 
-        let vuln_purl_statuses = versioned_purl_query
-            .join(
-                JoinType::LeftJoin,
-                entity::purl_status::Relation::ContextCpe.def(),
-            )
+        let vuln_purl_statuses = purl_status_query
             .try_into_multi_model::<PurlStatusCatcher>()?
             .all(tx)
             .await?;
+
+        println!("{:#?}", vuln_purl_statuses);
 
         let vuln_sbom_statuses = sbom_status_query
             .try_into_multi_model::<SbomStatusCatcher>()?
@@ -282,7 +289,7 @@ struct PurlStatusCatcher {
     status: entity::status::Model,
     purl_status: entity::purl_status::Model,
     version_range: entity::version_range::Model,
-    cpe: entity::cpe::Model,
+    cpe: Option<entity::cpe::Model>,
 
     base_purl: entity::base_purl::Model,
 }
@@ -297,7 +304,7 @@ impl FromQueryResult for PurlStatusCatcher {
                 "",
                 entity::version_range::Entity,
             )?,
-            cpe: Self::from_query_result_multi_model(res, "", entity::cpe::Entity)?,
+            cpe: Self::from_query_result_multi_model_optional(res, "", entity::cpe::Entity)?,
             base_purl: Self::from_query_result_multi_model(res, "", entity::base_purl::Entity)?,
         })
     }
@@ -402,12 +409,10 @@ impl VulnerabilityAdvisoryStatus {
         let mut statuses = HashMap::new();
 
         for each in models {
-            let mut context = None;
-
-            let cpe: Result<OwnedUri, _> = (&each.cpe).try_into();
-            if let Ok(cpe) = cpe {
-                context = Some(StatusContext::Cpe(cpe.to_string()));
-            }
+            let context = each.cpe.as_ref().and_then(|cpe| {
+                let cpe: Result<OwnedUri, _> = cpe.try_into();
+                cpe.ok().map(|cpe| StatusContext::Cpe(cpe.to_string()))
+            });
 
             let status_entry = statuses.entry(each.status.slug.clone()).or_insert(vec![]);
             status_entry.push(VulnerabilityAdvisoryStatus {

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,6 +1,7 @@
 mod details;
 mod summary;
 
+use async_graphql::ContainerType;
 pub use details::*;
 use sea_orm::{ColumnTrait, LoaderTrait, ModelTrait, QueryFilter};
 pub use summary::*;

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,7 +1,6 @@
 mod details;
 mod summary;
 
-use async_graphql::ContainerType;
 pub use details::*;
 use sea_orm::{ColumnTrait, LoaderTrait, ModelTrait, QueryFilter};
 pub use summary::*;

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -2,9 +2,7 @@ use crate::{
     vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
     Error,
 };
-use sea_orm::{
-    prelude::*, EntityTrait, FromQueryResult, IntoIdentity, QueryFilter, QuerySelect, QueryTrait,
-};
+use sea_orm::{prelude::*, EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait};
 use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
 use trustify_common::db::limiter::LimiterAsModelTrait;
 use trustify_common::db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel};
@@ -131,8 +129,7 @@ impl VulnerabilityService {
     ) -> Result<Option<VulnerabilityDetails>, Error> {
         let connection = self.db.connection(&tx);
 
-        if let Some(vulnerability) = vulnerability::Entity::find()
-            .filter(vulnerability::Column::Id.eq(identifier))
+        if let Some(vulnerability) = vulnerability::Entity::find_by_id(identifier)
             .one(&connection)
             .await?
         {
@@ -169,7 +166,7 @@ struct VulnerabilityCatcher {
 impl FromQueryResult for VulnerabilityCatcher {
     fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
         Ok(Self {
-            vulnerability: Self::from_query_result_multi_model(res, vulnerability::Entity)?,
+            vulnerability: Self::from_query_result_multi_model(res, "", vulnerability::Entity)?,
             average_score: res.try_get("", "average_score")?,
             average_severity: res.try_get("", "average_severity")?,
         })

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -95,6 +95,8 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let vuln = vuln.unwrap();
 
+    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+
     assert_eq!(2, vuln.advisories.len());
 
     Ok(())

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -48,6 +48,8 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(2, vuln.advisories.len());
 
+    println!("{}", serde_json::to_string_pretty(&vuln)?);
+
     let rustsec_advisory = vuln
         .advisories
         .iter()

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -48,7 +48,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(2, vuln.advisories.len());
 
-    println!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
 
     let rustsec_advisory = vuln
         .advisories


### PR DESCRIPTION
and learning the statuses of each SBOM related.

Allow multi-model queries to include the same table/model multiple times with appropriate aliasing.