### PR TITLE
fix: openapi.yaml github action execution

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
       - name: Checkout trustify-ui
         uses: actions/checkout@v4
         with:
@@ -31,7 +30,7 @@ jobs:
           cp ./trustify/openapi.yaml ./trustify-ui/client/openapi/trustd.yaml
           
           cd ./trustify-ui
-          npm install 
+          npm ci --ignore-scripts 
           npm run generate
           git diff
 


### PR DESCRIPTION
The last execution of the openapi gh action failed due to recent changes. This PR should fix it. Here is this PR running in my local fork to prove it won't fail if this PR is merged https://github.com/carlosthe19916/trustify/actions/runs/11131756934/job/30934066364

Also taking the chance to replace `npm install` by `npm ci` to guarantee the package.lock will be respected 