### PR TITLE
Provide a meaningful way for updating/deleting CSAF advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8543,6 +8543,7 @@ dependencies = [
  "regex",
  "sea-orm",
  "sea-query",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8668,6 +8668,7 @@ dependencies = [
  "sbom-walker",
  "sea-orm",
  "sea-query",
+ "semver",
  "serde",
  "serde_json",
  "serde_yml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ schemars = "0.8"
 sea-orm = "~1.0" # See https://www.sea-ql.org/blog/2024-08-04-sea-orm-1.0/#release-planning
 sea-orm-migration = "~1.0"
 sea-query = "0.31.0"
+semver = "1"
 serde = "1.0.183"
 serde_json = "1.0.114"
 serde_yml = "0.0.12"

--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -1,4 +1,6 @@
 use migration::Iden;
+use sea_orm::{ConnectionTrait, DbErr, ExecResult};
+use sea_query::{Func, SelectStatement};
 use std::fmt::Write;
 
 /// PostgreSQL's `array_agg` function.
@@ -50,5 +52,24 @@ pub struct VersionMatches;
 impl Iden for VersionMatches {
     fn unquoted(&self, s: &mut dyn Write) {
         write!(s, "version_matches").unwrap()
+    }
+}
+
+/// The function updating the deprecated state of a consistent set of advisories.
+pub struct UpdateDeprecatedAdvisory;
+
+impl Iden for UpdateDeprecatedAdvisory {
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(s, "update_deprecated_advisory").unwrap()
+    }
+}
+
+impl UpdateDeprecatedAdvisory {
+    pub async fn execute(db: &impl ConnectionTrait, identifier: &str) -> Result<ExecResult, DbErr> {
+        let stmt = db
+            .get_database_backend()
+            .build(SelectStatement::new().expr(Func::cust(Self).arg(identifier)));
+
+        db.execute(stmt).await
     }
 }

--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -35,6 +35,14 @@ impl Id {
         result.extend(sha512.map(Id::Sha512));
         result
     }
+
+    /// Get the value of the [`Id::Uuid`] variant, or return `None` if it is another variant.
+    pub fn try_as_uid(&self) -> Option<Uuid> {
+        match &self {
+            Self::Uuid(uuid) => Some(*uuid),
+            _ => None,
+        }
+    }
 }
 
 /// Create a filter for an ID

--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -17,6 +17,8 @@ pub struct Model {
     pub id: Uuid,
     #[graphql(name = "name")]
     pub identifier: String,
+    pub version: Option<String>,
+    pub deprecated: bool,
     pub issuer_id: Option<Uuid>,
     pub published: Option<OffsetDateTime>,
     pub modified: Option<OffsetDateTime>,

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -81,6 +81,8 @@ mod m0000625_alter_qualified_purl_purl_column;
 mod m0000630_create_product_version_range;
 mod m0000631_alter_product_cpe_key;
 mod m0000640_create_product_status;
+mod m0000650_alter_advisory_tracking;
+
 pub struct Migrator;
 
 #[async_trait::async_trait]
@@ -168,6 +170,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000630_create_product_version_range::Migration),
             Box::new(m0000631_alter_product_cpe_key::Migration),
             Box::new(m0000640_create_product_status::Migration),
+            Box::new(m0000650_alter_advisory_tracking::Migration),
         ]
     }
 }

--- a/migration/src/m0000650_alter_advisory_tracking.rs
+++ b/migration/src/m0000650_alter_advisory_tracking.rs
@@ -1,0 +1,114 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .add_column(ColumnDef::new(Advisory::Version).string().null().to_owned())
+                    .add_column(
+                        ColumnDef::new(Advisory::Deprecated)
+                            .boolean()
+                            .default(false)
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Advisory::Table)
+                    .name(Indexes::ByIdAndVersion.to_string())
+                    .col(Advisory::Identifier)
+                    .col(Advisory::Version)
+                    .to_owned(),
+            )
+            .await?;
+
+        // create the function, for updating the state
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000650_alter_advisory_tracking/update_deprecated_advisory.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        // create the state of the "deprecated" column, running the function once
+        manager
+            .get_connection()
+            .execute_unprepared(r#"SELECT update_deprecated_advisory();"#)
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+CREATE INDEX not_deprecated ON advisory (id)
+    WHERE deprecated is not true;
+"#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(r#"DROP FUNCTION update_deprecated_advisory"#)
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Advisory::Table)
+                    .name(Indexes::NotDeprecated.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Advisory::Table)
+                    .name(Indexes::ByIdAndVersion.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .drop_column(Advisory::Deprecated)
+                    .drop_column(Advisory::Version)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Advisory {
+    Table,
+    Identifier,
+    Version,
+    Deprecated,
+}
+
+#[derive(DeriveIden)]
+enum Indexes {
+    ByIdAndVersion,
+    NotDeprecated,
+}

--- a/migration/src/m0000650_alter_advisory_tracking/update_deprecated_advisory.sql
+++ b/migration/src/m0000650_alter_advisory_tracking/update_deprecated_advisory.sql
@@ -2,15 +2,12 @@ CREATE OR REPLACE FUNCTION update_deprecated_advisory(identifier_input TEXT DEFA
     RETURNS VOID AS
 $$
 BEGIN
-    WITH MostRecent AS (SELECT DISTINCT ON (identifier) id
-                        FROM advisory
-                        WHERE identifier = COALESCE(identifier_input, identifier)
-                        ORDER BY identifier, modified DESC)
     UPDATE advisory
-    SET deprecated = CASE
-                         WHEN id IN (SELECT id FROM MostRecent) THEN FALSE
-                         ELSE TRUE
-        END
+    SET deprecated = (id != (SELECT id
+                             FROM advisory a
+                             WHERE a.identifier = COALESCE(identifier_input, advisory.identifier)
+                             ORDER BY a.modified DESC
+                             LIMIT 1))
     WHERE identifier = COALESCE(identifier_input, identifier);
 END;
 $$ LANGUAGE plpgsql;

--- a/migration/src/m0000650_alter_advisory_tracking/update_deprecated_advisory.sql
+++ b/migration/src/m0000650_alter_advisory_tracking/update_deprecated_advisory.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION update_deprecated_advisory(identifier_input TEXT DEFAULT NULL)
+    RETURNS VOID AS
+$$
+BEGIN
+    WITH MostRecent AS (SELECT DISTINCT ON (identifier) id
+                        FROM advisory
+                        WHERE identifier = COALESCE(identifier_input, identifier)
+                        ORDER BY identifier, modified DESC)
+    UPDATE advisory
+    SET deprecated = CASE
+                         WHEN id IN (SELECT id FROM MostRecent) THEN FALSE
+                         ELSE TRUE
+        END
+    WHERE identifier = COALESCE(identifier_input, identifier);
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -51,6 +51,7 @@ jsonpath-rust = { workspace = true }
 log = { workspace = true }
 packageurl = { workspace = true }
 regex = { workspace = true }
+semver = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 spdx-rs = { workspace = true }

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -34,6 +34,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-1".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -70,6 +71,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -117,6 +119,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-1".to_string()),
+                version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -134,6 +137,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -210,6 +214,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-1".to_string()),
+                version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -227,6 +232,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -343,7 +343,7 @@ async fn upload_default_csaf_format(ctx: &TrustifyContext) -> Result<(), anyhow:
     let result: IngestResult = app.call_and_read_body_json(request).await;
     log::debug!("{result:?}");
     assert!(matches!(result.id, Id::Uuid(_)));
-    assert_eq!(result.document_id, "CVE-2023-33201");
+    assert_eq!(result.document_id, "https://www.redhat.com/#CVE-2023-33201");
 
     Ok(())
 }
@@ -421,7 +421,7 @@ async fn upload_with_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     let result: IngestResult = app.call_and_read_body_json(request).await;
     log::debug!("{result:?}");
     assert!(matches!(result.id, Id::Uuid(_)));
