### PR TITLE
feat: CI pipeline to build, package, test, and deploy each merged PR

### DIFF
--- a/.github/workflows/container-latest.yaml
+++ b/.github/workflows/container-latest.yaml
@@ -1,35 +1,41 @@
 name: container-latest
 
-# Build a "latest" container for every commit
+# Build "latest" container, run e2e tests against it, and deploy it to
+# https://trustify-latest-staging.apps.cluster.trustification.rocks/
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency: container-latest
 
+env:
+  IMAGE_NAME: trustd
+  IMAGE_TAG: latest
+  OPENSHIFT_NAMESPACE: trustify-latest
+  OPENSHIFT_SERVER: https://api.cluster.trustification.rocks:6443
+  APP_NAME: staging
+
 jobs:
   build:
-    if: ${{ github.repository == 'trustification/trustify' }}
     uses: ./.github/workflows/build-binary.yaml
     with:
       version: latest
 
   publish:
-    if: ${{ github.repository == 'trustification/trustify' }}
     needs: [ build ]
     runs-on: ubuntu-22.04
+
+    outputs:
+      image: ${{ steps.push.outputs.registry-path }}
 
     permissions:
       contents: write
       packages: write
       id-token: write
       attestations: write
-
-    env:
-      IMAGE_NAME: trustd
-      IMAGE_TAG: latest
 
     steps:
 
@@ -53,6 +59,7 @@ jobs:
       # Push to ghcr.io
 
       - name: Push to ghcr.io
+        id: push
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMAGE_NAME }}
@@ -60,3 +67,35 @@ jobs:
           registry: ghcr.io/${{ github.repository_owner }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  e2e-test:
+    needs: publish
+    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
+    with:
+      server_image: ${{ needs.publish.outputs.image }}
+      run_api_tests: true
+      run_ui_tests: true
+
+  deploy:
+    runs-on: ubuntu-22.04
+    needs:
+      - publish
+      - e2e-test
+
+    steps:
+
+      - name: Log in and set context
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ env.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+
+      - name: Install trustify
+        uses: trustification/trustify-operator/.github/actions/install-trustify@main
+        env:
+          SERVER_IMAGE: ${{ needs.publish.outputs.image }}
+        with:
+          operator-bundle-image: ghcr.io/trustification/trustify-operator-bundle:latest
+          trustify-cr: '{"kind":"Trustify","apiVersion":"org.trustify/v1alpha1","metadata":{"name":"${{ env.APP_NAME }}"},"spec":{"serverImage":"${{ env.SERVER_IMAGE }}"}}'
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          app-name: ${{ env.APP_NAME }}

--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -1,4 +1,4 @@
-name: container-latest
+name: latest-release
 
 # Build "latest" container, run e2e tests against it, and deploy it to
 # https://trustify-latest-staging.apps.cluster.trustification.rocks/
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
 
-concurrency: container-latest
+concurrency: latest-release
 
 env:
   IMAGE_NAME: trustd

--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -77,6 +77,7 @@ jobs:
       run_ui_tests: true
 
   deploy:
+    if: ${{ github.repository == 'trustification/trustify' }}
     runs-on: ubuntu-22.04
     needs:
       - publish


### PR DESCRIPTION
Fixes: #804

Requires an `OPENSHIFT_TOKEN` secret that enables privileged access to an OCP instance, e.g. https://api.cluster.trustification.rocks:6443

The following commands were used to generate the token on the OCP host:

```
oc create serviceaccount ${ACCT_NAME}
oc create clusterrolebinding ${ACCT_NAME} --clusterrole=cluster-admin --serviceaccount=default:${ACCT_NAME}
oc create token ${ACCT_NAME} --duration=$((365*24))h
```
Upon successful completion of the `latest-release` workflow, the app will be available here:
https://trustify-latest-staging.apps.cluster.trustification.rocks/