### PR TITLE
feat: refactor temp file creation to reduce S3 usage

### DIFF
--- a/migration/src/m0000510_create_maven_cmp_fns.rs
+++ b/migration/src/m0000510_create_maven_cmp_fns.rs
@@ -6,17 +6,13 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let x = manager
+        manager
             .get_connection()
             .execute_unprepared(include_str!(
                 "m0000510_create_maven_cmp_fns/mavenver_cmp.sql"
             ))
             .await
-            .map(|_| ());
-
-        println!("{:#?}", x);
-
-        x?;
+            .map(|_| ())?;
 
         manager
             .get_connection()

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod dispatch;
 pub mod fs;
 pub mod s3;
+mod temp;
 
 use crate::service::fs::FileSystemBackend;
 use bytes::{Bytes, BytesMut};

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -1,11 +1,10 @@
+use crate::service::temp::TempFile;
 use crate::service::{StorageBackend, StorageKey, StorageResult, StoreError};
 use bytes::Bytes;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::Stream;
 use s3::{creds::Credentials, error::S3Error, Bucket};
-use std::{fmt::Debug, io, pin::pin};
-use tokio_util::io::StreamReader;
-use trustify_common::{config::S3Config, hashing::Contexts};
-use uuid::Uuid;
+use std::{fmt::Debug, pin::pin};
+use trustify_common::config::S3Config;
 
 #[derive(Clone, Debug)]
 pub struct S3Backend {
@@ -43,37 +42,15 @@ impl StorageBackend for S3Backend {
         E: Debug,
         S: Stream<Item = Result<Bytes, E>>,
     {
-        let mut contexts = Contexts::new();
-        let stream = pin!(stream.map(|item| {
-            if let Ok(ref bytes) = item {
-                contexts.update(bytes);
-            }
-            item
-        }));
+        let errhdlr = |e| StoreError::Backend(S3Error::Io(e));
 
-        // StreamReader requires std::io::Error items instead of Debug
-        let stream = stream.map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{e:?}")));
-        let mut rdr = StreamReader::new(stream);
+        let stream = pin!(stream);
+        let mut file = TempFile::new(stream).await.map_err(errhdlr)?;
+        let mut source = file.reader().await.map_err(errhdlr)?;
+        let result = file.result();
 
-        // Write the object with a temp key while digests are being calculated
-        let path = format!("__temp__{}", Uuid::new_v4());
         self.bucket
-            .put_object_stream(&mut rdr, &path)
-            .await
-            .map_err(StoreError::Backend)?;
-
-        let result = StorageResult {
-            digests: contexts.finish(),
-        };
-        let key: String = result.key().to_string();
-
-        // Rename the object with a key calculated from its digests
-        self.bucket
-            .copy_object_internal(&path, &key)
-            .await
-            .map_err(StoreError::Backend)?;
-        self.bucket
-            .delete_object(&path)
+            .put_object_stream(&mut source, result.key().to_string())
             .await
             .map_err(StoreError::Backend)?;
 

--- a/modules/storage/src/service/temp.rs
+++ b/modules/storage/src/service/temp.rs
@@ -1,0 +1,62 @@
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use std::{
+    fmt::Debug,
+    io::{Error, SeekFrom},
+    pin::pin,
+};
+use tempfile::tempfile;
+use tokio::{
+    fs::File,
+    io::{AsyncRead, AsyncSeekExt, AsyncWriteExt},
+};
+use trustify_common::hashing::{Contexts, Digests};
+
+use super::StorageResult;
+
+pub struct TempFile {
+    file: File,
+    digests: Digests,
+}
+
+/// Writes the contents of a stream to a temporary file and provides a
+/// unique key for consumers to use to write the contents elsewhere,
+/// e.g. Filesystem or S3.
+impl TempFile {
+    pub async fn new<S, E>(stream: S) -> Result<Self, Error>
+    where
+        E: Debug,
+        S: Stream<Item = Result<Bytes, E>>,
+    {
+        let mut file = File::from(tempfile()?);
+        let mut stream = pin!(stream);
+        let mut contexts = Contexts::new();
+
+        while let Some(next) = stream
+            .next()
+            .await
+            .transpose()
+            .map_err(|e| Error::other(format!("{e:?}")))?
+        {
+            contexts.update(&next);
+            file.write_all(&next).await?;
+        }
+        let digests = contexts.finish();
+
+        Ok(Self { file, digests })
+    }
+
+    /// Return a clone of the temp file after resetting its position
+    pub async fn reader(&mut self) -> Result<impl AsyncRead, Error> {
+        self.file.seek(SeekFrom::Start(0)).await?;
+        self.file.try_clone().await
+    }
+
+    /// Passing self should ensure self.file is dropped and hence
+    /// deleted from the filesystem
+    pub fn result(self) -> StorageResult {
+        StorageResult {
+            digests: self.digests,
+        }
+    }
+}


### PR DESCRIPTION
Now both the FS and S3 backends share the same logic to create a temp file before permanently storing its content keyed by its digest. This enables a single S3 write per document rather than the previous potentially expensive write/copy/delete.

Relates to #621 