### PR TITLE
fix: avoid workflow failures in forks

### DIFF
--- a/.github/workflows/container-latest.yaml
+++ b/.github/workflows/container-latest.yaml
@@ -11,11 +11,13 @@ concurrency: container-latest
 
 jobs:
   build:
+    if: ${{ github.repository == 'trustification/trustify' }}
     uses: ./.github/workflows/build-binary.yaml
     with:
       version: latest
 
   publish:
+    if: ${{ github.repository == 'trustification/trustify' }}
     needs: [ build ]
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/rita-pr-merged.yaml
+++ b/.github/workflows/rita-pr-merged.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   notify_channel:
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event.pull_request.merged && secrets.MATRIX_BOT_PASSWORD }}
     steps:
       - name: Send message
         run: |


### PR DESCRIPTION
There are some workflows we want to run in downstream forks, and others we don't.