### PR TITLE
chore: fix openapi validate command

### DIFF
--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -48,6 +48,8 @@ impl Validate {
                 "--rm",
                 "-v",
                 ".:/src",
+                "--security-opt",
+                "label=disable",
                 "docker.io/openapitools/openapi-generator-cli:v7.7.0",
                 "validate",
                 "-i",


### PR DESCRIPTION
Closes #659 

```
➜  trustify git:(foo) ✗ cargo xtask validate-openapi --export
   Compiling xtask v0.1.0-alpha.13 (/home/heliofrota/Desktop/tc/trustify/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.96s
     Running `target/debug/xtask validate-openapi --export`
Writing openapi.yaml to "openapi_yaml"
Writing openapi.yaml to "/tmp/openapi.yaml"
Validating spec (/src/openapi.yaml)
Warnings:
	- Unused model: AdvisoryVulnerabilityAssertions
	- Unused model: Assertion
	- Unused model: Uuid

[info] Spec has 3 recommendation(s).
```

I found here https://bugzilla.redhat.com/show_bug.cgi?id=1777018