### PR TITLE
fix: able to run pm-mode in container

### DIFF
--- a/.github/scripts/Containerfile.pmmode
+++ b/.github/scripts/Containerfile.pmmode
@@ -1,0 +1,53 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+
+ARG tag
+
+RUN uname -m
+
+# set up staging directory
+
+RUN mkdir /stage
+
+# install zlib and cleanup
+
+RUN dnf install --installroot /stage --setop install_weak_deps=false --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2
+RUN dnf clean all --installroot /stage
+
+# prepare our binary
+
+RUN mkdir /unpack/
+COPY download/ /unpack/
+RUN cd unpack && \
+    tar --strip-components 2 -xavf trustd-$(uname -m)-unknown-linux-gnu/trustd-${tag}-$(uname -m)-unknown-linux-gnu.tar.gz && \
+    find
+
+# copy binary to staging
+
+RUN cp -av /unpack/trustd /stage/usr/local/bin
+
+# dump staging
+
+RUN find /stage
+RUN du -h /stage
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL \
+    org.opencontainers.image.description="Trustify - Main server binary" \
+    org.opencontainers.image.source="https://github.com/trustification/trustify"
+
+RUN microdnf reinstall tzdata -y
+ENV TZ=UTC
+
+# copy staging over to actual image
+
+COPY --from=builder /stage/ .
+
+RUN useradd -ms /bin/bash trustify
+RUN chown -R trustify /usr/local/bin
+RUN chmod -R u+rwx /usr/local/bin
+USER trustify
+
+WORKDIR /usr/local/bin
+ENTRYPOINT ["./trustd"]
+


### PR DESCRIPTION
Related to https://github.com/trustification/trustify/issues/725

```console
➜  trustify git:(minimal) ✗ podman run -it ff9a6186871e
RUST_LOG is unset, using default: 'info,actix_web_prom=error'
2024-09-05T20:12:41.391532Z  WARN trustd::db: Setting up managed DB; not suitable for production use!
2024-09-05T20:13:01.569275Z  INFO trustd::db: PostgreSQL installed in "/usr/local/bin/.trustify/postgres"
2024-09-05T20:13:01.569318Z  INFO trustd::db: Running on port 45587
2024-09-05T20:13:01.601705Z  INFO bootstrap: sqlx::postgres::notice: database "trustify" does not exist, skipping database=Database { username: "postgres", password: "trustify", host: "localhost", port: 45587, name: "trustify", max_conn: 75, min_conn: 25 }
2024-09-05T20:13:01.601756Z  INFO bootstrap: sqlx::query: summary="DROP DATABASE IF EXISTS …" db.statement="\n\nDROP DATABASE IF EXISTS \"trustify\";\n" rows_affected=0 rows_returned=0 elapsed=403.995µs elapsed_secs=0.000403995 database=Database { username: "postgres", password: "trustify", host: "localhost", port: 45587, name: "trustify", max_conn: 75, min_conn: 25 }
2024-09-05T20:13:01.639588Z  INFO bootstrap: sqlx::query: summary="CREATE DATABASE \"trustify\";" db.statement="" rows_affected=0 rows_returned=0 elapsed=28.721674ms elapsed_secs=0.028721674 database=Database { username: "postgres", password: "trustify", host: "localhost", port: 45587, name: "trustify", max_conn: 75, min_conn: 25 }
2024-09-05T20:13:01.863348Z  INFO bootstrap:migrate: sea_orm_migration::migrator: Applying all pending migrations database=Database { username: "postgres", password: "trustify", host: "localhost", port: 45587, name: "trustify", max_conn: 75, min_conn: 25 } self=Database { db: SqlxPostgresPoolConnection, name: "trustify" }
...
...
```