### PR TITLE
fix parallel safe by removing raise notice

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -73,6 +73,7 @@ mod m0000575_create_weakness;
 mod m0000580_mark_fns;
 mod m0000590_get_purl_fns;
 mod m0000595_analysis_api_index;
+mod m0000600_remove_raise_notice_fns;
 
 pub struct Migrator;
 
@@ -153,6 +154,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000580_mark_fns::Migration),
             Box::new(m0000590_get_purl_fns::Migration),
             Box::new(m0000595_analysis_api_index::Migration),
+            Box::new(m0000600_remove_raise_notice_fns::Migration),
         ]
     }
 }

--- a/migration/src/m0000600_remove_raise_notice_fns.rs
+++ b/migration/src/m0000600_remove_raise_notice_fns.rs
@@ -1,0 +1,28 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000600_remove_raise_notice_fns/semver_cmp.sql"
+            ))
+            .await
+            .map(|_| ())?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0000580_mark_fns/semver_cmp.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0000600_remove_raise_notice_fns/semver_cmp.sql
+++ b/migration/src/m0000600_remove_raise_notice_fns/semver_cmp.sql
@@ -1,0 +1,124 @@
+create or replace function semver_cmp(left_p text, right_p text)
+    returns integer
+as
+$$
+declare
+    left_parts text[];
+    right_parts text[];
+
+    left_major bigint;
+    left_minor bigint;
+    left_patch bigint;
+    left_pre text;
+    left_build text;
+
+    right_major bigint;
+    right_minor bigint;
+    right_patch bigint;
+    right_pre text;
+    right_build text;
+
+    left_numeric bool;
+    right_numeric bool;
+
+    cur integer;
+
+begin
+    left_parts = regexp_split_to_array(left_p, E'\\+');
+    left_build = left_parts[2];
+
+    left_parts = regexp_split_to_array(left_parts[1], E'-');
+    left_pre = left_parts[2];
+
+    left_parts = regexp_split_to_array(left_parts[1], E'\\.');
+    left_major = left_parts[1]::decimal;
+    left_minor = left_parts[2]::decimal;
+    left_patch = left_parts[3]::decimal;
+
+    right_parts = regexp_split_to_array(right_p, E'\\+');
+    right_build = right_parts[2];
+
+    right_parts = regexp_split_to_array(right_parts[1], E'-');
+    right_pre = right_parts[2];
+
+    right_parts = regexp_split_to_array(right_parts[1], E'\\.');
+    right_major = right_parts[1]::decimal;
+    right_minor = right_parts[2]::decimal;
+    right_patch = right_parts[3]::decimal;
+
+    if left_major > right_major then
+        return +1;
+    elsif left_major < right_major then
+        return -1;
+    end if;
+
+    if left_minor > right_minor then
+        return +1;
+    elsif left_minor < right_minor then
+        return -1;
+    end if;
+
+    if left_patch > right_patch then
+        return +1;
+    elsif left_patch < right_patch then
+        return -1;
+    end if;
+
+    if left_pre is null and right_pre is not null then
+        return +1;
+    elsif left_pre is not null and right_pre is null then
+        return -1;
+    elsif left_pre is not null and right_pre is not null then
+        left_parts = regexp_split_to_array(left_pre, E'\\.');
+        right_parts = regexp_split_to_array(right_pre, E'\\.');
+        -- do the hard work
+
+        cur := 0;
+        loop
+            cur := cur + 1;
+
+            left_pre := left_parts[cur];
+            right_pre := right_parts[cur];
+
+            if left_pre is null and right_pre is null then
+                return 0;
+            end if;
+
+            if left_pre is null and right_pre is not null then
+                return -1;
+            elsif left_pre is not null and right_pre is null then
+                return +1;
+            end if;
+
+            left_numeric := is_numeric(left_pre);
+            right_numeric := is_numeric(right_pre);
+
+            if left_numeric and right_numeric then
+                if left_pre::bigint < right_pre::bigint then
+                    return -1;
+                elsif left_pre::bigint > right_pre::bigint then
+                    return +1;
+                end if;
+            else
+                if left_pre < right_pre then
+                    return -1;
+                elsif left_pre > right_pre then
+                    return +1;
+                end if;
+            end if;
+
+            if cur > 10 then
+                exit;
+            end if;
+        end loop;
+    else
+        return 0;
+    end if;
+
+    return null;
+exception
+    when others then
+        return null;
+end
+$$
+    language 'plpgsql' immutable parallel safe;


### PR DESCRIPTION
We were still getting 500 errors due to parallel execution of version/semver related pg functions ... this was due to usage of **RAISE NOTICE** which is not parallel safe.

For the pg curious ... the usage of **regexp_split_to_array**  can in some cases also not be parallel safe (though it is in our usage here).