-    assert_eq!(result.document_id, "CVE-2023-33201");
+    assert_eq!(result.document_id, "https://www.redhat.com/#CVE-2023-33201");
 
     // now check the labels
 

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -14,7 +14,7 @@ use trustify_common::memo::Memo;
 use trustify_entity::{advisory, labels::Labels, organization};
 use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq, Eq)]
 pub struct AdvisoryHead {
     /// The opaque UUID of the advisory.
     #[serde(with = "uuid::serde::urn")]

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -29,6 +29,7 @@ pub async fn ingest_sample_advisory<'a>(
             &Digests::digest(title),
             AdvisoryInformation {
                 title: Some(title.to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -74,7 +75,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
-        .fetch_advisories(q(""), Paginated::default(), ())
+        .fetch_advisories(q(""), Paginated::default(), Default::default(), ())
         .await?;
 
     assert_eq!(fetched.total, 2);
@@ -92,7 +93,12 @@ async fn all_advisories_filtered_by_average_score(
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
-        .fetch_advisories(q("average_score>8"), Paginated::default(), ())
+        .fetch_advisories(
+            q("average_score>8"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
 
     assert_eq!(fetched.total, 1);
@@ -110,7 +116,12 @@ async fn all_advisories_filtered_by_average_severity(
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
-        .fetch_advisories(q("average_severity>=critical"), Paginated::default(), ())
+        .fetch_advisories(
+            q("average_severity>=critical"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
 
     log::debug!("{:#?}", fetched);

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -3,6 +3,7 @@ use trustify_common::db::Database;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_ingestor::service::IngestorService;
 use trustify_module_storage::service::dispatch::DispatchBackend;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Config {
@@ -28,4 +29,11 @@ pub fn configure(
     crate::sbom::endpoints::configure(svc, db.clone(), config.sbom_upload_limit);
     crate::vulnerability::endpoints::configure(svc, db.clone());
     crate::weakness::endpoints::configure(svc, db.clone());
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, ToSchema, serde::Deserialize, IntoParams)]
+pub struct Deprecation {
+    #[serde(default)]
+    #[param(inline)]
+    pub deprecated: trustify_module_ingestor::common::Deprecation,
 }

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -1,26 +1,20 @@
 pub mod advisory;
-
 pub mod ai;
+pub mod endpoints;
+pub mod error;
 pub mod license;
+pub mod openapi;
 pub mod organization;
 pub mod product;
 pub mod purl;
 pub mod sbom;
-
 pub mod source_document;
 pub mod vulnerability;
-
 pub mod weakness;
 
-pub mod openapi;
-pub use openapi::openapi;
-
-pub mod endpoints;
 pub use endpoints::{configure, Config};
-
-pub mod error;
-
 pub use error::Error;
+pub use openapi::openapi;
 
 #[cfg(test)]
 pub mod test;

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -24,6 +24,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
                 title: Some("CAPT-1".to_string()),
+                version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -40,6 +41,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("EMPORIUM-1"),
             AdvisoryInformation {
                 title: Some("EMPORIUM-1".to_string()),
+                version: None,
                 issuer: Some("Capt Pickles Boutique Emporium".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -81,6 +83,7 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
                 title: Some("Pickles can experience a buffer overflow".to_string()),
+                version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,

--- a/modules/fundamental/src/organization/model/mod.rs
+++ b/modules/fundamental/src/organization/model/mod.rs
@@ -13,7 +13,7 @@ use trustify_entity::organization;
 
 /// An organization who may issue advisories, product SBOMs, or
 /// otherwise be involved in supply-chain evidence.
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq, Eq)]
 pub struct OrganizationHead {
     /// The opaque UUID of the organization.
     pub id: Uuid,

--- a/modules/fundamental/src/organization/model/summary.rs
+++ b/modules/fundamental/src/organization/model/summary.rs
@@ -6,7 +6,7 @@ use trustify_common::paginated;
 use trustify_entity::organization;
 use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, PartialEq, Eq)]
 pub struct OrganizationSummary {
     #[serde(flatten)]
     pub head: OrganizationHead,

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -17,6 +17,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("CPIC-1"),
             AdvisoryInformation {
                 title: Some("CAPT-1".to_string()),
+                version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -22,6 +22,7 @@ use trustify_entity::{
     advisory, base_purl, cpe, license, organization, purl_license_assertion, purl_status,
     qualified_purl, sbom, status, version_range, versioned_purl, vulnerability,
 };
+use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
@@ -39,8 +40,11 @@ impl PurlDetails {
         package: Option<base_purl::Model>,
         package_version: Option<versioned_purl::Model>,
         qualified_package: &qualified_purl::Model,
+        deprecation: Deprecation,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
+        // TODO: apply deprecation filter
+
         let package_version = if let Some(package_version) = package_version {
             package_version
         } else {
@@ -77,6 +81,7 @@ impl PurlDetails {
                 purl_status::Entity.into_iden(),
                 purl_status::Column::Id.into_iden(),
             )])
+            .with_deprecation_related(deprecation)
             .all(tx)
             .await?;
 

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -108,7 +108,7 @@ impl PurlDetails {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq)]
 pub struct PurlAdvisory {
     #[serde(flatten)]
     pub head: AdvisoryHead,
@@ -166,7 +166,7 @@ impl PurlAdvisory {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq)]
 pub struct PurlStatus {
     pub vulnerability: VulnerabilityHead,
     pub status: String,
@@ -174,7 +174,7 @@ pub struct PurlStatus {
     pub context: Option<StatusContext>,
 }
 
-#[derive(Serialize, Clone, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Clone, Deserialize, Debug, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum StatusContext {
     Purl(Purl),

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -567,7 +567,9 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let uuid = results.items[0].head.uuid;
 
-    let _results = service.purl_by_uuid(&uuid, Transactional::None).await?;
+    let _results = service
+        .purl_by_uuid(&uuid, Default::default(), Transactional::None)
+        .await?;
 
     Ok(())
 }
@@ -594,7 +596,9 @@ async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let uuid = tomcat_jsp.head.uuid;
 
-    let tomcat_jsp = service.purl_by_uuid(&uuid, Transactional::None).await?;
+    let tomcat_jsp = service
+        .purl_by_uuid(&uuid, Default::default(), Transactional::None)
+        .await?;
 
     assert!(tomcat_jsp.is_some());
 
@@ -759,7 +763,11 @@ async fn purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ingest_some_log4j_data(ctx).await?;
 
     let results = service
-        .purl_by_purl(&Purl::from_str("pkg:maven/org.apache/log4j@1.2.3")?, ())
+        .purl_by_purl(
+            &Purl::from_str("pkg:maven/org.apache/log4j@1.2.3")?,
+            Default::default(),
+            (),
+        )
         .await?;
 
     assert_eq!(results.unwrap().version.version, "1.2.3");
@@ -809,6 +817,7 @@ async fn license_information(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     let result = service
         .purl_by_purl(
             &Purl::try_from("pkg:rpm/redhat/libsepol@3.5-1.el9?arch=s390x")?,
+            Default::default(),
             Transactional::None,
         )
         .await?;

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -1,12 +1,14 @@
 #[cfg(test)]
 mod test;
 
+use crate::endpoints::Deprecation;
 use crate::vulnerability::service::VulnerabilityService;
 use crate::Error::Internal;
 use actix_web::{delete, get, web, HttpResponse, Responder};
-use trustify_common::db::query::Query;
-use trustify_common::db::{Database, Transactional};
-use trustify_common::model::Paginated;
+use trustify_common::{
+    db::{query::Query, Database, Transactional},
+    model::Paginated,
+};
 use utoipa::OpenApi;
 
 pub fn configure(config: &mut web::ServiceConfig, db: Database) {
@@ -56,10 +58,11 @@ pub async fn all(
     state: web::Data<VulnerabilityService>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
+    web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
 ) -> actix_web::Result<impl Responder> {
     Ok(HttpResponse::Ok().json(
         state
-            .fetch_vulnerabilities(search, paginated, Transactional::None)
+            .fetch_vulnerabilities(search, paginated, deprecated, Transactional::None)
             .await?,
     ))
 }
@@ -81,8 +84,11 @@ pub async fn all(
 pub async fn get(
     state: web::Data<VulnerabilityService>,
     id: web::Path<String>,
+    web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
 ) -> actix_web::Result<impl Responder> {
-    let vuln = state.fetch_vulnerability(&id, Transactional::None).await?;
+    let vuln = state
+        .fetch_vulnerability(&id, deprecated, Transactional::None)
+        .await?;
     if let Some(vuln) = vuln {
         Ok(HttpResponse::Ok().json(vuln))
     } else {
@@ -108,7 +114,15 @@ pub async fn delete(
     state: web::Data<VulnerabilityService>,
     id: web::Path<String>,
 ) -> actix_web::Result<impl Responder> {
-    let vuln = state.fetch_vulnerability(&id, Transactional::None).await?;
+    let vuln = state
+        // we ignore deprecated advisories, as we delete the vulnerability anyway.
+        .fetch_vulnerability(
+            &id,
+            trustify_module_ingestor::common::Deprecation::Ignore,
+            Transactional::None,
+        )
+        .await?;
+
     if let Some(vuln) = vuln {
         let rows_affected = state
             .delete_vulnerability(&vuln.head.identifier, ())

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -31,6 +31,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
                 title: Some("CAPT-1".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -68,6 +69,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -111,6 +113,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-1".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -149,6 +152,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -206,6 +210,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
                 title: Some("RHSA-1".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,
@@ -244,6 +249,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
                 title: Some("RHSA-2".to_string()),
+                version: None,
                 issuer: None,
                 published: Some(OffsetDateTime::now_utc()),
                 modified: None,

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -5,11 +5,10 @@ pub use vulnerability_advisory::*;
 use crate::{vulnerability::model::VulnerabilityHead, Error};
 use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
-use trustify_common::memo::Memo;
-use trustify_cvss::cvss3::severity::Severity;
-use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
+use trustify_common::{db::ConnectionOrTransaction, memo::Memo};
+use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
 use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
+use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -80,10 +79,12 @@ impl VulnerabilityDetails {
 
     pub async fn from_entity(
         vulnerability: &vulnerability::Model,
+        deprecation: Deprecation,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let advisory_vulnerabilities = vulnerability
             .find_related(advisory_vulnerability::Entity)
+            .with_deprecation_related(deprecation)
             .all(tx)
             .await?;
 

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -13,7 +13,7 @@ use trustify_common::memo::Memo;
 use trustify_entity::{advisory_vulnerability, vulnerability, vulnerability_description};
 use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq, Eq)]
 pub struct VulnerabilityHead {
     #[schema(required)]
     pub normative: bool,

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -10,6 +10,7 @@ use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::{
     advisory, advisory_vulnerability, cvss3, vulnerability, vulnerability_description,
 };
+use trustify_module_ingestor::common::{Deprecation, DeprecationExt};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -35,10 +36,15 @@ impl VulnerabilitySummary {
     pub async fn from_entities(
         vulnerabilities: &[vulnerability::Model],
         averages: &[(Option<f64>, Option<Severity>)],
+        deprecation: Deprecation,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let advisories = vulnerabilities
-            .load_many_to_many(advisory::Entity::find(), advisory_vulnerability::Entity, tx)
+            .load_many_to_many(
+                advisory::Entity::find().with_deprecation(deprecation),
+                advisory_vulnerability::Entity,
+                tx,
+            )
             .await?;
 
         let vuln_cvss3s = vulnerabilities.load_many(cvss3::Entity, tx).await?;

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -4,18 +4,20 @@ use crate::{
 };
 use sea_orm::{prelude::*, EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait};
 use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
-use trustify_common::db::limiter::LimiterAsModelTrait;
-use trustify_common::db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel};
-use trustify_common::db::query::Columns;
 use trustify_common::{
     db::{
-        query::{Filtering, Query},
+        limiter::LimiterAsModelTrait,
+        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
+        query::{Columns, Filtering, Query},
         Database, Transactional,
     },
     model::{Paginated, PaginatedResults},
 };
-use trustify_entity::cvss3::Severity;
-use trustify_entity::{cvss3, vulnerability};
+use trustify_entity::{
+    cvss3::{self, Severity},
+    vulnerability,
+};
+use trustify_module_ingestor::common::Deprecation;
 
 pub struct VulnerabilityService {
     db: Database,
@@ -30,6 +32,7 @@ impl VulnerabilityService {
         &self,
         search: Query,
         paginated: Paginated,
+        deprecation: Deprecation,
         tx: TX,
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
         let connection = self.db.connection(&tx);
@@ -117,14 +120,20 @@ impl VulnerabilityService {
 
         Ok(PaginatedResults {
             total,
-            items: VulnerabilitySummary::from_entities(&vulnerabilities, &averages, &connection)
-                .await?,
+            items: VulnerabilitySummary::from_entities(
+                &vulnerabilities,
+                &averages,
+                deprecation,
+                &connection,
+            )
+            .await?,
         })
     }
 
     pub async fn fetch_vulnerability<TX: AsRef<Transactional> + Sync + Send>(
         &self,
         identifier: &str,
+        deprecation: Deprecation,
         tx: TX,
     ) -> Result<Option<VulnerabilityDetails>, Error> {
         let connection = self.db.connection(&tx);
@@ -134,7 +143,7 @@ impl VulnerabilityService {
             .await?
         {
             Ok(Some(
-                VulnerabilityDetails::from_entity(&vulnerability, &connection).await?,
+                VulnerabilityDetails::from_entity(&vulnerability, deprecation, &connection).await?,
             ))
         } else {
             Ok(None)

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -226,7 +226,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let cve_advisory = vuln
         .advisories
         .iter()
-        .find(|e| e.head.head.identifier == "CVE-2023-0044");
+        .find(|e| e.head.head.identifier == "https://www.redhat.com/#CVE-2023-0044");
     assert!(cve_advisory.is_some());
     let cve_advisory = cve_advisory.unwrap();
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -17,7 +17,12 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         .await?;
 
     let vulns = service
-        .fetch_vulnerabilities(Query::default(), Paginated::default(), ())
+        .fetch_vulnerabilities(
+            Query::default(),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
 
     assert_eq!(1, vulns.items.len());
@@ -41,7 +46,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2021-32714", Transactional::None)
+        .fetch_vulnerability("CVE-2021-32714", Default::default(), Transactional::None)
         .await?;
 
     assert!(vuln.is_some());
@@ -92,7 +97,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", Transactional::None)
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), Transactional::None)
         .await?;
 
     assert!(vuln.is_some());
@@ -162,7 +167,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(quarkus_sbom.advisories.is_empty());
 
     let vuln = vuln_service
-        .fetch_vulnerability("CVE-2024-26308", Transactional::None)
+        .fetch_vulnerability("CVE-2024-26308", Default::default(), Transactional::None)
         .await?
         .unwrap();
 
@@ -207,7 +212,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["csaf/cve-2023-0044.json"]).await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2023-0044", Transactional::None)
+        .fetch_vulnerability("CVE-2023-0044", Default::default(), Transactional::None)
         .await?;
 
     assert!(vuln.is_some());
@@ -249,7 +254,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     ctx.ingest_documents(["cve/CVE-2024-29025.json"]).await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", ())
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), ())
         .await?
         .expect("Vulnerability not found");
 
@@ -261,7 +266,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     assert_eq!(1, affected);
 
     assert!(service
-        .fetch_vulnerability("CVE-2024-29025", ())
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), ())
         .await?
         .is_none());
 
@@ -284,21 +289,36 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     .await?;
 
     let vulns = service
-        .fetch_vulnerabilities(q(""), Paginated::default(), ())
+        .fetch_vulnerabilities(q(""), Paginated::default(), Default::default(), ())
         .await?;
     assert_eq!(5, vulns.items.len());
     let vulns = service
-        .fetch_vulnerabilities(q("average_score>9"), Paginated::default(), ())
+        .fetch_vulnerabilities(
+            q("average_score>9"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-42282");
     let vulns = service
-        .fetch_vulnerabilities(q("average_severity=critical"), Paginated::default(), ())
+        .fetch_vulnerabilities(
+            q("average_severity=critical"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-42282");
     let vulns = service
-        .fetch_vulnerabilities(q("average_severity<high"), Paginated::default(), ())
+        .fetch_vulnerabilities(
+            q("average_severity<high"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(
@@ -306,11 +326,16 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         trustify_cvss::cvss3::severity::Severity::Medium
     );
     let vulns = service
-        .fetch_vulnerabilities(q("average_severity>=high"), Paginated::default(), ())
+        .fetch_vulnerabilities(
+            q("average_severity>=high"),
+            Paginated::default(),
+            Default::default(),
+            (),
+        )
         .await?;
     assert_eq!(4, vulns.items.len());
     let vulns = service
-        .fetch_vulnerabilities(q("20862"), Paginated::default(), ())
+        .fetch_vulnerabilities(q("20862"), Paginated::default(), Default::default(), ())
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-20862");

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -1,0 +1,148 @@
+#![allow(clippy::expect_used)]
+
+use super::prepare_ps_state_change;
+use test_context::test_context;
+use test_log::test;
+use trustify_common::purl::Purl;
+use trustify_module_fundamental::{
+    advisory::service::AdvisoryService,
+    purl::{
+        model::details::purl::{PurlStatus, StatusContext},
+        service::PurlService,
+    },
+    vulnerability::{model::VulnerabilityHead, service::VulnerabilityService},
+};
+use trustify_module_ingestor::common::Deprecation;
+use trustify_test_context::TrustifyContext;
+
+/// Ensure that ingesting an advisory, and a change for it, then deleting the newested one, still
+/// leads to a "most recent" document.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = prepare_ps_state_change(ctx).await?;
+
+    // the internal document ID will change, it's a new document
+
+    assert_ne!(r1.id, r2.id);
+
+    // now delete the newer one
+
+    let service = AdvisoryService::new(ctx.db.clone());
+    service
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .await?;
+
+    // now test, find only one, for either ignore or consider
+
+    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let v = vuln
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, ())
+        .await?
+        .expect("must exist");
+
+    assert_eq!(v.advisories.len(), 1);
+
+    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let v = vuln
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, ())
+        .await?
+        .expect("must exist");
+
+    assert_eq!(v.advisories.len(), 1);
+
+    // done
+
+    Ok(())
+}
+
+/// Ingest the same document twice, then deleting the latter. The fixed state should be rolled back.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = prepare_ps_state_change(ctx).await?;
+
+    // the internal document ID will change, it's a new document
+
+    assert_ne!(r1.id, r2.id);
+
+    // now delete the newer one
+
+    let service = AdvisoryService::new(ctx.db.clone());
+    service
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .await?;
+
+    // check info
+
+    let service = PurlService::new(ctx.db.clone());
+    let purls = service
+        .purls(Default::default(), Default::default(), ())
+        .await?;
+
+    // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
+    let purl = purls
+        .items
+        .iter()
+        .find(|purl| {
+            purl.base.purl.name == "eap7-bouncycastle-util"
+                && purl.version.version == "1.76.0-4.redhat_00001.1.el9eap"
+        })
+        .expect("must find one");
+
+    assert_eq!(
+        purl.base.purl,
+        Purl {
+            ty: "rpm".to_string(),
+            namespace: Some("redhat".to_string()),
+            name: "eap7-bouncycastle-util".to_string(),
+            version: None,
+            qualifiers: Default::default(),
+        }
+    );
+    assert_eq!(purl.version.version, "1.76.0-4.redhat_00001.1.el9eap");
+
+    // get vuln by purl
+
+    let mut purl = service
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, ())
+        .await?
+        .expect("must find something");
+
+    // must be 1, as we deleted the latter one
+
+    assert_eq!(purl.advisories.len(), 1);
+    purl.advisories
+        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+    let adv1 = &purl.advisories[0];
+
+    assert_eq!(adv1.head.identifier, "CVE-2023-33201");
+
+    // now check the details
+
+    assert_eq!(
+        adv1.status,
+        vec![PurlStatus {
+            vulnerability: VulnerabilityHead {
+                normative: true,
+                identifier: "CVE-2023-33201".to_string(),
+                title: None,
+                description: None,
+                published: None,
+                modified: None,
+                withdrawn: None,
+                discovered: None,
+                released: None,
+                cwes: vec![],
+            },
+            status: "affected".to_string(),
+            context: Some(StatusContext::Cpe(
+                "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
+            )),
+        }]
+    );
+
+    // done
+
+    Ok(())
+}

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -116,7 +116,10 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
         .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
     let adv1 = &purl.advisories[0];
 
-    assert_eq!(adv1.head.identifier, "CVE-2023-33201");
+    assert_eq!(
+        adv1.head.identifier,
+        "https://www.redhat.com/#CVE-2023-33201"
+    );
 
     // now check the details
 

--- a/modules/fundamental/tests/advisory/csaf/mod.rs
+++ b/modules/fundamental/tests/advisory/csaf/mod.rs
@@ -1,0 +1,1 @@
+mod reingest;

--- a/modules/fundamental/tests/advisory/csaf/mod.rs
+++ b/modules/fundamental/tests/advisory/csaf/mod.rs
@@ -1,1 +1,146 @@
+#![allow(clippy::expect_used)]
+
+mod delete;
 mod reingest;
+
+use csaf::definitions::ProductIdT;
+use csaf::document::Revision;
+use csaf::Csaf;
+use trustify_module_ingestor::model::IngestResult;
+use trustify_test_context::{document_bytes, TrustifyContext};
+
+/// Ingest a document twice, mutating it using the provided closure.
+async fn twice<M1, M2>(
+    ctx: &TrustifyContext,
+    m1: M1,
+    m2: M2,
+) -> anyhow::Result<(IngestResult, IngestResult)>
+where
+    M1: FnOnce(Csaf) -> Csaf,
+    M2: FnOnce(Csaf) -> Csaf,
+{
+    let data = document_bytes("csaf/cve-2023-33201.json").await?;
+    let csaf: Csaf = serde_json::from_slice(&data)?;
+
+    let csaf = m1(csaf);
+
+    let result = ctx
+        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
+        .await?;
+
+    let csaf = m2(csaf);
+
+    let result2 = ctx
+        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
+        .await?;
+
+    Ok((result, result2))
+}
+
+/// Uptick the tracking information according to the spec, adding a new revision record,
+/// incrementing the main tracking version.
+fn uptick_tracking(csaf: &mut Csaf) {
+    let current = &csaf.document.tracking.version;
+
+    let next = uptick_version(current).expect("unable to increment version");
+
+    csaf.document.tracking.version = next.clone();
+    csaf.document.tracking.revision_history.push(Revision {
+        date: Default::default(),
+        legacy_version: None,
+        number: next,
+        summary: "Updated for test".to_string(),
+    });
+}
+
+/// Uptick the version by one.
+///
+/// The version can be either a plain number or a semantic version. We increment by one, considering
+/// a major change.
+///
+/// > Whenever the operator needs to do a new matching run on his asset database (matching the products from the CSAF product tree with deployed products) the MAJOR version is incremented.
+fn uptick_version(version: &str) -> anyhow::Result<String> {
+    if version.contains('.') {
+        let mut version = semver::Version::parse(version)?;
+        version.major += 1;
+        Ok(version.to_string())
+    } else {
+        let version = version.parse::<u64>()? + 1;
+        Ok(version.to_string())
+    }
+}
+
+/// prepare a state with an updated advisory, making a change in the product state section.
+async fn prepare_ps_state_change(
+    ctx: &TrustifyContext,
+) -> anyhow::Result<(IngestResult, IngestResult)> {
+    const CVE: &str = "CVE-2023-33201";
+    const PRODUCT: &str =
+        "9Base-JBEAP-7.4:eap7-bouncycastle-util-0:1.76.0-4.redhat_00001.1.el9eap.noarch";
+
+    twice(
+        ctx,
+        |mut csaf| {
+            let vulns = csaf
+                .vulnerabilities
+                .as_mut()
+                .expect("test data has vulnerabilities");
+
+            let v = vulns
+                .iter_mut()
+                .find(|v| v.cve.as_deref() == Some(CVE))
+                .expect("test data has a specific CVE");
+
+            let ps = v
+                .product_status
+                .as_mut()
+                .expect("test data has product status information");
+
+            // remove from fixed to known affected
+
+            ps.fixed
+                .as_mut()
+                .expect(r#"test data has "fixed" entries"#)
+                .retain(|ps| ps.0 != PRODUCT);
+            ps.known_affected
+                .as_mut()
+                .expect(r#"test data has "known affected" entries"#)
+                .push(ProductIdT(PRODUCT.into()));
+
+            csaf
+        },
+        |mut csaf| {
+            uptick_tracking(&mut csaf);
+            csaf.document.tracking.current_release_date += chrono::Duration::days(1);
+
+            let vulns = csaf
+                .vulnerabilities
+                .as_mut()
+                .expect("test data has vulnerabilties");
+
+            let v = vulns
+                .iter_mut()
+                .find(|v| v.cve.as_deref() == Some(CVE))
+                .expect("test data has a specific CVE");
+
+            let ps = v
+                .product_status
+                .as_mut()
+                .expect("test data has product status information");
+
+            // now back to fixed
+
+            ps.known_affected
+                .as_mut()
+                .expect(r#"test data has "known affected" entries"#)
+                .retain(|ps| ps.0 != PRODUCT);
+            ps.fixed
+                .as_mut()
+                .expect(r#"test data has "fixed" entries"#)
+                .push(ProductIdT(PRODUCT.into()));
+
+            csaf
+        },
+    )
+    .await
+}

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -131,7 +131,10 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     assert_eq!(purl.advisories.len(), 1);
     let adv = &purl.advisories[0];
 
-    assert_eq!(adv.head.identifier, "CVE-2023-33201");
+    assert_eq!(
+        adv.head.identifier,
+        "https://www.redhat.com/#CVE-2023-33201"
+    );
 
     // now check the details
 
@@ -224,8 +227,14 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let adv1 = &purl.advisories[0];
     let adv2 = &purl.advisories[1];
 
-    assert_eq!(adv1.head.identifier, "CVE-2023-33201");
-    assert_eq!(adv2.head.identifier, "CVE-2023-33201");
+    assert_eq!(
+        adv1.head.identifier,
+        "https://www.redhat.com/#CVE-2023-33201"
+    );
+    assert_eq!(
+        adv2.head.identifier,
+        "https://www.redhat.com/#CVE-2023-33201"
+    );
 
     // now check the details
 

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -113,7 +113,7 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     );
     assert_eq!(purl.version.version, "1.76.0-4.redhat_00001.1.el9eap");
 
-    // FIXME: I'd expect the qualifiers to be present, but they aren't.
+    // FIXME(#879): I'd expect the qualifiers to be present, but they aren't.
     /*
     assert_eq!(
         purl.qualifiers.clone().into_iter().collect::<Vec<_>>(),
@@ -204,7 +204,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     );
     assert_eq!(purl.version.version, "1.76.0-4.redhat_00001.1.el9eap");
 
-    // FIXME: I'd expect the qualifiers to be present, but they aren't.
+    // FIXME(#879): I'd expect the qualifiers to be present, but they aren't.
     /*
     assert_eq!(
         purl.qualifiers.clone().into_iter().collect::<Vec<_>>(),

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -1,4 +1,6 @@
-use csaf::{definitions::ProductIdT, document::Revision, Csaf};
+#![allow(clippy::expect_used)]
+
+use super::{prepare_ps_state_change, twice};
 use test_context::test_context;
 use test_log::test;
 use trustify_common::purl::Purl;
@@ -9,14 +11,14 @@ use trustify_module_fundamental::{
     },
     vulnerability::{model::VulnerabilityHead, service::VulnerabilityService},
 };
-use trustify_module_ingestor::model::IngestResult;
-use trustify_test_context::{document_bytes, TrustifyContext};
+use trustify_module_ingestor::common::Deprecation;
+use trustify_test_context::TrustifyContext;
 
 /// Ensure that ingesting the same document twice, leads to the same ID.
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
-    let (r1, r2) = twice(&ctx, |csaf| csaf, |csaf| csaf).await?;
+    let (r1, r2) = twice(ctx, |csaf| csaf, |csaf| csaf).await?;
 
     // no change, same result
 
@@ -26,9 +28,9 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let vuln = VulnerabilityService::new(ctx.db.clone());
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", ())
+        .fetch_vulnerability("CVE-2023-33201", Default::default(), ())
         .await?
-        .expect("must exists");
+        .expect("must exist");
 
     assert_eq!(v.advisories.len(), 1);
 
@@ -43,36 +45,42 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = prepare_ps_state_change(ctx).await?;
 
-    // TODO: it changes. but should it?
+    // the internal document ID will change, it's a new document
 
     assert_ne!(r1.id, r2.id);
 
-    // check info
+    // check info - non-deprecated
 
     let vuln = VulnerabilityService::new(ctx.db.clone());
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", ())
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, ())
         .await?
-        .expect("must exists");
-
-    // FIXME: as we did perform an update, we should not get two advisories, but the same one
+        .expect("must exist");
 
     assert_eq!(v.advisories.len(), 1);
+
+    // check info - with-deprecated
+
+    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let v = vuln
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, ())
+        .await?
+        .expect("must exist");
+
+    assert_eq!(v.advisories.len(), 2);
 
     // done
 
     Ok(())
 }
 
-/// Ingest the same document, with an update on the product state.
-///
-/// This just ensures that ingesting the exact same document doesn't change the state.
+/// Ingest the same document twice. First having an affected, then fixed state.
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = prepare_ps_state_change(ctx).await?;
 
-    // TODO: it changes. but should it?
+    // the internal document ID will change, it's a new document
 
     assert_ne!(r1.id, r2.id);
 
@@ -115,12 +123,100 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // get vuln by purl
 
-    let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, ())
+    let purl = service
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, ())
         .await?
         .expect("must find something");
 
-    // FIXME: should be 1 I guess
+    assert_eq!(purl.advisories.len(), 1);
+    let adv = &purl.advisories[0];
+
+    assert_eq!(adv.head.identifier, "CVE-2023-33201");
+
+    // now check the details
+
+    assert_eq!(
+        adv.status,
+        vec![PurlStatus {
+            vulnerability: VulnerabilityHead {
+                normative: true,
+                identifier: "CVE-2023-33201".to_string(),
+                title: None,
+                description: None,
+                published: None,
+                modified: None,
+                withdrawn: None,
+                discovered: None,
+                released: None,
+                cwes: vec![],
+            },
+            status: "fixed".to_string(),
+            context: Some(StatusContext::Cpe(
+                "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
+            )),
+        }]
+    );
+
+    // done
+
+    Ok(())
+}
+
+/// Ingest the same document twice. First having an affected, then fixed state.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = prepare_ps_state_change(ctx).await?;
+
+    // the internal document ID will change, it's a new document
+
+    assert_ne!(r1.id, r2.id);
+
+    // check info
+
+    let service = PurlService::new(ctx.db.clone());
+    let purls = service
+        .purls(Default::default(), Default::default(), ())
+        .await?;
+
+    // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
+    let purl = purls
+        .items
+        .iter()
+        .find(|purl| {
+            purl.base.purl.name == "eap7-bouncycastle-util"
+                && purl.version.version == "1.76.0-4.redhat_00001.1.el9eap"
+        })
+        .expect("must find one");
+
+    assert_eq!(
+        purl.base.purl,
+        Purl {
+            ty: "rpm".to_string(),
+            namespace: Some("redhat".to_string()),
+            name: "eap7-bouncycastle-util".to_string(),
+            version: None,
+            qualifiers: Default::default(),
+        }
+    );
+    assert_eq!(purl.version.version, "1.76.0-4.redhat_00001.1.el9eap");
+
+    // FIXME: I'd expect the qualifiers to be present, but they aren't.
+    /*
+    assert_eq!(
+        purl.qualifiers.clone().into_iter().collect::<Vec<_>>(),
+        vec![("arch".to_string(), "noarch".to_string())]
+    );
+    */
+
+    // get vuln by purl
+
+    let mut purl = service
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, ())
+        .await?
+        .expect("must find something");
+
+    // must be 2, as we consider deprecated ones too
 
     assert_eq!(purl.advisories.len(), 2);
     purl.advisories
@@ -128,14 +224,10 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let adv1 = &purl.advisories[0];
     let adv2 = &purl.advisories[1];
 
-    // FIXME: Getting weird? Same "ID" twice, but wait!
-
     assert_eq!(adv1.head.identifier, "CVE-2023-33201");
     assert_eq!(adv2.head.identifier, "CVE-2023-33201");
 
     // now check the details
-
-    // FIXME: same here, instead of having contradicting information, we should have "fixed" now.
 
     assert_eq!(
         adv1.status,
@@ -183,122 +275,4 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // done
 
     Ok(())
-}
-
-/// prepare a state with an updated advisory, making a change in the product state section.
-async fn prepare_ps_state_change(
-    ctx: &TrustifyContext,
-) -> anyhow::Result<(IngestResult, IngestResult)> {
-    const CVE: &str = "CVE-2023-33201";
-    const PRODUCT: &str =
-        "9Base-JBEAP-7.4:eap7-bouncycastle-util-0:1.76.0-4.redhat_00001.1.el9eap.noarch";
-
-    twice(
-        &ctx,
-        |mut csaf| {
-            let vulns = csaf.vulnerabilities.as_mut().unwrap();
-
-            let v = vulns
-                .iter_mut()
-                .find(|v| v.cve.as_deref() == Some(CVE))
-                .unwrap();
-
-            let ps = v.product_status.as_mut().unwrap();
-
-            // remove from fixed to known affected
-
-            ps.fixed.as_mut().unwrap().retain(|ps| ps.0 != PRODUCT);
-            ps.known_affected
-                .as_mut()
-                .unwrap()
-                .push(ProductIdT(PRODUCT.into()));
-
-            csaf
-        },
-        |mut csaf| {
-            uptick_tracking(&mut csaf);
-            csaf.document.tracking.current_release_date += chrono::Duration::days(1);
-
-            let vulns = csaf.vulnerabilities.as_mut().unwrap();
-
-            let v = vulns
-                .iter_mut()
-                .find(|v| v.cve.as_deref() == Some(CVE))
-                .unwrap();
-
-            let ps = v.product_status.as_mut().unwrap();
-
-            // now back to fixed
-
-            ps.known_affected
-                .as_mut()
-                .unwrap()
-                .retain(|ps| ps.0 != PRODUCT);
-            ps.fixed.as_mut().unwrap().push(ProductIdT(PRODUCT.into()));
-
-            csaf
-        },
-    )
-    .await
-}
-
-/// Ingest a document twice, mutating it using the provided closure.
-async fn twice<M1, M2>(
-    ctx: &TrustifyContext,
-    m1: M1,
-    m2: M2,
-) -> anyhow::Result<(IngestResult, IngestResult)>
-where
-    M1: FnOnce(Csaf) -> Csaf,
-    M2: FnOnce(Csaf) -> Csaf,
-{
-    let data = document_bytes("csaf/cve-2023-33201.json").await?;
-    let csaf: Csaf = serde_json::from_slice(&data)?;
-
-    let csaf = m1(csaf);
-
-    let result = ctx
-        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
-        .await?;
-
-    let csaf = m2(csaf);
-
-    let result2 = ctx
-        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
-        .await?;
-
-    Ok((result, result2))
-}
-
-/// Uptick the tracking information according to the spec, adding a new revision record,
-/// incrementing the main tracking version.
-fn uptick_tracking(csaf: &mut Csaf) {
-    let current = &csaf.document.tracking.version;
-
-    let next = uptick_version(&current).expect("unable to increment version");
-
-    csaf.document.tracking.version = next.clone();
-    csaf.document.tracking.revision_history.push(Revision {
-        date: Default::default(),
-        legacy_version: None,
-        number: next.into(),
-        summary: "Updated for test".to_string(),
-    });
-}
-
-/// Uptick the version by one.
-///
-/// The version can be either a plain number or a semantic version. We increment by one, considering
-/// a major change.
-///
-/// > Whenever the operator needs to do a new matching run on his asset database (matching the products from the CSAF product tree with deployed products) the MAJOR version is incremented.
-fn uptick_version(version: &str) -> anyhow::Result<String> {
-    if version.contains('.') {
-        let mut version = semver::Version::parse(version)?;
-        version.major += 1;
-        Ok(version.to_string())
-    } else {
-        let version = version.parse::<u64>()? + 1;
-        Ok(version.to_string())
-    }
 }

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -1,0 +1,304 @@
+use csaf::{definitions::ProductIdT, document::Revision, Csaf};
+use test_context::test_context;
+use test_log::test;
+use trustify_common::purl::Purl;
+use trustify_module_fundamental::{
+    purl::{
+        model::details::purl::{PurlStatus, StatusContext},
+        service::PurlService,
+    },
+    vulnerability::{model::VulnerabilityHead, service::VulnerabilityService},
+};
+use trustify_module_ingestor::model::IngestResult;
+use trustify_test_context::{document_bytes, TrustifyContext};
+
+/// Ensure that ingesting the same document twice, leads to the same ID.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = twice(&ctx, |csaf| csaf, |csaf| csaf).await?;
+
+    // no change, same result
+
+    assert_eq!(r1.id, r2.id);
+
+    // check info
+
+    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let v = vuln
+        .fetch_vulnerability("CVE-2023-33201", ())
+        .await?
+        .expect("must exists");
+
+    assert_eq!(v.advisories.len(), 1);
+
+    // done
+
+    Ok(())
+}
+
+/// Ingest the same document, with an update on the product state.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = prepare_ps_state_change(ctx).await?;
+
+    // TODO: it changes. but should it?
+
+    assert_ne!(r1.id, r2.id);
+
+    // check info
+
+    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let v = vuln
+        .fetch_vulnerability("CVE-2023-33201", ())
+        .await?
+        .expect("must exists");
+
+    // FIXME: as we did perform an update, we should not get two advisories, but the same one
+
+    assert_eq!(v.advisories.len(), 1);
+
+    // done
+
+    Ok(())
+}
+
+/// Ingest the same document, with an update on the product state.
+///
+/// This just ensures that ingesting the exact same document doesn't change the state.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let (r1, r2) = prepare_ps_state_change(ctx).await?;
+
+    // TODO: it changes. but should it?
+
+    assert_ne!(r1.id, r2.id);
+
+    // check info
+
+    let service = PurlService::new(ctx.db.clone());
+    let purls = service
+        .purls(Default::default(), Default::default(), ())
+        .await?;
+
+    // pkg:rpm/redhat/eap7-bouncycastle@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
+    let purl = purls
+        .items
+        .iter()
+        .find(|purl| {
+            purl.base.purl.name == "eap7-bouncycastle-util"
+                && purl.version.version == "1.76.0-4.redhat_00001.1.el9eap"
+        })
+        .expect("must find one");
+
+    assert_eq!(
+        purl.base.purl,
+        Purl {
+            ty: "rpm".to_string(),
+            namespace: Some("redhat".to_string()),
+            name: "eap7-bouncycastle-util".to_string(),
+            version: None,
+            qualifiers: Default::default(),
+        }
+    );
+    assert_eq!(purl.version.version, "1.76.0-4.redhat_00001.1.el9eap");
+
+    // FIXME: I'd expect the qualifiers to be present, but they aren't.
+    /*
+    assert_eq!(
+        purl.qualifiers.clone().into_iter().collect::<Vec<_>>(),
+        vec![("arch".to_string(), "noarch".to_string())]
+    );
+    */
+
+    // get vuln by purl
+
+    let mut purl = service
+        .purl_by_uuid(&purl.head.uuid, ())
+        .await?
+        .expect("must find something");
+
+    // FIXME: should be 1 I guess
+
+    assert_eq!(purl.advisories.len(), 2);
+    purl.advisories
+        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+    let adv1 = &purl.advisories[0];
+    let adv2 = &purl.advisories[1];
+
+    // FIXME: Getting weird? Same "ID" twice, but wait!
+
+    assert_eq!(adv1.head.identifier, "CVE-2023-33201");
+    assert_eq!(adv2.head.identifier, "CVE-2023-33201");
+
+    // now check the details
+
+    // FIXME: same here, instead of having contradicting information, we should have "fixed" now.
+
+    assert_eq!(
+        adv1.status,
+        vec![PurlStatus {
+            vulnerability: VulnerabilityHead {
+                normative: true,
+                identifier: "CVE-2023-33201".to_string(),
+                title: None,
+                description: None,
+                published: None,
+                modified: None,
+                withdrawn: None,
+                discovered: None,
+                released: None,
+                cwes: vec![],
+            },
+            status: "affected".to_string(),
+            context: Some(StatusContext::Cpe(
+                "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
+            )),
+        }]
+    );
+    assert_eq!(
+        adv2.status,
+        vec![PurlStatus {
+            vulnerability: VulnerabilityHead {
+                normative: true,
+                identifier: "CVE-2023-33201".to_string(),
+                title: None,
+                description: None,
+                published: None,
+                modified: None,
+                withdrawn: None,
+                discovered: None,
+                released: None,
+                cwes: vec![],
+            },
+            status: "fixed".to_string(),
+            context: Some(StatusContext::Cpe(
+                "cpe:/a:redhat:jboss_enterprise_application_platform:7.4:*:el9:*".to_string()
+            )),
+        }]
+    );
+
+    // done
+
+    Ok(())
+}
+
+/// prepare a state with an updated advisory, making a change in the product state section.
+async fn prepare_ps_state_change(
+    ctx: &TrustifyContext,
+) -> anyhow::Result<(IngestResult, IngestResult)> {
+    const CVE: &str = "CVE-2023-33201";
+    const PRODUCT: &str =
+        "9Base-JBEAP-7.4:eap7-bouncycastle-util-0:1.76.0-4.redhat_00001.1.el9eap.noarch";
+
+    twice(
+        &ctx,
+        |mut csaf| {
+            let vulns = csaf.vulnerabilities.as_mut().unwrap();
+
+            let v = vulns
+                .iter_mut()
+                .find(|v| v.cve.as_deref() == Some(CVE))
+                .unwrap();
+
+            let ps = v.product_status.as_mut().unwrap();
+
+            // remove from fixed to known affected
+
+            ps.fixed.as_mut().unwrap().retain(|ps| ps.0 != PRODUCT);
+            ps.known_affected
+                .as_mut()
+                .unwrap()
+                .push(ProductIdT(PRODUCT.into()));
+
+            csaf
+        },
+        |mut csaf| {
+            uptick_tracking(&mut csaf);
+            csaf.document.tracking.current_release_date += chrono::Duration::days(1);
+
+            let vulns = csaf.vulnerabilities.as_mut().unwrap();
+
+            let v = vulns
+                .iter_mut()
+                .find(|v| v.cve.as_deref() == Some(CVE))
+                .unwrap();
+
+            let ps = v.product_status.as_mut().unwrap();
+
+            // now back to fixed
+
+            ps.known_affected
+                .as_mut()
+                .unwrap()
+                .retain(|ps| ps.0 != PRODUCT);
+            ps.fixed.as_mut().unwrap().push(ProductIdT(PRODUCT.into()));
+
+            csaf
+        },
+    )
+    .await
+}
+
+/// Ingest a document twice, mutating it using the provided closure.
+async fn twice<M1, M2>(
+    ctx: &TrustifyContext,
+    m1: M1,
+    m2: M2,
+) -> anyhow::Result<(IngestResult, IngestResult)>
+where
+    M1: FnOnce(Csaf) -> Csaf,
+    M2: FnOnce(Csaf) -> Csaf,
+{
+    let data = document_bytes("csaf/cve-2023-33201.json").await?;
+    let csaf: Csaf = serde_json::from_slice(&data)?;
+
+    let csaf = m1(csaf);
+
+    let result = ctx
+        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
+        .await?;
+
+    let csaf = m2(csaf);
+
+    let result2 = ctx
+        .ingest_read(serde_json::to_vec(&csaf)?.as_slice())
+        .await?;
+
+    Ok((result, result2))
+}
+
+/// Uptick the tracking information according to the spec, adding a new revision record,
+/// incrementing the main tracking version.
+fn uptick_tracking(csaf: &mut Csaf) {
+    let current = &csaf.document.tracking.version;
+
+    let next = uptick_version(&current).expect("unable to increment version");
+
+    csaf.document.tracking.version = next.clone();
+    csaf.document.tracking.revision_history.push(Revision {
+        date: Default::default(),
+        legacy_version: None,
+        number: next.into(),
+        summary: "Updated for test".to_string(),
+    });
+}
+
+/// Uptick the version by one.
+///
+/// The version can be either a plain number or a semantic version. We increment by one, considering
+/// a major change.
+///
+/// > Whenever the operator needs to do a new matching run on his asset database (matching the products from the CSAF product tree with deployed products) the MAJOR version is incremented.
+fn uptick_version(version: &str) -> anyhow::Result<String> {
+    if version.contains('.') {
+        let mut version = semver::Version::parse(version)?;
+        version.major += 1;
+        Ok(version.to_string())
+    } else {
+        let version = version.parse::<u64>()? + 1;
+        Ok(version.to_string())
+    }
+}

--- a/modules/fundamental/tests/advisory/mod.rs
+++ b/modules/fundamental/tests/advisory/mod.rs
@@ -1,0 +1,1 @@
+mod csaf;

--- a/modules/fundamental/tests/fundamental.rs
+++ b/modules/fundamental/tests/fundamental.rs
@@ -1,1 +1,2 @@
+mod advisory;
 mod sbom;

--- a/modules/graphql/src/advisory.rs
+++ b/modules/graphql/src/advisory.rs
@@ -19,6 +19,8 @@ impl AdvisoryQuery {
             Ok(Some(advisory)) => Ok(Advisory {
                 id: advisory.advisory.id,
                 identifier: advisory.advisory.identifier,
+                deprecated: advisory.advisory.deprecated,
+                version: advisory.advisory.version,
                 issuer_id: advisory.advisory.issuer_id,
                 labels: advisory.advisory.labels,
                 published: advisory.advisory.published,
@@ -35,7 +37,10 @@ impl AdvisoryQuery {
     async fn get_advisories<'a>(&self, ctx: &Context<'a>) -> FieldResult<Vec<Advisory>> {
         let graph = ctx.data::<Arc<Graph>>()?;
 
-        let advisories = match graph.get_advisories(Transactional::None).await {
+        let advisories = match graph
+            .get_advisories(Default::default(), Transactional::None)
+            .await
+        {
             Ok(advisories) => advisories,
             _ => vec![],
         };
@@ -46,6 +51,8 @@ impl AdvisoryQuery {
                 Ok(Advisory {
                     id: advisory.advisory.id,
                     identifier: advisory.advisory.identifier,
+                    deprecated: advisory.advisory.deprecated,
+                    version: advisory.advisory.version,
                     issuer_id: advisory.advisory.issuer_id,
                     labels: advisory.advisory.labels,
                     published: advisory.advisory.published,

--- a/modules/ingestor/Cargo.toml
+++ b/modules/ingestor/Cargo.toml
@@ -32,6 +32,7 @@ roxmltree = { workspace = true }
 sbom-walker = { workspace = true }
 sea-orm = { workspace = true }
 sea-query = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }

--- a/modules/ingestor/src/common.rs
+++ b/modules/ingestor/src/common.rs
@@ -1,0 +1,63 @@
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Related, Select};
+use trustify_entity::advisory;
+use utoipa::ToSchema;
+
+#[derive(
+    Copy, Clone, PartialEq, Eq, Debug, Default, ToSchema, serde::Deserialize, serde::Serialize,
+)]
+pub enum Deprecation {
+    /// Ignore deprecated documents
+    #[default]
+    Ignore,
+    /// Consider deprecated documents
+    Consider,
+}
+
+impl Deprecation {
+    pub fn filter(&self, advisories: Select<advisory::Entity>) -> Select<advisory::Entity> {
+        // rule out deprecated advisories, if requested to
+        match self {
+            Deprecation::Ignore => advisories.filter(advisory::Column::Deprecated.eq(false)),
+            Deprecation::Consider => advisories,
+        }
+    }
+
+    pub fn filter_for<E>(&self, other: Select<E>) -> Select<E>
+    where
+        E: EntityTrait + Related<advisory::Entity>,
+    {
+        match self {
+            Deprecation::Ignore => other
+                .left_join(advisory::Entity)
+                .filter(advisory::Column::Deprecated.eq(false)),
+            Deprecation::Consider => other,
+        }
+    }
+}
+
+/// Extend advisory queries with deprecation.
+pub trait DeprecationExt {
+    /// Apply deprecation filtering to e.g. [`Select`].
+    fn with_deprecation(self, deprecation: Deprecation) -> Self;
+}
+
+impl DeprecationExt for Select<advisory::Entity> {
+    fn with_deprecation(self, deprecation: Deprecation) -> Self {
+        deprecation.filter(self)
+    }
+}
+
+/// Extend queries relating to advisories with deprecation.
+pub trait DeprecationForExt {
+    /// Apply deprecation filtering to e.g. [`Select`] which has a relation to [`advisory::Entity`].
+    fn with_deprecation_related(self, deprecation: Deprecation) -> Self;
+}
+
+impl<E> DeprecationForExt for Select<E>
+where
+    E: EntityTrait + Related<advisory::Entity>,
+{
+    fn with_deprecation_related(self, deprecation: Deprecation) -> Self {
+        deprecation.filter_for(self)
+    }
+}

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -43,6 +43,7 @@ struct UploadParams {
 #[openapi(
     paths(upload),
     components(schemas(
+        crate::common::Deprecation,
         crate::model::IngestResult,
         crate::service::dataset::DatasetIngestResult,
     )),

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -1,5 +1,6 @@
 //! Support for CVEs.
 
+use crate::common::{Deprecation, DeprecationExt};
 use crate::{graph::advisory::AdvisoryContext, graph::error::Error, graph::Graph};
 use sea_orm::{
     ActiveValue::Set, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
@@ -136,9 +137,11 @@ impl VulnerabilityContext {
 
     pub async fn advisories<TX: AsRef<Transactional>>(
         &self,
+        deprecation: Deprecation,
         tx: TX,
     ) -> Result<Vec<AdvisoryContext>, Error> {
         Ok(advisory::Entity::find()
+            .with_deprecation(deprecation)
             .join(
                 JoinType::Join,
                 advisory_vulnerability::Relation::Advisory.def().rev(),
@@ -319,7 +322,9 @@ mod tests {
 
         let cve = cve.unwrap();
 
-        let linked_advisories = cve.advisories(Transactional::None).await?;
+        let linked_advisories = cve
+            .advisories(Default::default(), Transactional::None)
+            .await?;
 
         assert_eq!(2, linked_advisories.len());
 

--- a/modules/ingestor/src/lib.rs
+++ b/modules/ingestor/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod common;
 pub mod db;
 pub mod endpoints;
 pub mod graph;

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -14,6 +14,7 @@ use csaf::{
     Csaf,
 };
 use sbom_walker::report::ReportSink;
+use semver::Version;
 use std::fmt::Debug;
 use std::str::FromStr;
 use time::OffsetDateTime;
@@ -28,6 +29,8 @@ impl<'a> From<Information<'a>> for AdvisoryInformation {
     fn from(value: Information<'a>) -> Self {
         let value = value.0;
         Self {
+            // TODO: consider failing if the version doesn't parse
+            version: parse_csaf_version(value),
             title: Some(value.document.title.clone()),
             issuer: Some(value.document.publisher.name.clone()),
             published: OffsetDateTime::from_unix_timestamp(
@@ -40,6 +43,28 @@ impl<'a> From<Information<'a>> for AdvisoryInformation {
             .ok(),
             withdrawn: None,
         }
+    }
+}
+
+/// Parse a CSAF tracking version.
+///
+/// This can be either a semantic version or a plain number. In case of a plain number, we use
+/// this as a major version.
+fn parse_csaf_version(csaf: &Csaf) -> Option<Version> {
+    // TODO: consider checking individual tracking records too
+    let version = &csaf.document.tracking.version;
+    if version.contains('.') {
+        csaf.document.tracking.version.parse().ok()
+    } else {
+        u64::from_str(version)
+            .map(|major| Version {
+                major,
+                minor: 0,
+                patch: 0,
+                pre: Default::default(),
+                build: Default::default(),
+            })
+            .ok()
     }
 }
 

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -1,3 +1,4 @@
+use crate::service::advisory::csaf::util::gen_identifier;
 use crate::{
     graph::{
         advisory::{
@@ -88,7 +89,7 @@ impl<'g> CsafLoader<'g> {
 
         let tx = self.graph.transaction().await?;
 
-        let advisory_id = csaf.document.tracking.id.clone();
+        let advisory_id = gen_identifier(&csaf);
         let labels = labels.into().add("type", "csaf");
 
         let advisory = self

--- a/modules/ingestor/src/service/advisory/csaf/util.rs
+++ b/modules/ingestor/src/service/advisory/csaf/util.rs
@@ -148,3 +148,23 @@ impl<'a> ResolveProductIdCache<'a> {
         self.product_id_to_relationship.get(product_id).copied()
     }
 }
+
+pub fn gen_identifier(csaf: &Csaf) -> String {
+    // From the spec:
+    // > The combination of `/document/publisher/namespace` and `/document/tracking/id` identifies a CSAF document globally unique.
+
+    let mut file_name = String::with_capacity(csaf.document.tracking.id.len());
+
+    let mut in_sequence = false;
+    for c in csaf.document.tracking.id.chars() {
+        if c.is_ascii_alphanumeric() || c == '+' || c == '-' {
+            file_name.push(c);
+            in_sequence = false;
+        } else if !in_sequence {
+            file_name.push('_');
+            in_sequence = true;
+        }
+    }
+
+    format!("{}#{file_name}", csaf.document.publisher.namespace)
+}

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -134,6 +134,8 @@ impl<'g> CveLoader<'g> {
 
         let information = AdvisoryInformation {
             title: title.clone(),
+            // TODO: check if we have some kind of version information
+            version: None,
             issuer: org_name.cloned(),
             published,
             modified,

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -52,6 +52,8 @@ impl<'g> OsvLoader<'g> {
 
         let information = AdvisoryInformation {
             title: osv.summary.clone(),
+            // TODO: check if we have some kind of version information
+            version: None,
             issuer,
             published: Some(osv.published.into_time()),
             modified: Some(osv.modified.into_time()),

--- a/modules/ingestor/tests/db.rs
+++ b/modules/ingestor/tests/db.rs
@@ -1,0 +1,177 @@
+use hex::ToHex;
+use sea_orm::{ConnectionTrait, EntityTrait, QueryOrder};
+use std::fmt::Display;
+use test_context::test_context;
+use test_log::test;
+use time::{macros::datetime, Duration};
+use trustify_common::hashing::Digests;
+use trustify_entity::{advisory, source_document};
+use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
+use trustify_test_context::TrustifyContext;
+
+#[derive(Debug, PartialEq, Eq)]
+struct Entry {
+    pub identifier: String,
+    pub sha256: String,
+    pub deprecated: bool,
+}
+
+impl Entry {
+    pub fn new(
+        identifier: impl Into<String>,
+        id: impl Display,
+        deprecated: bool,
+    ) -> anyhow::Result<Self> {
+        let identifier = identifier.into();
+        let id = format!("{identifier}/{id}");
+        let digests = Digests::digest(&id);
+
+        Ok(Self {
+            identifier,
+            sha256: digests.sha256.encode_hex(),
+            deprecated,
+        })
+    }
+}
+
+/// Ensure that updating all at once groups by document identifier.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn update_deprecated_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    create_set(ctx).await?;
+    reset_all(ctx).await?;
+
+    // next, run the function to update them all
+
+    ctx.db
+        .execute_unprepared("SELECT update_deprecated_advisory()")
+        .await?;
+
+    // check
+
+    let all = get_all(ctx).await?;
+
+    assert_eq!(
+        all,
+        vec![
+            Entry::new("A", "1", true)?,
+            Entry::new("A", "2", true)?,
+            Entry::new("A", "3", true)?,
+            Entry::new("A", "4", false)?,
+            Entry::new("B", "1", true)?,
+            Entry::new("B", "2", true)?,
+            Entry::new("B", "3", true)?,
+            Entry::new("B", "4", false)?,
+            Entry::new("C", "1", true)?,
+            Entry::new("C", "2", true)?,
+            Entry::new("C", "3", true)?,
+            Entry::new("C", "4", false)?,
+            Entry::new("D", "1", true)?,
+            Entry::new("D", "2", true)?,
+            Entry::new("D", "3", true)?,
+            Entry::new("D", "4", false)?,
+        ]
+    );
+
+    // done
+
+    Ok(())
+}
+
+/// Ensure that updating only one, actually does update only one, grouped by identifier.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn update_deprecated_one(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    create_set(ctx).await?;
+    reset_all(ctx).await?;
+
+    // next, run the function to update only one
+
+    ctx.db
+        .execute_unprepared("SELECT update_deprecated_advisory('B')")
+        .await?;
+
+    let all = get_all(ctx).await?;
+
+    assert_eq!(
+        all,
+        vec![
+            Entry::new("A", "1", false)?,
+            Entry::new("A", "2", false)?,
+            Entry::new("A", "3", false)?,
+            Entry::new("A", "4", false)?,
+            Entry::new("B", "1", true)?,
+            Entry::new("B", "2", true)?,
+            Entry::new("B", "3", true)?,
+            Entry::new("B", "4", false)?,
+            Entry::new("C", "1", false)?,
+            Entry::new("C", "2", false)?,
+            Entry::new("C", "3", false)?,
+            Entry::new("C", "4", false)?,
+            Entry::new("D", "1", false)?,
+            Entry::new("D", "2", false)?,
+            Entry::new("D", "3", false)?,
+            Entry::new("D", "4", false)?,
+        ]
+    );
+
+    // done
+
+    Ok(())
+}
+
+async fn create_set(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    let graph = &ctx.graph;
+
+    let published = datetime!(2024-01-01 00:00 UTC);
+
+    for d in ["A", "B", "C", "D"] {
+        for i in [1, 2, 3, 4] {
+            let id = format!("{d}/{i}");
+            let digests = Digests::digest(&id);
+            let modified = published + Duration::days(i as i64);
+
+            let info = AdvisoryInformation {
+                title: None,
+                issuer: None,
+                published: Some(published),
+                modified: Some(modified),
+                withdrawn: None,
+                version: None,
+            };
+            graph.ingest_advisory(d, (), &digests, info, ()).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn reset_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    // now mark them all as non-deprecated
+
+    ctx.db
+        .execute_unprepared("UPDATE advisory SET deprecated = false")
+        .await?;
+
+    Ok(())
+}
+
+async fn get_all(ctx: &TrustifyContext) -> anyhow::Result<Vec<Entry>> {
+    let all = advisory::Entity::find()
+        .find_also_related(source_document::Entity)
+        .order_by_asc(advisory::Column::Identifier)
+        .order_by_asc(advisory::Column::Modified)
+        .all(&ctx.db)
+        .await?;
+
+    Ok(all
+        .into_iter()
+        .filter_map(|(adv, doc)| {
+            Some(Entry {
+                identifier: adv.identifier,
+                sha256: doc?.sha256,
+                deprecated: adv.deprecated,
+            })
+        })
+        .collect::<Vec<_>>())
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,6 +64,14 @@ paths:
           type: integer
           format: int64
           minimum: 0
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
       responses:
         '200':
           description: Matching vulnerabilities
@@ -1246,6 +1254,14 @@ paths:
       summary: Retrieve details of a fully-qualified pURL
       operationId: getPurl
       parameters:
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
       - name: key
         in: path
         description: opaque identifier for a fully-qualified PURL, or URL-encoded pURL itself
@@ -2258,6 +2274,11 @@ components:
           type: string
         sbom_id:
           type: string
+    Deprecation:
+      type: string
+      enum:
+      - Ignore
+      - Consider
     Id:
       type: string
       description: A hash/digest prefixed with its type.


### PR DESCRIPTION
That PR is more of a discussion than a PR (as of now).

The goal was to find out, how the system behaves when updating a CSAF advisory. It looks like any change creates a new advisory. Despite the combination of namespace and ID being unique.

This means, that changing an affected product to fixed, will leave two advisories. One saying the product is affected, one saying the product is not affected. Both have the same "ID", but also ignore the namespace.

I think this is something we need to discuss. As right now, it's seems a bit weird.

The new tests are either failing, or passing (incorrectly), but there are some TODOs, explaining the expectations.

## ToDo

* [x] Update when deleting an advisory
* [x] Add test for deleting an advisory

Closes  #856 