### PR TITLE
Query params should be url-encoded

### DIFF
--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -93,6 +93,7 @@ pub trait Filtering<T: EntityTrait> {
 impl<T: EntityTrait> Filtering<T> for Select<T> {
     fn filtering_with<C: IntoColumns>(self, search: Query, context: C) -> Result<Self, Error> {
         let Query { q, sort, .. } = &search;
+        log::debug!("filtering with: q='{q}' sort='{sort}'");
         let columns = context.columns();
 
         let mut result = if q.is_empty() {

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -293,7 +293,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
     setup(&ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl?q=type=maven";
+    let uri = "/api/v1/purl?q=type%3Dmaven";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedPurlSummary = app.call_and_read_body_json(request).await;
 


### PR DESCRIPTION
I'm not sure how this worked, frankly. Maybe actix request handlers somehow do The Right Thing with unbalanced '=' operators?