### PR TITLE
Have ingestion take bytes instead of stream and omit the Format arg

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -8,7 +8,6 @@ use crate::{advisory::service::AdvisoryService, Error};
 use actix_web::{delete, get, post, web, HttpResponse, Responder};
 use futures_util::TryStreamExt;
 use std::str::FromStr;
-use tokio_util::io::ReaderStream;
 use trustify_common::{db::query::Query, db::Database, id::Id, model::Paginated};
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::service::{Format, IngestorService};
@@ -167,8 +166,7 @@ pub async fn upload(
     bytes: web::Bytes,
 ) -> Result<impl Responder, Error> {
     let fmt = Format::from_bytes(&bytes)?;
-    let payload = ReaderStream::new(&*bytes);
-    let result = service.ingest(labels, issuer, fmt, payload).await?;
+    let result = service.ingest(labels, issuer, fmt, &bytes).await?;
     log::info!("Uploaded Advisory: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -10,7 +10,7 @@ use futures_util::TryStreamExt;
 use std::str::FromStr;
 use trustify_common::{db::query::Query, db::Database, id::Id, model::Paginated};
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::IngestorService;
 use trustify_module_storage::service::StorageBackend;
 use utoipa::{IntoParams, OpenApi};
 
@@ -165,8 +165,7 @@ pub async fn upload(
     web::Query(UploadParams { issuer, labels }): web::Query<UploadParams>,
     bytes: web::Bytes,
 ) -> Result<impl Responder, Error> {
-    let fmt = Format::from_bytes(&bytes)?;
-    let result = service.ingest(labels, issuer, fmt, &bytes).await?;
+    let result = service.ingest(labels, issuer, &bytes).await?;
     log::info!("Uploaded Advisory: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -14,7 +14,6 @@ use actix_web::{delete, get, post, web, HttpResponse, Responder};
 use futures_util::TryStreamExt;
 use sea_orm::prelude::Uuid;
 use std::str::FromStr;
-use tokio_util::io::ReaderStream;
 use trustify_auth::{authenticator::user::UserInformation, authorizer::Authorizer, Permission};
 use trustify_common::{
     db::{query::Query, Database},
@@ -357,9 +356,7 @@ pub async fn upload(
     bytes: web::Bytes,
 ) -> Result<impl Responder, Error> {
     let fmt = Format::from_bytes(&bytes)?;
-    let payload = ReaderStream::new(&*bytes);
-
-    let result = service.ingest(labels, None, fmt, payload).await?;
+    let result = service.ingest(labels, None, fmt, &bytes).await?;
     log::info!("Uploaded SBOM: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -23,7 +23,7 @@ use trustify_common::{
     purl::Purl,
 };
 use trustify_entity::{labels::Labels, relationship::Relationship};
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::IngestorService;
 use trustify_module_storage::service::StorageBackend;
 use utoipa::OpenApi;
 
@@ -355,8 +355,7 @@ pub async fn upload(
     web::Query(UploadQuery { labels }): web::Query<UploadQuery>,
     bytes: web::Bytes,
 ) -> Result<impl Responder, Error> {
-    let fmt = Format::from_bytes(&bytes)?;
-    let result = service.ingest(labels, None, fmt, &bytes).await?;
+    let result = service.ingest(labels, None, &bytes).await?;
     log::info!("Uploaded SBOM: {}", result.id);
     Ok(HttpResponse::Created().json(result))
 }

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -8,7 +8,6 @@ use trustify_common::db::query::Query;
 use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
 use trustify_module_fundamental::sbom::{model::details::SbomDetails, service::SbomService};
-use trustify_module_ingestor::service::Format;
 use trustify_test_context::{document_bytes, TrustifyContext};
 
 fn assert_sboms(sbom1: &SbomDetails, sbom2: &SbomDetails) {
@@ -224,7 +223,7 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // ingest the second version
     let result2 = ctx
         .ingestor
-        .ingest(("source", "test"), None, Format::SPDX, {
+        .ingest(("source", "test"), None, {
             // re-serialize file (non-pretty)
             let json: Value =
                 serde_json::from_slice(&document_bytes("nhc/v1/nhc-0.4.z.json.xz").await?)?;

--- a/modules/importer/src/runner/clearly_defined/mod.rs
+++ b/modules/importer/src/runner/clearly_defined/mod.rs
@@ -15,10 +15,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::{
-    graph::Graph,
-    service::{Format, IngestorService},
-};
+use trustify_module_ingestor::{graph::Graph, service::IngestorService};
 
 struct Context<C: RunContext + 'static> {
     context: C,
@@ -41,7 +38,6 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
-                    Format::ClearlyDefined,
                     &data,
                 )
                 .await

--- a/modules/importer/src/runner/clearly_defined/mod.rs
+++ b/modules/importer/src/runner/clearly_defined/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 use parking_lot::Mutex;
 use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
-use tokio_util::io::ReaderStream;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{
@@ -43,7 +42,7 @@ impl<C: RunContext> Context<C> {
                         .extend(&self.labels.0),
                     None,
                     Format::ClearlyDefined,
-                    ReaderStream::new(&*data),
+                    &data,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/csaf/storage.rs
+++ b/modules/importer/src/runner/csaf/storage.rs
@@ -4,7 +4,6 @@ use csaf_walker::validation::{
 };
 use parking_lot::Mutex;
 use std::sync::Arc;
-use tokio_util::io::ReaderStream;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use walker_common::utils::url::Urlify;
@@ -44,7 +43,7 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
                     .extend(&self.labels.0),
                 None, /* CSAF tracks issuer internally */
                 fmt,
-                ReaderStream::new(doc.data.as_ref()),
+                &doc.data,
             )
             .await
             .map_err(StorageError::Storage)?;

--- a/modules/importer/src/runner/csaf/storage.rs
+++ b/modules/importer/src/runner/csaf/storage.rs
@@ -5,7 +5,7 @@ use csaf_walker::validation::{
 use parking_lot::Mutex;
 use std::sync::Arc;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::IngestorService;
 use walker_common::utils::url::Urlify;
 
 pub struct StorageVisitor<C: RunContext> {
@@ -32,7 +32,6 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
         let doc = result?;
         let location = doc.context.url().to_string();
         let file = doc.possibly_relative_url();
-        let fmt = Format::from_bytes(&doc.data).map_err(|e| StorageError::Processing(e.into()))?;
 
         self.ingestor
             .ingest(
@@ -42,7 +41,6 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
                     .add("file", file)
                     .extend(&self.labels.0),
                 None, /* CSAF tracks issuer internally */
-                fmt,
                 &doc.data,
             )
             .await

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 use parking_lot::Mutex;
 use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
-use tokio_util::io::ReaderStream;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{
@@ -43,7 +42,7 @@ impl<C: RunContext> Context<C> {
                         .extend(&self.labels.0),
                     None,
                     Format::CVE,
-                    ReaderStream::new(data.as_slice()),
+                    &data,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -15,10 +15,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::{
-    graph::Graph,
-    service::{Format, IngestorService},
-};
+use trustify_module_ingestor::{graph::Graph, service::IngestorService};
 
 struct Context<C: RunContext + 'static> {
     context: C,
@@ -41,7 +38,6 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
-                    Format::CVE,
                     &data,
                 )
                 .await

--- a/modules/importer/src/runner/osv/mod.rs
+++ b/modules/importer/src/runner/osv/mod.rs
@@ -15,10 +15,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::{
-    graph::Graph,
-    service::{Format, IngestorService},
-};
+use trustify_module_ingestor::{graph::Graph, service::IngestorService};
 
 struct Context<C: RunContext + 'static> {
     context: C,
@@ -41,7 +38,6 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
-                    Format::OSV,
                     &data,
                 )
                 .await

--- a/modules/importer/src/runner/osv/mod.rs
+++ b/modules/importer/src/runner/osv/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 use parking_lot::Mutex;
 use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
-use tokio_util::io::ReaderStream;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{
@@ -43,7 +42,7 @@ impl<C: RunContext> Context<C> {
                         .extend(&self.labels.0),
                     None,
                     Format::OSV,
-                    ReaderStream::new(data.as_slice()),
+                    &data,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/sbom/storage.rs
+++ b/modules/importer/src/runner/sbom/storage.rs
@@ -10,7 +10,7 @@ use sbom_walker::validation::{
 };
 use std::sync::Arc;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::IngestorService;
 use walker_common::{compression::decompress_opt, utils::url::Urlify};
 
 pub struct StorageVisitor<C: RunContext> {
@@ -65,8 +65,6 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
             None => (doc.data.clone(), false),
         };
 
-        let fmt = Format::sbom_from_bytes(&data).map_err(|e| StorageError::Processing(e.into()))?;
-
         let result = self
             .ingestor
             .ingest(
@@ -76,7 +74,6 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
                     .add("file", &file)
                     .extend(&self.labels.0),
                 None,
-                fmt,
                 &data,
             )
             .await

--- a/modules/importer/src/runner/sbom/storage.rs
+++ b/modules/importer/src/runner/sbom/storage.rs
@@ -9,7 +9,6 @@ use sbom_walker::validation::{
     ValidatedSbom, ValidatedVisitor, ValidationContext, ValidationError,
 };
 use std::sync::Arc;
-use tokio_util::io::ReaderStream;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::service::{Format, IngestorService};
 use walker_common::{compression::decompress_opt, utils::url::Urlify};
@@ -78,7 +77,7 @@ impl<C: RunContext> ValidatedVisitor for StorageVisitor<C> {
                     .extend(&self.labels.0),
                 None,
                 fmt,
-                ReaderStream::new(data.as_ref()),
+                &data,
             )
             .await
             .map_err(StorageError::Storage)?;

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -120,12 +120,12 @@ impl IngestorService {
         &self,
         labels: impl Into<Labels> + Debug,
         issuer: Option<String>,
-        fmt: Format,
         bytes: &[u8],
     ) -> Result<IngestResult, Error> {
         let start = Instant::now();
+        let fmt = Format::from_bytes(bytes)?;
+        let stream = ReaderStream::new(bytes);
 
-        let stream = ReaderStream::new(&*bytes);
         let result = self
             .storage
             .store(stream)

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -48,7 +48,7 @@ mod test {
     use crate::service::{Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::document_stream;
+    use trustify_test_context::document_bytes;
     use trustify_test_context::TrustifyContext;
 
     #[test_context(TrustifyContext)]
@@ -57,10 +57,10 @@ mod test {
         let graph = Graph::new(ctx.db.clone());
         let ingestor = IngestorService::new(graph, ctx.storage.clone());
 
-        let data = document_stream("clearly-defined/chrono.yaml").await?;
+        let data = document_bytes("clearly-defined/chrono.yaml").await?;
 
         ingestor
-            .ingest(("source", "test"), None, Format::ClearlyDefined, data)
+            .ingest(("source", "test"), None, Format::ClearlyDefined, &data)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -45,7 +45,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
 #[cfg(test)]
 mod test {
     use crate::graph::Graph;
-    use crate::service::{Format, IngestorService};
+    use crate::service::IngestorService;
     use test_context::test_context;
     use test_log::test;
     use trustify_test_context::document_bytes;
@@ -60,7 +60,7 @@ mod test {
         let data = document_bytes("clearly-defined/chrono.yaml").await?;
 
         ingestor
-            .ingest(("source", "test"), None, Format::ClearlyDefined, &data)
+            .ingest(("source", "test"), None, &data)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -69,19 +69,19 @@ mod test {
     use crate::service::{Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document_stream, TrustifyContext};
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]
     async fn ingest_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         let db = &ctx.db;
         let graph = Graph::new(db.clone());
-        let data = document_stream("zookeeper-3.9.2-cyclonedx.json").await?;
+        let data = document_bytes("zookeeper-3.9.2-cyclonedx.json").await?;
 
         let ingestor = IngestorService::new(graph, ctx.storage.clone());
 
         ingestor
-            .ingest(("source", "test"), None, Format::CycloneDX, data)
+            .ingest(("source", "test"), None, Format::CycloneDX, &data)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -66,7 +66,7 @@ impl<'g> CyclonedxLoader<'g> {
 #[cfg(test)]
 mod test {
     use crate::graph::Graph;
-    use crate::service::{Format, IngestorService};
+    use crate::service::IngestorService;
     use test_context::test_context;
     use test_log::test;
     use trustify_test_context::{document_bytes, TrustifyContext};
@@ -81,7 +81,7 @@ mod test {
         let ingestor = IngestorService::new(graph, ctx.storage.clone());
 
         ingestor
-            .ingest(("source", "test"), None, Format::CycloneDX, &data)
+            .ingest(("source", "test"), None, &data)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -67,18 +67,18 @@ mod test {
     use crate::service::{Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document_stream, TrustifyContext};
+    use trustify_test_context::{document_bytes, TrustifyContext};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]
     async fn ingest_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         let graph = Graph::new(ctx.db.clone());
-        let data = document_stream("ubi9-9.2-755.1697625012.json").await?;
+        let data = document_bytes("ubi9-9.2-755.1697625012.json").await?;
 
         let ingestor = IngestorService::new(graph, ctx.storage.clone());
 
         ingestor
-            .ingest(("source", "test"), None, Format::SPDX, data)
+            .ingest(("source", "test"), None, Format::SPDX, &data)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -64,7 +64,7 @@ impl<'g> SpdxLoader<'g> {
 #[cfg(test)]
 mod test {
     use crate::graph::Graph;
-    use crate::service::{Format, IngestorService};
+    use crate::service::IngestorService;
     use test_context::test_context;
     use test_log::test;
     use trustify_test_context::{document_bytes, TrustifyContext};
@@ -78,7 +78,7 @@ mod test {
         let ingestor = IngestorService::new(graph, ctx.storage.clone());
 
         ingestor
-            .ingest(("source", "test"), None, Format::SPDX, &data)
+            .ingest(("source", "test"), None, &data)
             .await
             .expect("must ingest");
 

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -17,7 +17,7 @@ use trustify_common::db;
 use trustify_common::hashing::{Digests, HashingRead};
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::model::IngestResult;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::IngestorService;
 use trustify_module_storage::service::fs::FileSystemBackend;
 
 #[allow(dead_code)]
@@ -68,9 +68,7 @@ impl TrustifyContext {
 
     pub async fn ingest_document(&self, path: &str) -> Result<IngestResult, anyhow::Error> {
         let bytes = document_bytes(path).await?;
-        let format = Format::from_bytes(&bytes)?;
-
-        Ok(self.ingestor.ingest((), None, format, &bytes).await?)
+        Ok(self.ingestor.ingest((), None, &bytes).await?)
     }
 }
 

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -69,9 +69,8 @@ impl TrustifyContext {
     pub async fn ingest_document(&self, path: &str) -> Result<IngestResult, anyhow::Error> {
         let bytes = document_bytes(path).await?;
         let format = Format::from_bytes(&bytes)?;
-        let stream = ReaderStream::new(bytes.as_ref());
 
-        Ok(self.ingestor.ingest((), None, format, stream).await?)
+        Ok(self.ingestor.ingest((), None, format, &bytes).await?)
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure about the changes to `Format` in the last commit. We need further testing to see whether an additional byte array or the `SyncIoBridge` affects performance more adversely.