### PR TITLE
feat: replace SyncAdapter with SyncIoBridge to reduce RAM usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4410,6 +4410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
 
 [[package]]
+name = "peak_alloc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c4e8e2dd832fd76346468f822e4e600d30ba4e5aa545a128abf12cfae7ea3e"
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7552,6 +7558,7 @@ dependencies = [
  "futures",
  "liblzma",
  "log",
+ "peak_alloc",
  "postgresql_embedded",
  "test-context",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ opentelemetry_sdk = "0.22"
 osv = { version = "0.2.0", default-features = false }
 packageurl = "0.3.0"
 parking_lot = "0.12"
+peak_alloc = "0.2.0"
 pem = "3"
 prometheus = "0.13.3"
 rand = "0.8.5"

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -2,6 +2,7 @@ mod corner_cases;
 mod perf;
 
 use super::*;
+use serde_json::Value;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
@@ -162,7 +163,8 @@ where
         ctx,
         sbom,
         |data| {
-            let (sbom, _) = parse_spdx(&Discard, data)?;
+            let json: Value = serde_json::from_reader(data)?;
+            let (sbom, _) = parse_spdx(&Discard, json)?;
             Ok(fix_spdx_rels(sbom))
         },
         |ctx, sbom, tx| {

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -39,6 +39,7 @@ spdx-expression = { workspace = true }
 spdx-rs = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["serde-well-known"] }
+tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras"] }
@@ -52,4 +53,3 @@ rstest = {workspace = true }
 serde_yaml = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
-tokio = { workspace = true, features = ["full"] }

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -15,7 +15,7 @@ use sbom_walker::report::{check, ReportSink};
 use serde_json::Value;
 use spdx_rs::models::{RelationshipType, SPDX};
 use std::collections::HashMap;
-use std::{io::Read, str::FromStr};
+use std::str::FromStr;
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, db::Transactional, purl::Purl};
@@ -316,11 +316,7 @@ pub fn fix_license(report: &dyn ReportSink, mut json: Value) -> (Value, bool) {
 /// Parse a SPDX document, possibly replacing invalid license expressions.
 ///
 /// Returns the parsed document and a flag indicating if license expressions got replaced.
-pub fn parse_spdx(
-    report: &dyn ReportSink,
-    data: impl Read,
-) -> Result<(SPDX, bool), serde_json::Error> {
-    let json = serde_json::from_reader::<_, Value>(data)?;
+pub fn parse_spdx(report: &dyn ReportSink, json: Value) -> Result<(SPDX, bool), serde_json::Error> {
     let (json, changed) = fix_license(report, json);
     Ok((serde_json::from_value(json)?, changed))
 }

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -131,7 +131,6 @@ impl IngestorService {
 
         let reader = self
             .storage
-            .clone() // TODO: why?
             .retrieve(result.key())
             .await
             .map_err(Error::Storage)?

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -4,7 +4,6 @@ use crate::{
     service::Error,
 };
 use cyclonedx_bom::prelude::Bom;
-use std::io::Read;
 use trustify_common::{hashing::Digests, id::Id};
 use trustify_entity::labels::Labels;
 
@@ -17,15 +16,12 @@ impl<'g> CyclonedxLoader<'g> {
         Self { graph }
     }
 
-    pub async fn load<R: Read>(
+    pub async fn load(
         &self,
         labels: Labels,
-        document: R,
+        sbom: Bom,
         digests: &Digests,
     ) -> Result<IngestResult, Error> {
-        let sbom = Bom::parse_json_value(serde_json::from_reader(document)?)
-            .map_err(|err| Error::UnsupportedFormat(format!("Failed to parse: {err}")))?;
-
         let labels = labels.add("type", "cyclonedx");
 
         log::info!(

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -7,7 +7,7 @@ use crate::{
     model::IngestResult,
     service::Error,
 };
-use std::io::Read;
+use serde_json::Value;
 use trustify_common::{hashing::Digests, id::Id};
 use trustify_entity::labels::Labels;
 
@@ -20,10 +20,10 @@ impl<'g> SpdxLoader<'g> {
         Self { graph }
     }
 
-    pub async fn load<R: Read>(
+    pub async fn load(
         &self,
         labels: Labels,
-        json: R,
+        json: Value,
         digests: &Digests,
     ) -> Result<IngestResult, Error> {
         let warnings = Warnings::default();

--- a/modules/storage/src/service/dispatch.rs
+++ b/modules/storage/src/service/dispatch.rs
@@ -34,10 +34,10 @@ impl StorageBackend for DispatchBackend {
         }
     }
 
-    async fn retrieve(
-        self,
+    async fn retrieve<'a>(
+        &self,
         key: StorageKey,
-    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error>
+    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error>
     where
         Self: Sized,
     {

--- a/modules/storage/src/service/fs.rs
+++ b/modules/storage/src/service/fs.rs
@@ -119,10 +119,10 @@ impl StorageBackend for FileSystemBackend {
         Ok(result)
     }
 
-    async fn retrieve(
-        self,
+    async fn retrieve<'a>(
+        &self,
         StorageKey(hash): StorageKey,
-    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error> {
+    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error> {
         let target = level_dir(&self.content, &hash, NUM_LEVELS);
         create_dir_all(&target).await?;
         let target = target.join(hash);

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -84,8 +84,10 @@ pub trait StorageBackend {
         S: Stream<Item = Result<Bytes, E>>;
 
     /// Retrieve the content as an async reader
-    fn retrieve(
-        self,
+    fn retrieve<'a>(
+        &self,
         key: StorageKey,
-    ) -> impl Future<Output = Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error>>;
+    ) -> impl Future<
+        Output = Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error>,
+    >;
 }

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -57,10 +57,10 @@ impl StorageBackend for S3Backend {
         Ok(result)
     }
 
-    async fn retrieve(
-        self,
+    async fn retrieve<'a>(
+        &self,
         StorageKey(key): StorageKey,
-    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>>>, Self::Error> {
+    ) -> Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error> {
         match self.bucket.get_object_stream(key).await {
             Ok(resp) => Ok(Some(resp.bytes)),
             Err(S3Error::HttpFailWithBody(404, _)) => Ok(None),

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 futures = { workspace = true }
 liblzma = { workspace = true }
 log = { workspace = true }
+peak_alloc = { workspace = true }
 postgresql_embedded = { workspace = true }
 test-context = { workspace = true }
 tokio = { workspace = true }

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -38,16 +38,19 @@ impl TrustifyContext {
             .await
             .expect("initializing the storage backend");
         let graph = Graph::new(db.clone());
-
         let ingestor = IngestorService::new(graph.clone(), storage.clone());
+        let mem_limit_mb = env::var("MEM_LIMIT_MB")
+            .unwrap_or("500".into())
+            .parse()
+            .expect("a numerical value");
 
         Self {
             db,
             graph,
             storage,
             ingestor,
+            mem_limit_mb,
             postgresql: postgresql.into(),
-            mem_limit_mb: 500.0,
         }
     }
 


### PR DESCRIPTION
Because serde deserialization is synchronous, and because we immediately read back the bytes we store when ingesting a doc (to ensure we can), we store them in RAM before asking serde to deserialize them.

So now we deserialize through the bridge, hopefully using less RAM in the process.

Helps with #654 though I'm sure there's more to do.