### PR TITLE
chore: using workspace.package to centralize configs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,12 @@ members = [
     "xtask",
 ]
 
+[workspace.package]
+version = "0.1.0-alpha.13"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+
 [workspace.dependencies]
 actix = "0.13.3"
 actix-cors = "0.7"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-common"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-migration = { workspace = true }

--- a/common/auth/Cargo.toml
+++ b/common/auth/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "trustify-auth"
-version = "0.1.0-alpha.13"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 description = "Authentication and authorization functionality"
 
 [dependencies]

--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-infrastructure"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 actix-cors = { workspace = true }

--- a/cvss/Cargo.toml
+++ b/cvss/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-cvss"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-entity"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-common = { workspace = true }

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "trustify-migration"
-version = "0.1.0-alpha.13"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [lib]
 name = "migration"

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-module-fundamental"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/modules/graphql/Cargo.toml
+++ b/modules/graphql/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-module-graphql"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-entity = { workspace = true }

--- a/modules/importer/Cargo.toml
+++ b/modules/importer/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-module-importer"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "trustify-module-ingestor"
-version = "0.1.0-alpha.13"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-common = { workspace = true }

--- a/modules/storage/Cargo.toml
+++ b/modules/storage/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "trustify-module-storage"
-version = "0.1.0-alpha.13"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-common = { workspace = true }

--- a/modules/ui/Cargo.toml
+++ b/modules/ui/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-module-ui"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 actix-web = { workspace = true }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Trustify
   description: Software Supply-Chain Security API
   license:
-    name: ''
+    name: Apache-2.0
   version: 0.1.0-alpha.13
 paths:
   /api/v1/advisory:

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-server"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-auth = { workspace = true }

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-test-context"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 trustify-common = { workspace = true }

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "trustify-trustd"
-version = "0.1.0-alpha.13"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "trustd"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "xtask"
-version = "0.1.0-alpha.13"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION

![2024-08-12_08-47](https://github.com/user-attachments/assets/01b110c9-4b90-40fc-a600-771e8ff04fe8)


when running cargo release [dry-run] we can see it works fine, changing only the root `Cargo.toml`

`cargo release version alpha -v`

```console
   Upgrading workspace to version 0.1.0-alpha.14
[2024-08-12T10:58:24Z DEBUG cargo_release::ops::cargo] change:
    --- /home/heliofrota/Desktop/tc/trustify/Cargo.toml	original
    +++ /home/heliofrota/Desktop/tc/trustify/Cargo.toml	updated
    @@ -20,7 +20,7 @@
     ]

     [workspace.package]
    -version = "0.1.0-alpha.13"
    +version = "0.1.0-alpha.14"
     edition = "2021"
     publish = false
     license = "Apache-2.0"

   Upgrading trustify-cvss from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-migration from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-common from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-entity from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-storage from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-ingestor from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-test-context from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-auth from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-infrastructure from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-importer from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-ui from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-fundamental from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-module-graphql from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-server from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading trustify-trustd from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
   Upgrading xtask from 0.1.0-alpha.13 to 0.1.0-alpha.14 (inherited from workspace)
```   