### PR TITLE
fix: restore hard-coded base paths in CVE/ClearlyDefined walkers

### DIFF
--- a/modules/importer/src/runner/clearly_defined/mod.rs
+++ b/modules/importer/src/runner/clearly_defined/mod.rs
@@ -110,6 +110,7 @@ impl super::ImportRunner {
                 types: clearly_defined.types,
             },
         )
+        .path(Some("curations"))
         .continuation(continuation)
         .progress(progress);
 

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -106,6 +106,7 @@ impl super::ImportRunner {
                 start_year: cve.start_year,
             },
         )
+        .path(Some("cves"))
         .continuation(continuation)
         .progress(progress);
 


### PR DESCRIPTION
Oops!