### PR TITLE
chore: makes the test a bit faster

### DIFF
--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -163,7 +163,7 @@ where
         ctx,
         sbom,
         |data| {
-            let json: Value = serde_json::from_reader(data)?;
+            let json: Value = serde_json::from_slice(data)?;
             let (sbom, _) = parse_spdx(&Discard, json)?;
             Ok(fix_spdx_rels(sbom))
         },


### PR DESCRIPTION
before
```console
➜  trustify git:(bit-faster-test) ✗ cargo nextest run ingest_spdx_medium
        PASS [   5.922s] trustify-module-fundamental::fundamental sbom::spdx::perf::ingest_spdx_medium
        PASS [  27.862s] trustify-module-fundamental::fundamental sbom::spdx::perf::ingest_spdx_medium_cpes
```
after
```console
➜  trustify git:(bit-faster-test) ✗ cargo nextest run ingest_spdx_medium
        PASS [   4.746s] trustify-module-fundamental::fundamental sbom::spdx::perf::ingest_spdx_medium
        PASS [  22.021s] trustify-module-fundamental::fundamental sbom::spdx::perf::ingest_spdx_medium_cpes
```

How I found it?

* opened a terminal and `cargo nextest run ingest_spdx_medium`
* opened other terminal and `ps -aux | rg fundamental` then grabbed the pid and then `flamegraph -o a.svg --pid pid_here`

then I saw 

![a](https://github.com/user-attachments/assets/ec49d92d-9f3e-49a5-acc8-b4bf4e4ae92e)

then started navigating the code, and for this part 

![2024-08-23_11-05](https://github.com/user-attachments/assets/8d0949e4-18d1-4ec8-8e14-a543c83aa6ae)

I noticed that `from_slice`  already expects [u8]

![2024-08-23_11-08](https://github.com/user-attachments/assets/ed1904e1-471b-4de0-bd52-1a3a5cdc7661)


