### PR TITLE
chore: lower to debug

### DIFF
--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -263,7 +263,7 @@ pub fn fix_license(report: &dyn ReportSink, mut json: Value) -> (Value, bool) {
 
                     let message =
                         format!("Replacing faulty SPDX license expression with NOASSERTION: {err}");
-                    log::warn!("{message}");
+                    log::debug!("{message}");
                     report.error(message);
                 }
             }


### PR DESCRIPTION
We now collect that message and report it either through the ingestion result or the importer report. Shouting it out on the applications log channels no longer makes sense.