### PR TITLE
Improve performance of fetching product summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6918,6 +6918,7 @@ dependencies = [
  "futures-util",
  "hex",
  "humantime",
+ "itertools 0.13.0",
  "jsonpath-rust",
  "log",
  "sea-orm",

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -17,6 +17,7 @@ actix-web = { workspace = true }
 anyhow = { workspace = true }
 cpe = { workspace = true }
 futures-util = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }

--- a/modules/fundamental/src/product/model/details.rs
+++ b/modules/fundamental/src/product/model/details.rs
@@ -34,7 +34,7 @@ impl ProductDetails {
         };
         Ok(ProductDetails {
             head: ProductHead::from_entity(product, tx).await?,
-            versions: ProductVersionHead::from_entities(product_versions, tx).await?,
+            versions: ProductVersionHead::from_entities(&product_versions, tx).await?,
             vendor,
         })
     }

--- a/modules/fundamental/src/product/model/mod.rs
+++ b/modules/fundamental/src/product/model/mod.rs
@@ -54,7 +54,7 @@ impl ProductVersionHead {
     }
 
     pub async fn from_entities(
-        product_versions: &Vec<product_version::Model>,
+        product_versions: &[product_version::Model],
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();

--- a/modules/fundamental/src/product/model/mod.rs
+++ b/modules/fundamental/src/product/model/mod.rs
@@ -54,13 +54,13 @@ impl ProductVersionHead {
     }
 
     pub async fn from_entities(
-        product_versions: Vec<product_version::Model>,
+        product_versions: &Vec<product_version::Model>,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
 
         for entity in product_versions {
-            heads.push(ProductVersionHead::from_entity(&entity, tx).await?);
+            heads.push(ProductVersionHead::from_entity(entity, tx).await?);
         }
 
         Ok(heads)


### PR DESCRIPTION
By using load_many and load_one patterns we can now avoid querying in the loop