### PR TITLE
fix: restore hashes in SBOM fetch api

### DIFF
--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -117,8 +117,8 @@ impl TryFilterForId for Entity {
         Ok(match id {
             Id::Uuid(uuid) => Column::SbomId.eq(uuid).into_condition(),
             Id::Sha256(hash) => Column::Sha256.eq(hash).into_condition(),
-            Id::Sha384(hash) => crate::advisory::Column::Sha384.eq(hash).into_condition(),
-            Id::Sha512(hash) => crate::advisory::Column::Sha512.eq(hash).into_condition(),
+            Id::Sha384(hash) => Column::Sha384.eq(hash).into_condition(),
+            Id::Sha512(hash) => Column::Sha512.eq(hash).into_condition(),
             n => return Err(IdError::UnsupportedAlgorithm(n.prefix().to_string())),
         })
     }

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -40,7 +40,11 @@ impl SbomHead {
     ) -> Result<Self, Error> {
         Ok(Self {
             id: sbom.sbom_id,
-            hashes: vec![],
+            hashes: Id::build_vec(
+                sbom.sha256.clone(),
+                sbom.sha384.clone(),
+                sbom.sha512.clone(),
+            ),
             document_id: sbom.document_id.clone(),
             labels: sbom.labels.clone(),
             published: sbom.published,

--- a/modules/fundamental/src/test.rs
+++ b/modules/fundamental/src/test.rs
@@ -4,6 +4,7 @@ use actix_web::{
     dev::{Service, ServiceResponse},
     web, App, Error,
 };
+use bytes::Bytes;
 use sea_orm::prelude::async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use trustify_auth::authorizer::Authorizer;
@@ -13,6 +14,7 @@ use trustify_test_context::TrustifyContext;
 #[async_trait(?Send)]
 pub trait CallService {
     async fn call_service(&self, s: Request) -> ServiceResponse;
+    async fn call_and_read_body(&self, r: Request) -> Bytes;
     async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T;
 }
 
@@ -23,6 +25,9 @@ where
 {
     async fn call_service(&self, r: Request) -> ServiceResponse {
         actix_web::test::call_service(self, r).await
+    }
+    async fn call_and_read_body(&self, r: Request) -> Bytes {
+        actix_web::test::call_and_read_body(self, r).await
     }
     async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T {
         actix_web::test::call_and_read_body_json(self, r).await


### PR DESCRIPTION
Fixes #733

Added test to affirm that original SBOM can be downloaded by all hashes and uuid