### PR TITLE
ci: update deprecated github runner

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -48,7 +48,7 @@ jobs:
             args: --features vendored
 
           - target: x86_64-apple-darwin
-            os: macos-12
+            os: macos-13
           - target: aarch64-apple-darwin
             os: macos-14
 


### PR DESCRIPTION
As warned by GitHub:

>  A brownout will take place on November 4, 14:00 UTC - November 5, 00:00 UTC to raise awareness of the upcoming macOS-12 environment removal. For more details, see https://github.com/actions/runner-images/issues/10721
