### PR TITLE
ci: Continuously create image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.trustify/

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -1,0 +1,26 @@
+name: Multiple Architecture Image Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "release-*"
+#    tags:
+#      - "v*"
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image-build:
+    uses: trustification/release-tools/.github/workflows/build-push-images.yaml@main
+    with:
+      registry: "ghcr.io"
+      image_name: "${{ github.repository_owner }}/trustd"
+      containerfile: "./Dockerfile"
+      architectures: '[ "amd64" ]'
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+######################################################################
+# UI
+######################################################################
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS ui-source
+ARG ui_branch="main"
+ARG ui_commit
+
+USER root
+RUN dnf install git -y
+
+RUN git clone https://github.com/trustification/trustify-ui.git --branch ${ui_branch} /trustify-ui/
+RUN cd /trustify-ui/ && if [ -n "${ui_commit}" ]; then git checkout -b commit-branch ${ui_commit}; fi
+RUN chown -R 1001 /trustify-ui/
+
+USER 1001
+RUN npm install -g npm@9
+RUN cd /trustify-ui/ && npm clean-install --ignore-scripts && npm run build && npm run dist
+
+######################################################################
+# Prepare server
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi:latest AS server-source
+COPY . /trustify/
+RUN sed -i 's/trustify-ui = { git = "https:\/\/github.com\/trustification\/trustify-ui.git", tag = "static-main" }/trustify-ui = { path = "..\/trustify-ui\/crate" }/g' /trustify/Cargo.toml
+
+######################################################################
+# Build server
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi:latest AS server-builder
+
+# Dependencies
+RUN dnf install -y openssl-devel gcc
+
+RUN mkdir /stage/ && \
+    dnf install --installroot /stage/ --setop install_weak_deps=false --nodocs -y zlib openssl && \
+    dnf clean all --installroot /stage/
+
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=${PATH}:/root/.cargo/bin
+RUN rustup target add $(uname -m)-unknown-linux-gnu
+
+# Build source code
+COPY --from=ui-source /trustify-ui/ /code/trustify-ui/
+COPY --from=server-source /trustify/ /code/trustify/
+RUN cd /code/trustify/ && \
+    cargo build --no-default-features --release --target=$(uname -m)-unknown-linux-gnu && \
+    find /code/trustify/target/ -name "trustd" -exec cp -av {} /stage/usr/local/bin \;
+
+######################################################################
+# Builder runner
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest AS server-runner
+COPY --from=server-builder /stage/ .
+ENTRYPOINT ["/usr/local/bin/trustd"]


### PR DESCRIPTION
Fix: https://github.com/trustification/trustify/issues/637

- Tested in my local fork here https://github.com/carlosthe19916/trustify/actions/runs/10250287369 . The tested container image was also generated correctly in my local fork https://github.com/carlosthe19916/trustify/pkgs/container/trustd
- Adding a workflow to continuously create container images of the server. It takes the code available in the branch and merges it with the latest available UI in the trustify-ui repository