### PR TITLE
feat: sort importers by enabledness

### DIFF
--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -104,13 +104,13 @@ impl ImporterService {
     }
 
     pub async fn list(&self) -> Result<Vec<Importer>, Error> {
-        let result = importer::Entity::find()
+        let mut result: Vec<_> = importer::Entity::find()
             .all(&self.db)
             .await?
             .into_iter()
             .map(Importer::try_from)
             .collect::<Result<_, _>>()?;
-
+        result.sort_unstable_by_key(|i| (i.data.configuration.disabled, i.name.clone()));
         Ok(result)
     }
 


### PR DESCRIPTION
I hate having to scroll my importers to see an enabled one. I want to see the enabled ones at the top always.

Then after sorting them, I realized that the UI overrides my sort anyway. I wish it wouldn't. So with this, at least the api won't.