### PR TITLE
Add `cargo xtask precommit` rename `validate-openapi` to `openapi`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,10 @@ jobs:
           RUST_LOG: info,sqlx=error,sea_orm=error
       - name: Export and Validate Generated Openapi Spec
         run: |
-          cargo xtask validate-openapi --export
+          cargo xtask openapi
           git diff --quiet
           if [ $? -gt 0 ]; then
-              echo "::error::Uncommitted changes (run `cargo xtask validate-openapi --export` after making api changes)"
+              echo "::error::Uncommitted changes (run `cargo xtask openapi` after making api changes)"
               exit 1
           fi
       - name: Ensure schemas are up-to-date

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
 mod dataset;
 mod log;
 mod openapi;
+mod precommit;
 mod schema;
 
 #[derive(Debug, Parser)]
@@ -17,21 +18,24 @@ pub struct Xtask {
 impl Xtask {
     pub async fn run(self) -> anyhow::Result<()> {
         match self.command {
-            Command::ValidateOpenapi(command) => command.run(),
+            Command::Openapi(command) => command.run(),
             Command::GenerateDump(command) => command.run().await,
             Command::GenerateSchemas(command) => command.run().await,
+            Command::Precommit(command) => command.run().await,
         }
     }
 }
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Validate the generated OpenAPI spec
-    ValidateOpenapi(openapi::Validate),
+    /// Used to generate and/or validate the openapi spec
+    Openapi(openapi::Openapi),
     /// Generate a sample data database dump
     GenerateDump(dataset::GenerateDump),
     /// Generate all schemas
     GenerateSchemas(schema::GenerateSchema),
+    /// Run precommit checks
+    Precommit(precommit::Precommit),
 }
 
 #[tokio::main]

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
+use std::env::current_dir;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -73,7 +74,7 @@ pub fn validate() -> anyhow::Result<()> {
             "run",
             "--rm",
             "-v",
-            ".:/src",
+            format!("{}:/src", current_dir()?.to_str().unwrap()).as_str(),
             "--security-opt",
             "label=disable",
             "docker.io/openapitools/openapi-generator-cli:v7.7.0",

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -1,69 +1,34 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use std::{
-    env, fs,
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
 use trustify_server::openapi::openapi;
 
-#[derive(Debug, Parser)]
-pub struct Validate {
-    /// should the openapi.yaml be exported too?
-    #[arg(short, long, default_value = "false")]
-    export: bool,
+#[derive(Debug, Parser, Default)]
+pub struct Openapi {
+    /// skip generating the openapi file?
+    #[arg(long, default_value = "false")]
+    no_generate: bool,
+
+    /// skip validating the openapi file??
+    #[arg(long, default_value = "false")]
+    no_validate: bool,
 }
 
-impl Validate {
+impl Openapi {
     pub fn run(self) -> anyhow::Result<()> {
-        let command = if command_exists("podman") {
-            "podman"
-        } else if command_exists("docker") {
-            "docker"
-        } else {
-            return Err(anyhow!(
-                "This task requires podman or docker to be installed."
-            ));
-        };
-
-        let out_dir = env::temp_dir();
-        let openapi_yaml = Path::new(&out_dir).join("openapi.yaml");
-
-        let doc = openapi()
-            .to_yaml()
-            .map_err(|_| anyhow!("Failed to convert openapi spec to yaml"))?;
-
-        if self.export {
-            println!("Writing openapi.yaml to {:?}", "openapi_yaml");
-            write_openapi(None)?;
+        if !self.no_generate {
+            generate_openapi(None)?;
         }
 
-        println!("Writing openapi.yaml to {:?}", openapi_yaml);
-        fs::write(openapi_yaml, doc).map_err(|_| anyhow!("Failed to write openapi spec"))?;
-
-        // run the openapi generator validator container
-        if Command::new(command)
-            .args([
-                "run",
-                "--rm",
-                "-v",
-                ".:/src",
-                "--security-opt",
-                "label=disable",
-                "docker.io/openapitools/openapi-generator-cli:v7.7.0",
-                "validate",
-                "-i",
-                "/src/openapi.yaml",
-            ])
-            .current_dir(out_dir.to_str().unwrap())
-            .status()
-            .map_err(|_| anyhow!("Failed to validate openapi.yaml"))?
-            .success()
-        {
-            Ok(())
-        } else {
-            Err(anyhow!("Failed to validate openapi.yaml"))
+        if !self.no_validate {
+            validate()?;
         }
+
+        Ok(())
     }
 }
 
@@ -74,17 +39,54 @@ fn command_exists(cmd: &str) -> bool {
     }
 }
 
-pub fn write_openapi(base: Option<&Path>) -> anyhow::Result<()> {
-    let doc = openapi()
-        .to_yaml()
-        .context("Failed to convert openapi spec to yaml")?;
-
+pub fn generate_openapi(base: Option<&Path>) -> anyhow::Result<()> {
     let mut path = PathBuf::from("openapi.yaml");
     if let Some(base) = base {
         path = base.join(path);
     }
 
+    println!("Writing openapi to {:?}", &path);
+    let doc = openapi()
+        .to_yaml()
+        .context("Failed to convert openapi spec to yaml")?;
     fs::write(path, doc).context("Failed to write openapi spec")?;
 
     Ok(())
+}
+
+pub fn validate() -> anyhow::Result<()> {
+    let command = if command_exists("podman") {
+        "podman"
+    } else if command_exists("docker") {
+        "docker"
+    } else {
+        return Err(anyhow!(
+            "This openapi validation requires podman or docker to be installed."
+        ));
+    };
+
+    println!("Validating openapi at {:?}", "openapi.yaml");
+
+    // run the openapi validator container
+    if Command::new(command)
+        .args([
+            "run",
+            "--rm",
+            "-v",
+            ".:/src",
+            "--security-opt",
+            "label=disable",
+            "docker.io/openapitools/openapi-generator-cli:v7.7.0",
+            "validate",
+            "-i",
+            "/src/openapi.yaml",
+        ])
+        .status()
+        .map_err(|_| anyhow!("Failed to validate openapi.yaml"))?
+        .success()
+    {
+        Ok(())
+    } else {
+        Err(anyhow!("Failed to validate openapi.yaml"))
+    }
 }

--- a/xtask/src/precommit.rs
+++ b/xtask/src/precommit.rs
@@ -1,0 +1,63 @@
+use crate::openapi::Openapi;
+use crate::schema::GenerateSchema;
+use anyhow::anyhow;
+use clap::Parser;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Parser)]
+pub struct Precommit {}
+
+impl Precommit {
+    pub async fn run(self) -> anyhow::Result<()> {
+        GenerateSchema {
+            base: Path::new(".").to_path_buf(),
+        }
+        .run()
+        .await?;
+
+        Openapi::default().run()?;
+
+        println!("Running: cargo clippy");
+        if !Command::new("cargo")
+            .args([
+                "clippy",
+                "--all-targets",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+                "-D",
+                "clippy::unwrap_used",
+                "-D",
+                "clippy::expect_used",
+            ])
+            .status()
+            .map_err(|_| anyhow!("cargo clippy failed"))?
+            .success()
+        {
+            return Err(anyhow!("cargo clippy failed"));
+        }
+
+        println!("Running: cargo fmt");
+        if !Command::new("cargo")
+            .args(["fmt"])
+            .status()
+            .map_err(|_| anyhow!("cargo fmt failed"))?
+            .success()
+        {
+            return Err(anyhow!("cargo fmt failed"));
+        }
+
+        println!("Running: cargo check");
+        if !Command::new("cargo")
+            .args(["check"])
+            .status()
+            .map_err(|_| anyhow!("cargo check failed"))?
+            .success()
+        {
+            return Err(anyhow!("cargo check failed"));
+        }
+        Ok(())
+    }
+}

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -1,4 +1,4 @@
-use crate::{dataset::Instructions, openapi::write_openapi};
+use crate::dataset::Instructions;
 use clap::Parser;
 use schemars::JsonSchema;
 use std::{
@@ -10,22 +10,14 @@ use trustify_auth::auth::AuthConfig;
 #[derive(Debug, Parser)]
 pub struct GenerateSchema {
     #[arg(short, long, default_value = ".")]
-    base: PathBuf,
+    pub base: PathBuf,
 }
 
 impl GenerateSchema {
     pub async fn run(self) -> anyhow::Result<()> {
         // write schema
-
         self.write_schema::<Instructions>("xtask/schema/generate-dump.json")?;
         self.write_schema::<AuthConfig>("common/auth/schema/auth.json")?;
-
-        // write openapi spec
-
-        write_openapi(Some(&self.base))?;
-
-        // done
-
         Ok(())
     }
 


### PR DESCRIPTION
* I think this should streamline the xtask commands a bit.

* `cargo xtask precommit` does: generates the schema, generates openapi, validates openapi, cargo fmt, cargo clip, and cargo check.
	

* the `cargo xtask openapi` command now generates and validates (it has flags to skip either).

* the `cargo xtask gnerate-schemas` now only generates the schemas.
