### PR TITLE
Add AI endpoint under: `/api/v1/ai/completions` to query the DB for information.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,11 @@
 /data
 .trustify
 /download/
+.envrc
 
 *.cdx.json
 
 /flamegraph*.svg
 /perf.data*
 /dump.sql
-
+.ai_history.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 1.0.2",
  "socket2",
  "tokio",
  "tracing",
@@ -552,6 +552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +571,15 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
 ]
 
 [[package]]
@@ -660,6 +679,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.24.0"
+source = "git+https://github.com/chirino/async-openai?branch=optional-fields#7b9fe4b17c9f1985a296a313adf9e641a5812163"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder 0.20.1",
+ "eventsource-stream",
+ "futures",
+ "rand",
+ "reqwest 0.12.7",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +774,18 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "auto_enums"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459b77b7e855f875fd15f101064825cd79eb83185a961d66e6298560126facfb"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -796,6 +863,20 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -993,6 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -1246,7 +1328,7 @@ checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.2",
 ]
 
 [[package]]
@@ -1256,8 +1338,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
- "phf",
- "phf_codegen",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
 ]
 
 [[package]]
@@ -1342,6 +1424,16 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "concat-idents"
@@ -1446,7 +1538,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789c3810268d76fe9e70725383dd2aa23d8890578651d1bf540e1518b32fcbac"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.9.0",
  "language-tags",
  "lazy_static",
  "percent-encoding",
@@ -1569,6 +1661,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot 0.12.3",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,7 +1753,7 @@ dependencies = [
  "lazy_static",
  "log",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.7",
  "sectxtlib",
  "sequoia-openpgp",
  "serde",
