### PR TITLE
chore: fetch retries only sets this for the default config

### DIFF
--- a/xtask/src/dataset.rs
+++ b/xtask/src/dataset.rs
@@ -6,9 +6,8 @@ use serde_json::Value;
 use std::{io::BufReader, path::PathBuf, time::Duration};
 use tokio::io::AsyncWriteExt;
 use trustify_common::{db, model::BinaryByteSize};
-use trustify_module_importer::model::CveImporter;
 use trustify_module_importer::{
-    model::{CommonImporter, CsafImporter, ImporterConfiguration, SbomImporter},
+    model::{CommonImporter, CsafImporter, CveImporter, ImporterConfiguration, SbomImporter},
     runner::{
         context::RunContext,
         progress::{Progress, TracingProgress},
@@ -36,7 +35,7 @@ pub struct GenerateDump {
     size_limit: Option<BinaryByteSize>,
 
     /// Number of times to retry fetching a document.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "input")]
     fetch_retries: Option<usize>,
 }
 


### PR DESCRIPTION
In case of an input file, the argument is ignored. So it shouldn't be silently accepted and discarded.