### PR TITLE
Provide alternative CVE title, if none exists. And update one dep.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,8 +1343,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpe"
-version = "0.1.4"
-source = "git+https://github.com/ctron/cpe-rs?rev=c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b#c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "789c3810268d76fe9e70725383dd2aa23d8890578651d1bf540e1518b32fcbac"
 dependencies = [
  "derive_builder",
  "language-tags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ criterion = "0.5.1"
 chrono = { version = "0.4.35", default-features = false }
 clap = "4"
 concat-idents = "1"
-cpe = "0.1.3"
+cpe = "0.1.5"
 csaf = { version = "0.5.0", default-features = false }
 csaf-walker = { version = "0.9.0", default-features = false }
 cve = "0.3.1"
@@ -177,6 +177,6 @@ postgresql_commands = { version = "0.14.0", default-features = false, features =
 #oxide-auth = { git = "https://github.com/ctron/oxide-auth", rev = "cd0c79c48a702ea6bb0b05e95e9eddcba8f6c77f" }
 
 # required due to https://github.com/KenDJohnson/cpe-rs/pull/15
-cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
+#cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
 # required due to https://github.com/voteblake/csaf-rs/pull/29
 csaf = { git = "https://github.com/chirino/csaf-rs", rev = "414896904bc5e5287fd88b1daef5c27f70503d01" }


### PR DESCRIPTION
Many CVE project list v5 entries don't have a main title. However, most do have an English description. We already have the pattern of picking an English description as a primary piece of information, so why not re-use that pattern for a missing title too?

This PR lazily follows the pattern of picking the first `en` description, which we might improve on in the future. But for now, it seems good enough.

Aside from that, the PR also updates the `cpe` dependency to the most recent release, removing the need for the patch.

cc @carlosthe19916 