### PR TITLE
fix: prevent dumping the full CSAF document into the tracing context

### DIFF
--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -51,7 +51,7 @@ impl<'g> CsafLoader<'g> {
         Self { graph }
     }
 
-    #[instrument(skip(self, labels), err)]
+    #[instrument(skip(self, csaf, labels), err)]
     pub async fn load(
         &self,
         labels: impl Into<Labels>,


### PR DESCRIPTION
This prevents the CSAF document being attached to the trace context. This definitely solved the IDE logs performance issue for me, but I guess it might have other benefits (memory usage) as well.