### PR TITLE
Fix graph hashmap key mangling on analysis service invoke

### DIFF
--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -180,19 +180,21 @@ impl IngestorService {
         match fmt {
             Format::SPDX | Format::CycloneDX => {
                 let analysis_service = AnalysisService::new(self.graph.db.clone());
-                match analysis_service
-                    .load_graphs(vec![result.id.value()], ())
-                    .await
-                {
-                    Ok(_) => log::debug!(
+                if result.id.to_string().starts_with("urn:uuid:") {
+                    match analysis_service // TODO: today we chop off 'urn:uuid:' prefix using .split_off on result.id
+                        .load_graphs(vec![result.id.to_string().split_off("urn:uuid:".len())], ())
+                        .await
+                    {
+                        Ok(_) => log::debug!(
                         "Analysis graph for sbom: {} loaded successfully.",
                         result.id.value()
                     ),
-                    Err(e) => log::warn!(
+                        Err(e) => log::warn!(
                         "Error loading sbom {} into analysis graph : {}",
                         result.id.value(),
                         e
                     ),
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
**result.id** strings out to a uuid prefixed with "urn:uuid" ... which when analysis service is invoked in ingestor results in 2 entries in graph hashmap of the same graph (e.g one with a key of normal hypenated uuid and the other with a urn:uuid prefix. That is because lazy loading uses just the unadorned uuid string ... so eventually between using REST API search (lazy loading) and ingestor we end up with two different entries in the hashmap of the same sbom -  that was silly/wrong.

The fix chops off the urn:uuid bit from the string and its ugly - open to any better suggestions.