@@ -1648,6 +1766,29 @@ dependencies = [
  "walkdir",
  "walker-common",
  "xattr",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.2",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1876,10 +2017,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
- "derive_builder_core",
+ "derive_builder_core 0.9.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+dependencies = [
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -1892,6 +2042,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+dependencies = [
+ "derive_builder_core 0.20.1",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1926,6 +2098,17 @@ dependencies = [
  "quote",
  "syn 2.0.77",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f152f4b8559c4da5d574bafc7af85454d706b4c5fe8b530d508cacbb6807ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2000,6 +2183,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2252,12 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
@@ -2148,6 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -2159,6 +2364,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "humantime",
  "log",
 ]
 
@@ -2217,6 +2423,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fast_chemail"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2457,17 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ff"
@@ -2351,6 +2589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2705,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "garage-door"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2814,6 +3080,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3255,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3495,6 +3790,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "langchain-rust"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0a7587b3283552de832dd60572873589607bfc739b7151626545c3d6e9dec6"
+dependencies = [
+ "async-openai",
+ "async-recursion",
+ "async-stream",
+ "async-trait",
+ "csv",
+ "futures",
+ "futures-util",
+ "glob",
+ "html-escape",
+ "log",
+ "mockito",
+ "ollama-rs",
+ "readability",
+ "regex",
+ "reqwest 0.12.7",
+ "reqwest-eventsource",
+ "scraper",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "strum_macros 0.26.4",
+ "text-splitter",
+ "thiserror",
+ "tiktoken-rs",
+ "tokio",
+ "tokio-stream",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +4123,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever 0.26.0",
+ "markup5ever 0.11.0",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +4276,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
@@ -3908,6 +4297,30 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockito"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b34bd91b9e5c5b06338d392463e1318d683cf82ec3d3af4014609be6e2108d"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -3968,6 +4381,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4090,7 +4512,7 @@ dependencies = [
  "getrandom",
  "http 1.1.0",
  "rand",
- "reqwest",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4106,6 +4528,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ollama-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46483ac9e1f9e93da045b5875837ca3c9cf014fd6ab89b4d9736580ddefc4759"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "log",
+ "reqwest 0.12.7",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -4131,7 +4570,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "mime",
- "reqwest",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -4150,7 +4589,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "mime",
- "reqwest",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -4655,11 +5094,31 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -4668,8 +5127,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.2",
  "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
 ]
 
 [[package]]
@@ -4680,6 +5149,19 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4809,7 +5291,7 @@ dependencies = [
  "liblzma",
  "num-format",
  "regex",
- "reqwest",
+ "reqwest 0.12.7",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -5007,6 +5489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
+dependencies = [
+ "bitflags 2.6.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "purl"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5052,7 +5545,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.13",
  "socket2",
  "thiserror",
@@ -5069,7 +5562,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.13",
  "slab",
  "thiserror",
@@ -5156,6 +5649,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "readability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56596e20a6d3cf715182d9b6829220621e6e985cec04d00410cee29821b4220"
+dependencies = [
+ "html5ever 0.26.0",
+ "lazy_static",
+ "markup5ever_rcdom",
+ "regex",
+ "reqwest 0.11.27",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5689,26 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "reedline"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc271368d0d3f395745b40fababc0c9061f3fc2978189a8bc76f889e47255b01"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools 0.12.1",
+ "nu-ansi-term 0.50.1",
+ "serde",
+ "strip-ansi-escapes",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5271,6 +5798,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
@@ -5293,6 +5860,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -5306,7 +5874,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -5322,6 +5890,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest 0.12.7",
+ "thiserror",
+]
+
+[[package]]
 name = "reqwest-middleware"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5330,7 +5914,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest",
+ "reqwest 0.12.7",
  "serde",
  "thiserror",
  "tower-service",
@@ -5349,7 +5933,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "parking_lot 0.11.2",
- "reqwest",
+ "reqwest 0.12.7",
  "reqwest-middleware",
  "retry-policies",
  "tokio",
@@ -5368,7 +5952,7 @@ dependencies = [
  "getrandom",
  "http 1.1.0",
  "matchit 0.8.4",
- "reqwest",
+ "reqwest 0.12.7",
  "reqwest-middleware",
  "tracing",
 ]
@@ -5641,6 +6225,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -5822,7 +6412,7 @@ dependencies = [
  "humantime",
  "log",
  "parking_lot 0.12.3",
- "reqwest",
+ "reqwest 0.12.7",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -5874,6 +6464,22 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
+dependencies = [
+ "ahash 0.8.11",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.27.0",
+ "once_cell",
+ "selectors",
+ "tendril",
+]
 
 [[package]]
 name = "sct"
@@ -6065,6 +6671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "sectxtlib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6099,6 +6715,25 @@ checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.6.0",
+ "cssparser",
+ "derive_more 0.99.18",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -6282,6 +6917,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6335,6 +6979,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6364,6 +7029,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"
@@ -6877,6 +7548,19 @@ dependencies = [
  "parking_lot 0.12.3",
  "phf_shared 0.10.0",
  "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -6888,6 +7572,15 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
  "unicode-properties",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -7011,13 +7704,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7073,6 +7787,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -7152,6 +7877,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-splitter"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f280573deec490e745c503ecc1d0e17104e98936eaefd7b0aa4b1422c74b317"
+dependencies = [
+ "ahash 0.8.11",
+ "auto_enums",
+ "either",
+ "itertools 0.13.0",
+ "once_cell",
+ "pulldown-cmark",
+ "regex",
+ "strum 0.26.3",
+ "thiserror",
+ "tiktoken-rs",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7185,6 +7929,21 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c314e7ce51440f9e8f5a497394682a57b7c323d0f4d0a6b1b13c429056e0e234"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "parking_lot 0.12.3",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -7273,7 +8032,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
@@ -7520,7 +8279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -7556,7 +8315,7 @@ dependencies = [
  "jsonpath-rust",
  "log",
  "openid 0.15.0",
- "reqwest",
+ "reqwest 0.12.7",
  "schemars",
  "serde",
  "serde_json",
@@ -7593,7 +8352,7 @@ dependencies = [
  "postgresql_embedded",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.12.7",
  "ring",
  "rstest",
  "schemars",
@@ -7668,7 +8427,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot 0.12.3",
  "prometheus",
- "reqwest",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "tokio",
@@ -7745,6 +8504,8 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-graphql",
+ "async-trait",
+ "base64 0.22.1",
  "bytes",
  "bytesize",
  "chrono",
@@ -7757,6 +8518,7 @@ dependencies = [
  "humantime",
  "itertools 0.13.0",
  "jsonpath-rust",
+ "langchain-rust",
  "log",
  "packageurl",
  "sea-orm",
@@ -7828,7 +8590,7 @@ dependencies = [
  "osv",
  "parking_lot 0.12.3",
  "regex",
- "reqwest",
+ "reqwest 0.12.7",
  "sbom-walker",
  "schemars",
  "sea-orm",
@@ -8201,6 +8963,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8285,7 +9053,7 @@ dependencies = [
  "actix-web",
  "mime_guess",
  "regex",
- "reqwest",
+ "reqwest 0.12.7",
  "rust-embed",
  "serde",
  "serde_json",
@@ -8436,7 +9204,7 @@ dependencies = [
  "log",
  "openid 0.14.0",
  "pem",
- "reqwest",
+ "reqwest 0.12.7",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -8894,25 +9662,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+]
+
+[[package]]
 name = "xtask"
 version = "0.1.0-alpha.18"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
+ "env_logger",
+ "langchain-rust",
  "log",
+ "nu-ansi-term 0.46.0",
  "postgresql_commands",
+ "reedline",
  "schemars",
  "serde",
  "serde_json",
  "serde_yml",
+ "test-context",
  "tokio",
  "tracing-subscriber",
  "trustify-auth",
  "trustify-common",
+ "trustify-module-fundamental",
  "trustify-module-importer",
  "trustify-module-ingestor",
  "trustify-module-storage",
  "trustify-server",
+ "trustify-test-context",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,12 +75,14 @@ itertools = "0.13"
 jsn = "0.14"
 json-merge-patch = "0.0.1"
 jsonpath-rust = "0.7.0"
+langchain-rust = { version = "4.4.1", features = ["ollama"] }
 lenient_semver = "0.4.2"
 liblzma = "0.3"
 libz-sys = "*"
 log = "0.4.19"
 mime = "0.3.17"
 native-tls = "0.2"
+nu-ansi-term = "0.46"
 once_cell = "1.19.0"
 openid = "0.15"
 openssl = "0.10"
@@ -96,6 +98,7 @@ petgraph = {  version = "0.6.5", features = ["serde-1"] }
 prometheus = "0.13.3"
 quick-xml = "0.36.1"
 rand = "0.8.5"
+reedline = "0.34.0"
 regex = "1.10.3"
 reqwest = "0.12"
 ring = "0.17.8"
@@ -187,3 +190,6 @@ postgresql_commands = { version = "0.16.3", default-features = false, features =
 # required due to https://github.com/voteblake/csaf-rs/pull/29
 csaf = { git = "https://github.com/chirino/csaf-rs", rev = "414896904bc5e5287fd88b1daef5c27f70503d01" }
 
+# to pickup up fix: https://github.com/64bit/async-openai/pull/263 and https://github.com/64bit/async-openai/pull/267
+# needed to work against groq.com API
+async-openai = { git = "https://github.com/chirino/async-openai", branch = "optional-fields" }

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -17,9 +17,12 @@ actix-http = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
 async-graphql = { workspace = true, features = ["uuid", "time"] }
+async-trait = { workspace = true }
+base64 = { workspace = true }
 cpe = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
+langchain-rust = { workspace = true }
 log = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }

--- a/modules/fundamental/src/ai/endpoints/mod.rs
+++ b/modules/fundamental/src/ai/endpoints/mod.rs
@@ -1,0 +1,47 @@
+#[cfg(test)]
+mod test;
+
+use crate::ai::model::ChatState;
+use crate::ai::service::AiService;
+use actix_web::{post, web, HttpResponse, Responder};
+use trustify_common::db::Database;
+use utoipa::OpenApi;
+
+pub fn configure(config: &mut web::ServiceConfig, db: Database) {
+    let service = AiService::new(db.clone());
+    config
+        .app_data(web::Data::new(service))
+        .service(completions);
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(completions,),
+    components(schemas(
+        crate::ai::model::ChatState,
+        crate::ai::model::ChatMessage,
+        crate::ai::model::MessageType,
+    )),
+    tags()
+)]
+pub struct ApiDoc;
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "completions",
+    context_path = "/api",
+    request_body = ChatState,
+    responses(
+        (status = 200, description = "The resulting completion", body = ChatState),
+        (status = 400, description = "The request was invalid"),
+        (status = 404, description = "The AI service is not enabled")
+    )
+)]
+#[post("/v1/ai/completions")]
+pub async fn completions(
+    service: web::Data<AiService>,
+    request: web::Json<ChatState>,
+) -> actix_web::Result<impl Responder> {
+    let response = service.completions(&request, ()).await?;
+    Ok(HttpResponse::Ok().json(response))
+}

--- a/modules/fundamental/src/ai/endpoints/test.rs
+++ b/modules/fundamental/src/ai/endpoints/test.rs
@@ -1,0 +1,40 @@
+use crate::ai::model::ChatState;
+use crate::ai::service::test::ingest_fixtures;
+use crate::ai::service::AiService;
+use crate::test::caller;
+use actix_http::StatusCode;
+use actix_web::test::TestRequest;
+use test_context::test_context;
+use test_log::test;
+use trustify_test_context::call::CallService;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn configure(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let service = AiService::new(ctx.db.clone());
+    if !service.enabled() {
+        return Ok(()); // skip test
+    }
+
+    ingest_fixtures(ctx).await?;
+
+    let app = caller(ctx).await?;
+    let mut req = ChatState::new();
+    req.add_human_message("What is the latest version of Trusted Profile Analyzer?".into());
+
+    let request = TestRequest::post()
+        .uri("/api/v1/ai/completions")
+        .set_json(req)
+        .to_request();
+
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: ChatState = actix_web::test::read_body_json(response).await;
+    log::info!("result: {:?}", result);
+    assert!(result.messages.last().unwrap().content.contains("37.17.9"));
+
+    Ok(())
+}

--- a/modules/fundamental/src/ai/mod.rs
+++ b/modules/fundamental/src/ai/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod endpoints;
+pub mod model;
+pub mod service;

--- a/modules/fundamental/src/ai/model/mod.rs
+++ b/modules/fundamental/src/ai/model/mod.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct ChatState {
+    pub messages: Vec<ChatMessage>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct ChatMessage {
+    pub message_type: MessageType,
+    pub content: String,
+    pub internal_state: Option<String>,
+}
+
+#[derive(Clone, Eq, PartialEq, Default, Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageType {
+    #[default]
+    Human,
+    System,
+    Ai,
+    Tool,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize, ToSchema)]
+pub struct LLMInfo {
+    pub api_base: String,
+    pub model: String,
+}
+
+impl std::fmt::Display for MessageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            MessageType::System => write!(f, "system"),
+            MessageType::Ai => write!(f, "ai"),
+            MessageType::Human => write!(f, "human"),
+            MessageType::Tool => write!(f, "tool"),
+        }
+    }
+}
+
+impl Default for ChatState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChatState {
+    pub fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+        }
+    }
+
+    pub fn add_human_message(&mut self, message: String) {
+        self.messages.push(ChatMessage {
+            message_type: MessageType::Human,
+            content: message,
+            internal_state: None,
+        });
+    }
+}

--- a/modules/fundamental/src/ai/service/mod.rs
+++ b/modules/fundamental/src/ai/service/mod.rs
@@ -1,0 +1,227 @@
+pub mod tools;
+
+use crate::Error;
+
+use trustify_common::db::{Database, Transactional};
+
+use crate::ai::model::{ChatMessage, ChatState, LLMInfo, MessageType};
+
+use crate::ai::service::tools::{CVEInfo, ProductInfo, ToolLogger};
+use crate::product::service::ProductService;
+use crate::vulnerability::service::VulnerabilityService;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::Engine as _;
+use langchain_rust::chain::options::ChainCallOptions;
+use langchain_rust::chain::Chain;
+use langchain_rust::language_models::options::CallOptions;
+use langchain_rust::tools::OpenAIConfig;
+use langchain_rust::{
+    agent::{AgentExecutor, OpenAiToolAgentBuilder},
+    llm::openai::OpenAI,
+    memory::SimpleMemory,
+    prompt_args,
+    tools::Tool,
+};
+
+use std::env;
+
+use langchain_rust::schemas::{BaseMemory, Message};
+use std::fmt::Write;
+use std::sync::Arc;
+
+pub const PREFIX: &str = include_str!("prefix.txt");
+
+pub struct AiService {
+    llm: Option<OpenAI<OpenAIConfig>>,
+    llm_info: Option<LLMInfo>,
+    pub tools: Vec<Arc<dyn Tool>>,
+}
+
+impl AiService {
+    /// Creates a new instance of the AI service.  It can be run against any OpenAI compatible
+    /// API endpoint.  The service is disabled if the OPENAI_API_KEY environment variable is not set.
+    /// You can configure the following environment variables to run against different OpenAI compatible:
+    ///
+    /// * OPENAI_API_KEY
+    /// * OPENAI_API_BASE (default: https://api.openai.com/v1)
+    /// * OPENAI_MODEL (default: gpt-4o)
+    ///
+    /// ## Running Against OpenAI:
+    /// OpenAI tends to provide cutting edge proprietary models, but they are not open source.
+    ///
+    /// 1. generate an API key at: https://platform.openai.com/settings/profile?tab=api-keys
+    /// 2. export the following env variables:
+    /// ```bash
+    /// export OPENAI_API_KEY=xxxx
+    /// ```
+    ///
+    /// ## Running Against Groq:
+    /// On Groq you can use open source models and has a free tier.
+    ///
+    /// 1. generate an API key at: https://console.groq.com/keys
+    /// 2. export the following env variables:
+    /// ```bash
+    /// export OPENAI_API_KEY=xxxx
+    /// export OPENAI_API_BASE=https://api.groq.com/openai/v1
+    /// export OPENAI_MODEL=llama3-groq-70b-8192-tool-use-preview
+    /// ```
+    ///
+    /// ## Running Against Ollama:
+    /// Ollama lets you run against open source models locally on your machine, but you need
+    /// a machine with a powerful GPU.
+    ///
+    /// 1. install https://ollama.com/
+    /// 2. run `ollama pull llama3.1:70b`
+    /// 3. export the following env variables:
+    /// ```bash
+    /// export OPENAI_API_KEY=ollama
+    /// export OPENAI_API_BASE=http://localhost:11434/v1
+    /// export OPENAI_MODEL=llama3.1:70b
+    /// ```
+    ///
+    pub fn new(db: Database) -> Self {
+        let api_key = env::var("OPENAI_API_KEY");
+        let api_key = match api_key {
+            Ok(api_key) => api_key,
+            Err(_) => {
+                return Self {
+                    llm: None,
+                    llm_info: None,
+                    tools: vec![],
+                };
+            }
+        };
+
+        let api_base =
+            env::var("OPENAI_API_BASE").unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
+        let model = env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o".to_string());
+
+        log::info!("LLM API: {}", api_base.clone());
+        log::info!("LLM Model: {}", model);
+
+        let llm_config = OpenAIConfig::default()
+            .with_api_base(api_base.clone())
+            .with_api_key(api_key);
+
+        let llm = OpenAI::default()
+            .with_config(llm_config.clone())
+            .with_model(model.clone())
+            .with_options(CallOptions::default().with_seed(2000));
+
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(ToolLogger(ProductInfo(ProductService::new(db.clone())))),
+            Arc::new(ToolLogger(CVEInfo(VulnerabilityService::new(db.clone())))),
+        ];
+
+        Self {
+            llm: Some(llm),
+            llm_info: Some(LLMInfo { api_base, model }),
+            tools,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.llm.is_some()
+    }
+
+    pub fn llm_info(&self) -> Option<LLMInfo> {
+        self.llm_info.clone()
+    }
+
+    pub async fn completions<TX: AsRef<Transactional>>(
+        &self,
+        request: &ChatState,
+        _tx: TX,
+    ) -> Result<ChatState, Error> {
+        let llm = match self.llm.clone() {
+            Some(llm) => llm,
+            None => return Err(Error::NotFound("AI service is not enabled".to_string())),
+        };
+
+        let agent = OpenAiToolAgentBuilder::new()
+            .prefix(PREFIX)
+            .tools(&self.tools)
+            .options(ChainCallOptions::new().with_max_tokens(1000))
+            .build(llm)
+            .map_err(Error::AgentError)?;
+
+        let mut memory = SimpleMemory::new();
+        let mut prompt = "".to_string();
+        for chat_message in &request.messages {
+            match &chat_message.internal_state {
+                None => {
+                    if !prompt.is_empty() {
+                        _ = prompt.write_str("\n");
+                    }
+                    _ = prompt.write_str(&chat_message.content);
+                }
+
+                Some(internal_state) => {
+                    if !prompt.is_empty() {
+                        return Err(Error::BadRequest(
+                            "message with internal_state found after messages without".to_string(),
+                        ));
+                    }
+                    match STANDARD.decode(internal_state) {
+                        Ok(decoded) => {
+                            // todo: implement data encryption to avoid client side tampering
+                            let message: Message = serde_json::from_slice(decoded.as_slice())
+                                .map_err(|_| {
+                                    Error::BadRequest("internal_state failed to decode".to_string())
+                                })?;
+                            memory.add_message(message);
+                        }
+                        Err(_) => {
+                            return Err(Error::BadRequest("invalid internal_state".to_string()))
+                        }
+                    }
+                }
+            }
+        }
+
+        let memory: Arc<tokio::sync::Mutex<dyn BaseMemory>> = memory.into();
+        let executor = AgentExecutor::from_agent(agent).with_memory(memory.clone());
+
+        let _answer = executor
+            .invoke(prompt_args! {
+                "input" => prompt,
+            })
+            .await
+            .map_err(Error::ChainError)?;
+
+        let mut response = ChatState {
+            messages: Vec::new(),
+        };
+
+        let memory = memory.lock().await;
+        for message in memory.messages() {
+            if message.message_type == langchain_rust::schemas::MessageType::ToolMessage {
+                // skip tool messages for now...
+                continue;
+            }
+            let internal_state = match serde_json::to_vec(&message) {
+                Ok(serialized) => {
+                    // todo: implement data encryption to avoid client side tampering
+                    STANDARD.encode(serialized.as_slice())
+                }
+                Err(e) => return Err(Error::Internal(e.to_string())),
+            };
+            response.messages.push(ChatMessage {
+                content: message.content.clone(),
+                message_type: match message.message_type.clone() {
+                    langchain_rust::schemas::MessageType::HumanMessage => MessageType::Human,
+                    langchain_rust::schemas::MessageType::AIMessage => MessageType::Ai,
+                    langchain_rust::schemas::MessageType::SystemMessage => MessageType::System,
+                    langchain_rust::schemas::MessageType::ToolMessage => MessageType::Tool,
+                },
+                internal_state: Some(internal_state),
+            });
+        }
+
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+pub mod test;

--- a/modules/fundamental/src/ai/service/prefix.txt
+++ b/modules/fundamental/src/ai/service/prefix.txt
@@ -1,0 +1,16 @@
+You are a friendly Assistant designed to be able to assist with a tasks like:
+
+* listing the versions of a product.
+* listing packages that part of a product.
+* listing packages that are affected by a CVE.
+* answering questions about which product versions are affected by CVEs.
+
+If the Assistant is asked to perform a task that it is not able to do, it will respond with: I don't know
+
+The Assistant is able to complete those tasks by exclusivley using information from tool call responses.
+
+The Assistant provides short concise answers to questions and it does not halucinate information.
+
+Always use the available tools to provide up to date information.
+
+Do not talk about your knowledge cutoff.

--- a/modules/fundamental/src/ai/service/test.rs
+++ b/modules/fundamental/src/ai/service/test.rs
@@ -1,0 +1,59 @@
+use crate::ai::model::ChatState;
+use crate::ai::service::AiService;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db::Transactional;
+use trustify_common::hashing::Digests;
+use trustify_module_ingestor::graph::product::ProductInformation;
+use trustify_test_context::TrustifyContext;
+
+pub async fn ingest_fixtures(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let sbom = ctx
+        .graph
+        .ingest_sbom(
+            ("source", "http://redhat.com/test.json"),
+            &Digests::digest("RHSA-1"),
+            "a",
+            (),
+            Transactional::None,
+        )
+        .await?;
+
+    let pr = ctx
+        .graph
+        .ingest_product(
+            "Trusted Profile Analyzer",
+            ProductInformation {
+                vendor: Some("Red Hat".to_string()),
+            },
+            (),
+        )
+        .await?;
+
+    let _ver = pr
+        .ingest_product_version("37.17.9".to_string(), Some(sbom.sbom.sbom_id), ())
+        .await?;
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn completions(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = AiService::new(ctx.db.clone());
+    if !service.enabled() {
+        return Ok(()); // skip test
+    }
+
+    ingest_fixtures(ctx).await?;
+
+    let mut req = ChatState::new();
+    req.add_human_message("What is the latest version of Trusted Profile Analyzer?".into());
+
+    let result = service.completions(&req, ()).await?;
+
+    log::info!("result: {:?}", result);
+    assert!(result.messages.last().unwrap().content.contains("37.17.9"));
+
+    Ok(())
+}

--- a/modules/fundamental/src/ai/service/tools.rs
+++ b/modules/fundamental/src/ai/service/tools.rs
@@ -1,0 +1,160 @@
+use std::error::Error;
+
+use crate::product::service::ProductService;
+use crate::vulnerability::service::VulnerabilityService;
+use anyhow::anyhow;
+use async_trait::async_trait;
+use langchain_rust::tools::Tool;
+use serde_json::Value;
+use std::fmt::Write;
+use trustify_common::db::query::Query;
+
+pub struct ToolLogger<T: Tool>(pub T);
+
+#[async_trait]
+impl<T: Tool> Tool for ToolLogger<T> {
+    fn name(&self) -> String {
+        self.0.name()
+    }
+
+    fn description(&self) -> String {
+        self.0.description()
+    }
+
+    fn parameters(&self) -> Value {
+        self.0.parameters()
+    }
+
+    async fn call(&self, input: &str) -> Result<String, Box<dyn Error>> {
+        log::info!("  tool call: {}, input: {}", self.name(), input);
+        let result = self.0.call(input).await;
+        match &result {
+            Ok(result) => {
+                log::info!("     ok: {}", result);
+            }
+            Err(err) => {
+                log::info!("     err: {}", err);
+            }
+        }
+        result
+    }
+
+    async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
+        self.0.run(input).await
+    }
+
+    async fn parse_input(&self, input: &str) -> Value {
+        self.0.parse_input(input).await
+    }
+}
+
+pub struct ProductInfo(pub ProductService);
+
+#[async_trait]
+impl Tool for ProductInfo {
+    fn name(&self) -> String {
+        String::from("ProductInfo")
+    }
+
+    fn description(&self) -> String {
+        String::from(
+            r##"
+            This tool can be used to get information about a product.
+            The input should be the name of the product to search for.
+            "##,
+        )
+    }
+
+    async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
+        let service = &self.0;
+        let query = Query {
+            q: input
+                .as_str()
+                .ok_or("Input should be a string")?
+                .to_string(),
+            ..Default::default()
+        };
+
+        let results = service
+            .fetch_products(query, Default::default(), ())
+            .await?;
+
+        if results.items.is_empty() {
+            return Err(anyhow!("I don't know").into());
+        }
+
+        let mut result = "".to_string();
+        for product in results.items {
+            if let Some(vendor) = product.vendor {
+                writeln!(
+                    result,
+                    r#"The product "{}" is made by vendor "{}"."#,
+                    product.head.name, vendor.head.name
+                )?;
+            }
+            if !product.versions.is_empty() {
+                let versions = product
+                    .versions
+                    .iter()
+                    .map(|v| v.version.clone())
+                    .collect::<Vec<_>>();
+                writeln!(
+                    result,
+                    r#"The product "{}" has the following versions: {:?}."#,
+                    product.head.name, versions
+                )?;
+            }
+        }
+        Ok(result)
+    }
+}
+
+pub struct CVEInfo(pub VulnerabilityService);
+
+#[async_trait]
+impl Tool for CVEInfo {
+    fn name(&self) -> String {
+        String::from("CVEInfo")
+    }
+
+    fn description(&self) -> String {
+        String::from(
+            r##"
+            This tool can be used to get information about a Vulnerability.
+            The input should be the name of the Vulnerability to search for.
+            "##,
+        )
+    }
+
+    async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
+        let service = &self.0;
+
+        let query = Query {
+            q: input
+                .as_str()
+                .ok_or("Input should be a string")?
+                .to_string(),
+            ..Default::default()
+        };
+
+        let results = service
+            .fetch_vulnerabilities(query, Default::default(), ())
+            .await?;
+
+        if results.items.is_empty() {
+            return Err(anyhow!("I don't know").into());
+        }
+
+        let mut result = "".to_string();
+        for item in results.items {
+            writeln!(result, "ID: {}\n\n.", item.head.identifier)?;
+            if let Some(v) = item.head.description {
+                writeln!(result, "Description: {}\n\n.", v)?;
+            }
+            if let Some(v) = item.head.title {
+                writeln!(result, "Title: {}\n\n.", v)?;
+            }
+        }
+        Ok(result)
+    }
+}

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -21,6 +21,7 @@ pub fn configure(
 
     crate::advisory::endpoints::configure(svc, db.clone(), config.advisory_upload_limit);
     crate::license::endpoints::configure(svc, db.clone());
+    crate::ai::endpoints::configure(svc, db.clone());
     crate::organization::endpoints::configure(svc, db.clone());
     crate::purl::endpoints::configure(svc, db.clone());
     crate::product::endpoints::configure(svc, db.clone());

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod advisory;
 
+pub mod ai;
 pub mod license;
 pub mod organization;
 pub mod product;

--- a/modules/fundamental/src/openapi.rs
+++ b/modules/fundamental/src/openapi.rs
@@ -9,6 +9,7 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
     let mut doc = ApiDoc::openapi();
 
     doc.merge(crate::advisory::endpoints::ApiDoc::openapi());
+    doc.merge(crate::ai::endpoints::ApiDoc::openapi());
     doc.merge(crate::license::endpoints::ApiDoc::openapi());
     doc.merge(crate::organization::endpoints::ApiDoc::openapi());
     doc.merge(crate::purl::endpoints::ApiDoc::openapi());

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -218,6 +218,28 @@ paths:
                 format: binary
         '404':
           description: The document could not be found
+  /api/v1/ai/completions:
+    post:
+      tags:
+      - ai
+      operationId: completions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatState'
+        required: true
+      responses:
+        '200':
+          description: The resulting completion
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatState'
+        '400':
+          description: The request was invalid
+        '404':
+          description: The AI service is not enabled
   /api/v1/analysis/dep:
     get:
       tags:
@@ -2058,6 +2080,28 @@ components:
       - type: object
     BinaryByteSize:
       type: string
+    ChatMessage:
+      type: object
+      required:
+      - message_type
+      - content
+      properties:
+        content:
+          type: string
+        internal_state:
+          type: string
+          nullable: true
+        message_type:
+          $ref: '#/components/schemas/MessageType'
+    ChatState:
+      type: object
+      required:
+      - messages
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessage'
     ClearlyDefinedImporter:
       allOf:
       - $ref: '#/components/schemas/CommonImporter'
@@ -2384,6 +2428,13 @@ components:
           type: array
           items:
             type: string
+    MessageType:
+      type: string
+      enum:
+      - human
+      - system
+      - ai
+      - tool
     OrganizationDetails:
       allOf:
       - $ref: '#/components/schemas/OrganizationHead'

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,19 +7,27 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
+env_logger = { workspace = true }
+langchain-rust = { workspace = true, features = ["ollama"] }
 log = { workspace = true }
+nu-ansi-term = { workspace = true }
 postgresql_commands = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+test-context = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "tracing-log", "ansi"] }
+reedline = { workspace = true }
 
 trustify-auth = { workspace = true }
 trustify-common = { workspace = true }
+trustify-module-fundamental = { workspace = true }
 trustify-module-importer = { workspace = true }
 trustify-module-ingestor = { workspace = true }
 trustify-module-storage = { workspace = true }
 trustify-server = { workspace = true }
+trustify-test-context = { workspace = true }

--- a/xtask/src/ai.rs
+++ b/xtask/src/ai.rs
@@ -1,0 +1,127 @@
+use clap::Parser;
+use nu_ansi_term::Color::{Blue, DarkGray, Green, LightGray};
+use reedline::FileBackedHistory;
+use reedline::{DefaultPrompt, DefaultPromptSegment, Reedline, Signal};
+use std::env;
+use test_context::AsyncTestContext;
+use trustify_module_fundamental::ai::model::{ChatState, MessageType};
+use trustify_module_fundamental::ai::service::AiService;
+use trustify_test_context::TrustifyContext;
+
+#[derive(Debug, Parser, Default)]
+pub struct Ai {}
+
+impl Ai {
+    pub async fn run(self) -> anyhow::Result<()> {
+        run().await
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
+    // Set the following environment variables to against a different OpenAI API endpoint
+    // OPENAI_API_BASE, OPENAI_API_KEY, OPENAI_MODEL
+
+    // export EXTERNAL_TEST_DB to use an external database, otherwise
+    // a temporary database will be created for testing.
+    let ctx = TrustifyContext::setup().await;
+
+    // if we are not using an external database, ingest some documents so that
+    // we use the data in them to respond to questions.
+    if env::var("EXTERNAL_TEST_DB").is_err() {
+        println!("{}", LightGray.paint("ingesting documents..."));
+        ctx.ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
+            .await?;
+        ctx.ingest_document("ubi9-9.2-755.1697625012.json").await?;
+        ctx.ingest_document("zookeeper-3.9.2-cyclonedx.json")
+            .await?;
+        ctx.ingest_document("cve/CVE-2021-32714.json").await?;
+        ctx.ingest_document("cve/CVE-2024-26308.json").await?;
+        ctx.ingest_document("cve/CVE-2024-29025.json").await?;
+        ctx.ingest_document("csaf/cve-2023-33201.json").await?;
+        println!("{}", Green.paint("DONE!"));
+    }
+
+    let service = AiService::new(ctx.db.clone());
+    let llm_info = match service.llm_info() {
+        None => {
+            println!("{}", LightGray.paint("AI service is not enabled, please set the OPENAI_API_KEY, OPENAI_API_BASE, OPENAI_MODEL env vars."));
+            return Ok(());
+        }
+        Some(llm_info) => llm_info,
+    };
+
+    let history = Box::new(FileBackedHistory::with_file(5, ".ai_history.txt".into())?);
+
+    let mut line_editor = Reedline::create().with_history(history);
+
+    let prompt = DefaultPrompt {
+        left_prompt: DefaultPromptSegment::Basic("Trustify Assistant".to_string()),
+        right_prompt: DefaultPromptSegment::Basic(">>".to_string()),
+    };
+
+    println!(
+        "{}",
+        Blue.paint(
+            r#"
+
+Enter your question or type:
+    'quit' or 'exit' to exit.
+    'clear' to clear chat history.
+
+"#
+        )
+    );
+
+    println!(
+        "Using Model: {}, at endpoint: {}",
+        llm_info.model, llm_info.api_base
+    );
+
+    let mut chat_state = ChatState::new();
+    loop {
+        match line_editor.read_line(&prompt) {
+            Ok(Signal::Success(buffer)) => {
+                match buffer.trim().to_lowercase().as_str() {
+                    "quit" | "exit" => {
+                        println!("{}", Blue.paint("\nBye!"));
+                        return Ok(());
+                    }
+                    "clear" => {
+                        chat_state = ChatState::new();
+                        println!("{}", Blue.paint("\nChat history cleared..."));
+                        continue;
+                    }
+                    _ => {}
+                }
+
+                chat_state.add_human_message(buffer.clone());
+                let pos = chat_state.messages.len();
+
+                let new_state = service.completions(&chat_state, ()).await?;
+
+                for message in &new_state.messages {
+                    println!(
+                        "      {}: {}",
+                        LightGray.paint(message.message_type.to_string()),
+                        DarkGray.paint(message.content.clone())
+                    );
+                }
+
+                for i in pos..new_state.messages.len() {
+                    let message = &new_state.messages[i];
+                    if message.message_type == MessageType::Ai {
+                        println!("{}", Blue.paint(&message.content));
+                    }
+                }
+
+                chat_state = new_state;
+            }
+            Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => {
+                println!("\nBye!");
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@
 
 use clap::{Parser, Subcommand};
 
+mod ai;
 mod dataset;
 mod log;
 mod openapi;
@@ -22,6 +23,7 @@ impl Xtask {
             Command::GenerateDump(command) => command.run().await,
             Command::GenerateSchemas(command) => command.run().await,
             Command::Precommit(command) => command.run().await,
+            Command::Ai(command) => command.run().await,
         }
     }
 }
@@ -36,9 +38,12 @@ pub enum Command {
     GenerateSchemas(schema::GenerateSchema),
     /// Run precommit checks
     Precommit(precommit::Precommit),
+    /// Run ai tool
+    Ai(ai::Ai),
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    env_logger::init();
     Xtask::parse().run().await
 }


### PR DESCRIPTION
Add a `cargo xtask ai` cli interface to the AI service 

It uses that langchanin-rust apis interface with an LLM of your choice.

To run it against an OpenAI compatible endpoint, configure and export the following env variables:

* OPENAI_API_KEY
* OPENAI_API_BASE
* OPENAI_MODEL

To run against OpenAI, just set the 'OPENAI_API_KEY' env var.

Use ollama.com to run it all locally:

* install https://ollama.com/
* `ollama pull llama3.1:70b`
* `OPENAI_API_KEY=ollama OPENAI_API_BASE=http://localhost:11434/v1 OPENAI_MODEL=llama3.1:70b cargo xtask ai`