### PR TITLE
Revert the shallow clone import walkers

### DIFF
--- a/common/infrastructure/src/tracing.rs
+++ b/common/infrastructure/src/tracing.rs
@@ -3,7 +3,9 @@ use opentelemetry::{propagation::Injector, Context, KeyValue};
 use opentelemetry_sdk::Resource;
 use reqwest::RequestBuilder;
 use std::sync::Once;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{
+    field::MakeExt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+};
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq)]
 pub enum Tracing {
@@ -156,6 +158,7 @@ fn init_no_tracing() {
         .with(filter)
         .with(
             tracing_subscriber::fmt::layer()
+                .map_fmt_fields(|f| f.debug_alt())
                 .with_ansi(true)
                 .with_level(true)
                 .compact(),

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -46,7 +46,7 @@ pub enum Format {
 }
 
 impl<'g> Format {
-    #[instrument(skip(self, graph, stream), ret)]
+    #[instrument(skip(self, graph, stream))]
     pub async fn load<S>(
         &self,
         graph: &'g Graph,

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -177,7 +177,7 @@ impl IngestorService {
             .await?;
 
         let duration = Instant::now() - start;
-        log::info!(
+        log::debug!(
             "Ingested: {} ({}): took {}",
             result.id,
             result.document_id,


### PR DESCRIPTION
Fixes #764 

It doesn't seem possible to perpetually update shallow clones to successfully determine which new files need to be ingested.

So reverting back to the 30 minute clones for now.
