### PR TITLE
execute openapi.yaml synch with ui only on trustification and not on forks

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   trustify-ui:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'trustification' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Solves https://github.com/trustification/trustify/issues/820
The synch action for the openapi yaml file will only be triggered on the trustification/trustify repository and not on forks