### PR TITLE
ci: synchronize openapi.yaml on trustify-ui

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -1,0 +1,42 @@
+name: openapi
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - openapi.yaml
+
+jobs:
+  trustify-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: trustify
+      - name: Checkout trustify-ui
+        uses: actions/checkout@v4
+        with:
+          repository: trustification/trustify-ui
+          path: trustify-ui
+      - name: Update trustify-ui
+        run: |
+          rm ./trustify-ui/client/openapi/trustd.yaml
+          cp ./trustify/openapi.yaml ./trustify-ui/client/openapi/trustd.yaml
+          
+          cd ./trustify-ui
+          git diff
+      - name: Create Pull Request - trustify-ui
+        uses: peter-evans/create-pull-request@v5
+        id: ui-pr
+        with:
+          token: ${{ secrets.GH_PAT }}
+          path: ./trustify-ui
+          commit-message: "update client/openapi/trustd.yaml"
+          signoff: true
+          branch-suffix: short-commit-hash
+          title: "update client/openapi/trustd.yaml"
+          body: "Update trustify openapi definition"
+      - name: PR Notifications
+        run: |
+          echo "::notice:: Trustify UI Pull Request URL - ${{ steps.ui-pr.outputs.pull-request-url }}"


### PR DESCRIPTION
- For each change done to the file openapi.yaml file there will be a new PR against the trustify-ui repository to copy the content of the openapi.yaml file
- The ui repository has a hard dependency to the openapi yaml file and currently is way behind the latest changes, this PR should help the ui guys to realize there are changes to introduce and apply any remediation if needed.

Tested in my own forked branch and:
- This is how it looks a PR created by the gh action introduced in this PR https://github.com/trustification/trustify-ui/pull/159
- This is the action build log https://github.com/carlosthe19916/trustify/actions/runs/10910107238
- I added a `GH_PAT` secret to this repository in case this PR is accepted and merged