### PR TITLE
fix: refactor sbom dto objects to better represent data model

### DIFF
--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -671,7 +671,7 @@ async fn gc_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         assert_eq!(
             1,
             sbom_service
-                .delete_sbom(sbom.head.id, Transactional::None)
+                .delete_sbom(sbom.summary.head.id, Transactional::None)
                 .await?
         );
 

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -221,7 +221,7 @@ pub async fn delete(
     let id = Id::from_str(&id).map_err(Error::IdKey)?;
     match service.fetch_sbom(id.clone(), ()).await? {
         Some(v) => {
-            let rows_affected = service.delete_sbom(v.head.id, ()).await?;
+            let rows_affected = service.delete_sbom(v.summary.head.id, ()).await?;
             match rows_affected {
                 0 => Ok(HttpResponse::NotFound().finish()),
                 1 => {
@@ -391,7 +391,7 @@ pub async fn download(
     let stream = ingestor
         .storage()
         .clone()
-        .retrieve(sbom.head.hashes.try_into()?)
+        .retrieve(sbom.summary.head.hashes.try_into()?)
         .await
         .map_err(Error::Storage)?
         .map(|stream| stream.map_err(Error::Storage));

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -56,17 +56,20 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have different names
 
-    assert_eq!(sbom1.head.name, "quarkus-bom");
-    assert_eq!(sbom2.head.name, "quarkus-bom-2.13.8.Final-redhat-00004");
-    assert_eq!(sbom1.described_by.len(), 1);
-    assert_eq!(sbom2.described_by.len(), 1);
+    assert_eq!(sbom1.summary.head.name, "quarkus-bom");
+    assert_eq!(
+        sbom2.summary.head.name,
+        "quarkus-bom-2.13.8.Final-redhat-00004"
+    );
+    assert_eq!(sbom1.summary.described_by.len(), 1);
+    assert_eq!(sbom2.summary.described_by.len(), 1);
 
     // clear the ID as that one will be different
 
-    sbom1.described_by[0].id = "".into();
-    sbom2.described_by[0].id = "".into();
+    sbom1.summary.described_by[0].id = "".into();
+    sbom2.summary.described_by[0].id = "".into();
 
-    assert_eq!(sbom1.described_by[0], sbom2.described_by[0]);
+    assert_eq!(sbom1.summary.described_by[0], sbom2.summary.described_by[0]);
 
     // but both sboms can be found by the same purl
 
@@ -130,17 +133,17 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom1.described_by.len(), 1);
-    assert_eq!(sbom2.described_by.len(), 1);
+    assert_eq!(sbom1.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.summary.described_by.len(), 1);
+    assert_eq!(sbom2.summary.described_by.len(), 1);
 
     // clear the ID as that one will be different
 
-    sbom1.described_by[0].id = "".into();
-    sbom2.described_by[0].id = "".into();
+    sbom1.summary.described_by[0].id = "".into();
+    sbom2.summary.described_by[0].id = "".into();
 
-    assert_eq!(sbom1.described_by[0], sbom2.described_by[0]);
+    assert_eq!(sbom1.summary.described_by[0], sbom2.summary.described_by[0]);
 
     // done
 
@@ -190,17 +193,17 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom1.described_by.len(), 1);
-    assert_eq!(sbom2.described_by.len(), 1);
+    assert_eq!(sbom1.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.summary.described_by.len(), 1);
+    assert_eq!(sbom2.summary.described_by.len(), 1);
 
     // clear the ID as that one will be different
 
-    sbom1.described_by[0].id = "".into();
-    sbom2.described_by[0].id = "".into();
+    sbom1.summary.described_by[0].id = "".into();
+    sbom2.summary.described_by[0].id = "".into();
 
-    assert_eq!(sbom1.described_by[0], sbom2.described_by[0]);
+    assert_eq!(sbom1.summary.described_by[0], sbom2.summary.described_by[0]);
 
     // done
 
@@ -266,17 +269,17 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom2.head.name, "RHWA-NHC-0.4-RHEL-8");
-    assert_eq!(sbom1.described_by.len(), 1);
-    assert_eq!(sbom2.described_by.len(), 1);
+    assert_eq!(sbom1.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom2.summary.head.name, "RHWA-NHC-0.4-RHEL-8");
+    assert_eq!(sbom1.summary.described_by.len(), 1);
+    assert_eq!(sbom2.summary.described_by.len(), 1);
 
     // clear the ID as that one will be different
 
-    sbom1.described_by[0].id = "".into();
-    sbom2.described_by[0].id = "".into();
+    sbom1.summary.described_by[0].id = "".into();
+    sbom2.summary.described_by[0].id = "".into();
 
-    assert_eq!(sbom1.described_by[0], sbom2.described_by[0]);
+    assert_eq!(sbom1.summary.described_by[0], sbom2.summary.described_by[0]);
 
     // done
 
@@ -329,17 +332,23 @@ async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // both sboms have the same name
 
-    assert_eq!(sbom1.head.name, "registry.access.redhat.com/ubi9/ubi");
-    assert_eq!(sbom2.head.name, "registry.access.redhat.com/ubi9/ubi");
-    assert_eq!(sbom1.described_by.len(), 1);
-    assert_eq!(sbom2.described_by.len(), 1);
+    assert_eq!(
+        sbom1.summary.head.name,
+        "registry.access.redhat.com/ubi9/ubi"
+    );
+    assert_eq!(
+        sbom2.summary.head.name,
+        "registry.access.redhat.com/ubi9/ubi"
+    );
+    assert_eq!(sbom1.summary.described_by.len(), 1);
+    assert_eq!(sbom2.summary.described_by.len(), 1);
 
     // clear the ID as that one will be different
 
-    sbom1.described_by[0].id = "".into();
-    sbom2.described_by[0].id = "".into();
+    sbom1.summary.described_by[0].id = "".into();
+    sbom2.summary.described_by[0].id = "".into();
 
-    assert_eq!(sbom1.described_by[0], sbom2.described_by[0]);
+    assert_eq!(sbom1.summary.described_by[0], sbom2.summary.described_by[0]);
 
     // done
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2069,30 +2069,13 @@ components:
               $ref: '#/components/schemas/SbomStatus'
     SbomDetails:
       allOf:
-      - $ref: '#/components/schemas/SbomHead'
+      - $ref: '#/components/schemas/SbomSummary'
       - type: object
-        required:
-        - published
-        - authors
-        - described_by
-        - advisories
         properties:
           advisories:
             type: array
             items:
               $ref: '#/components/schemas/SbomAdvisory'
-          authors:
-            type: array
-            items:
-              type: string
-          described_by:
-            type: array
-            items:
-              $ref: '#/components/schemas/SbomPackage'
-          published:
-            type: string
-            format: date-time
-            nullable: true
     SbomHead:
       type: object
       required:
@@ -2100,8 +2083,13 @@ components:
       - hashes
       - document_id
       - labels
+      - published
       - name
       properties:
+        authors:
+          type: array
+          items:
+            type: string
         document_id:
           type: string
         hashes:
@@ -2115,6 +2103,10 @@ components:
           $ref: '#/components/schemas/Labels'
         name:
           type: string
+        published:
+          type: string
+          format: date-time
+          nullable: true
     SbomImporter:
       allOf:
       - $ref: '#/components/schemas/CommonImporter'
@@ -2200,22 +2192,12 @@ components:
       - $ref: '#/components/schemas/SbomHead'
       - type: object
         required:
-        - published
-        - authors
         - described_by
         properties:
-          authors:
-            type: array
-            items:
-              type: string
           described_by:
             type: array
             items:
               $ref: '#/components/schemas/SbomPackage'
-          published:
-            type: string
-            format: date-time
-            nullable: true
     State:
       type: string
       enum:


### PR DESCRIPTION
This is a first attempt to refactor SBOM DTOs to be more inline with the others. 

* `SbomHead` now maps all fields from `sboms` table
* `SbomSummary` is `SbomHead`+packages
* `SbomDetails` is `SbomSummary`+advisories
* All DTOs now implement `from_entity()` pattern