### PR TITLE
Mitigate deadlocks when creating purls

### DIFF
--- a/modules/ingestor/src/graph/purl/creator.rs
+++ b/modules/ingestor/src/graph/purl/creator.rs
@@ -1,7 +1,7 @@
 use crate::graph::error::Error;
 use sea_orm::{ActiveValue::Set, ConnectionTrait, EntityTrait};
 use sea_query::OnConflict;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use tracing::instrument;
 use trustify_common::{db::chunk::EntityChunkedIter, purl::Purl};
 use trustify_entity::{
@@ -36,9 +36,9 @@ impl PurlCreator {
 
         // insert all packages
 
-        let mut packages = HashMap::new();
-        let mut versions = HashMap::new();
-        let mut qualifieds = HashMap::new();
+        let mut packages = BTreeMap::new();
+        let mut versions = BTreeMap::new();
+        let mut qualifieds = BTreeMap::new();
 
         for purl in self.purls {
             let (package, version, qualified) = purl.uuids();


### PR DESCRIPTION
mitigates the likelihood of deadlocks when creating purls by enforcing order creating the base, versioned and qualified purl entities, fixes #817.

**Note** - [refactoring](https://github.com/trustification/trustify/issues/771) of purl (for performance) will fully address this.