### PR TITLE
Wip: show weird compile error:

### DIFF
--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -115,7 +115,7 @@ impl Database {
     pub fn connection<'db, TX: AsRef<Transactional>>(
         &'db self,
         tx: &'db TX,
-    ) -> ConnectionOrTransaction {
+    ) -> ConnectionOrTransaction<'db> {
         match tx.as_ref() {
             Transactional::None => ConnectionOrTransaction::Connection(&self.db),
             Transactional::Some(tx) => ConnectionOrTransaction::Transaction(tx),

--- a/modules/fundamental/src/ai/service/tools.rs
+++ b/modules/fundamental/src/ai/service/tools.rs
@@ -127,8 +127,9 @@ impl Tool for CVEInfo {
     }
 
     async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
-        let service = &self.0;
+        let service = self.0.clone();
 
+        _ = service.fetch_vulnerability("test", ()).await;
         let query = Query {
             q: input
                 .as_str()

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -463,8 +463,9 @@ impl VulnerabilitySbomStatus {
     async fn from_models<'i, I>(
         sbom_purl_status: I,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Vec<Self>, Error> where
-        I: Iterator<Item=&'i SbomStatusCatcher> + Clone
+    ) -> Result<Vec<Self>, Error>
+    where
+        I: Iterator<Item = &'i SbomStatusCatcher> + Clone,
     {
         let mut sboms = HashMap::new();
 

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -460,10 +460,12 @@ pub struct VulnerabilitySbomStatus {
 }
 
 impl VulnerabilitySbomStatus {
-    async fn from_models<'i, I: IntoIterator<Item = &'i SbomStatusCatcher> + Clone>(
+    async fn from_models<'i, I>(
         sbom_purl_status: I,
         tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Vec<Self>, Error> {
+    ) -> Result<Vec<Self>, Error> where
+        I: Iterator<Item=&'i SbomStatusCatcher> + Clone
+    {
         let mut sboms = HashMap::new();
 
         for status in sbom_purl_status.clone() {

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -17,6 +17,7 @@ use trustify_common::{
 use trustify_entity::cvss3::Severity;
 use trustify_entity::{cvss3, vulnerability};
 
+#[derive(Clone)]
 pub struct VulnerabilityService {
     db: Database,
 }


### PR DESCRIPTION
```
error: implementation of `FnOnce` is not general enough
   --> modules/fundamental/src/ai/service/tools.rs:129:73
    |
129 |       async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
    |  _________________________________________________________________________^
130 | |         let service = self.0.clone();
131 | |
132 | |         _ = service.fetch_vulnerability("test", ()).await;
...   |
159 | |         Ok(result)
160 | |     }
    | |_____^ implementation of `FnOnce` is not general enough
    |
    = note: closure with signature `for<'a> fn(&'a &SbomStatusCatcher) -> bool` must implement `FnOnce<(&&SbomStatusCatcher,)>`
    = note: ...but it actually implements `FnOnce<(&&SbomStatusCatcher,)>`
```