### PR TITLE
[DRAFT] - ci: integrate with global ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.trustify/

--- a/.github/workflows/ci-global.yaml
+++ b/.github/workflows/ci-global.yaml
@@ -1,0 +1,40 @@
+name: CI (global trustify CI)
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_call:
+
+concurrency:
+  group: ci-global-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-upload-for-global-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: save trustd image
+        run: |
+          docker build . -t ghcr.io/trustification/trustd:pr-test -f Dockerfile
+          docker save -o /tmp/trustd.tar ghcr.io/trustification/trustd:pr-test
+
+      - name: Upload trustd image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: trustd
+          path: /tmp/trustd.tar
+          retention-days: 1
+
+  run-global-ci:
+    needs: build-and-upload-for-global-ci
+    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
+    with:
+      artifact: trustd
+      server_image: ghcr.io/trustification/trustd:pr-test
+      run_api_tests: true
+      run_ui_tests: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+######################################################################
+# UI
+######################################################################
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS ui-source
+ARG ui_branch="main"
+ARG ui_commit
+
+USER root
+RUN dnf install git -y
+
+RUN git clone https://github.com/trustification/trustify-ui.git --branch ${ui_branch} /trustify-ui/
+RUN cd /trustify-ui/ && if [ -n "${ui_commit}" ]; then git checkout -b commit-branch ${ui_commit}; fi
+RUN chown -R 1001 /trustify-ui/
+
+USER 1001
+RUN npm install -g npm@9
+RUN cd /trustify-ui/ && npm clean-install --ignore-scripts && npm run build && npm run dist
+
+######################################################################
+# Prepare server
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi:latest AS server-source
+COPY . /trustify/
+RUN sed -i 's/trustify-ui = { git = "https:\/\/github.com\/trustification\/trustify-ui.git", tag = "static-main" }/trustify-ui = { path = "..\/trustify-ui\/crate" }/g' /trustify/Cargo.toml
+
+######################################################################
+# Build server
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi:latest AS server-builder
+
+# Dependencies
+RUN dnf install -y openssl-devel gcc
+
+RUN mkdir /stage/ && \
+    dnf install --installroot /stage/ --setop install_weak_deps=false --nodocs -y zlib openssl && \
+    dnf clean all --installroot /stage/
+
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=${PATH}:/root/.cargo/bin
+RUN rustup target add $(uname -m)-unknown-linux-gnu
+
+# Build source code
+COPY --from=ui-source /trustify-ui/ /code/trustify-ui/
+COPY --from=server-source /trustify/ /code/trustify/
+RUN cd /code/trustify/ && \
+    cargo build --no-default-features --release --target=$(uname -m)-unknown-linux-gnu && \
+    find /code/trustify/target/ -name "trustd" -exec cp -av {} /stage/usr/local/bin \;
+
+######################################################################
+# Builder runner
+######################################################################
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest AS server-runner
+COPY --from=server-builder /stage/ .
+ENTRYPOINT ["/usr/local/bin/trustd"]


### PR DESCRIPTION
@jcrossley3 @helio-frota this PR is just to show how to integrate this repo with the global tests https://github.com/trustification/trustify-ui-tests and https://github.com/trustification/trustify-api-tests

For each PR the tests will be executed.

This is a draft as you guys should find the appropriate way of creating the container images. I like to do it with Dockerfiles but it might not be what you guys prefer so I'll leave that to you.

The only purpose of this PR is to showcase how to make this repo run tests globally. Although as of today the  repositories https://github.com/trustification/trustify-ui-tests and https://github.com/trustification/trustify-api-tests
 do not have significant tests written there yet, but once I get into the UI work I should personally pay more attention to create UI e2e tests and enrich the https://github.com/trustification/trustify-ui-tests  repo.

> I have no idea how conflux works, neither what is the objective being pursued but I hope this helps somehow.