### PR TITLE
build: update Rust to 1.80.1, update garage-door

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "garage-door"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508f8261c1d1c2491cd7f7c2f2e4be1b33cf5ba17b00ee9cef93d134aa6a6cfe"
+checksum = "9891a8a90ed8e3f9d0c324841a5847f8b37723f246853bf3ab7573042e4bf733"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ cyclonedx-bom = "0.7.0"
 env_logger = "0.11.0"
 futures = "0.3.30"
 futures-util = "0.3"
-garage-door = "0.1.0"
+garage-door = "0.1.1"
 git2 = { version = "0.19.0", features = ["ssh"] }
 hex = "0.4.3"
 hide = "0.1.5"

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -227,7 +227,11 @@ impl DerefMut for Database {
     }
 }
 
-#[crate::db::async_trait::async_trait]
+/// Implementation of the connection trait for our database struct.
+///
+/// **NOTE**: We lack the implementations for the `mock` feature. However, the mock feature would
+/// require us to have the `Database` struct to be non-clone, which we don't support anyway.
+#[async_trait::async_trait]
 impl ConnectionTrait for Database {
     fn get_database_backend(&self) -> DbBackend {
         self.db.get_database_backend()
@@ -251,11 +255,6 @@ impl ConnectionTrait for Database {
 
     fn support_returning(&self) -> bool {
         self.db.support_returning()
-    }
-
-    #[cfg(feature = "mock")]
-    fn is_mock_connection(&self) -> bool {
-        self.db.is_mock_connection()
     }
 }
 

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -21,7 +21,7 @@ pub fn configure(config: &mut web::ServiceConfig, db: Database) {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(all, delete, get, delete),
+    paths(all, delete, get),
     components(schemas(
         crate::product::model::ProductHead,
         crate::product::model::ProductVersionHead,

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -22,6 +22,7 @@ use trustify_module_ingestor::graph::{
 use trustify_module_ingestor::service::Discard;
 use trustify_test_context::{document_bytes, TrustifyContext};
 
+#[allow(dead_code)]
 pub struct WithContext {
     pub sbom: SbomContext,
     pub db: Database,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Pre-req of https://github.com/trustification/trustify/issues/703

This also updates garage-door in order to work around https://github.com/trustification/trustify-ui/issues/145