### PR TITLE
build: add all required dependencies for embedded psql in the container

### DIFF
--- a/.github/scripts/Containerfile
+++ b/.github/scripts/Containerfile
@@ -10,7 +10,7 @@ RUN mkdir /stage
 
 # install zlib and cleanup
 
-RUN dnf install --installroot /stage --setop install_weak_deps=false --nodocs -y zlib openssl
+RUN dnf install --installroot /stage --setop install_weak_deps=false --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2
 RUN dnf clean all --installroot /stage
 
 # prepare our binary

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 /data
 .trustify
+/download/
 
 *.cdx.json
 


### PR DESCRIPTION
See https://github.com/trustification/trustify/issues/725

This fixes the issue of the missing dependencies. But still psql doesn't seem to run because it thinks it's been run as root.