### PR TITLE
ci: ds3 ingestion benchmark

### DIFF
--- a/.github/scripts/benchmark.sh
+++ b/.github/scripts/benchmark.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Create the dataset
+
+pushd etc/datasets
+make ds3.zip
+popd
+
+# Show httpie version
+
+http --version
+
+# Send
+
+start_time=$(date +%s)
+http --ignore-stdin POST localhost:8080/api/v1/dataset "Authorization:$(oidc token trustify -bf)" @etc/datasets/ds3.zip
+end_time=$(date +%s)
+
+runtime=$((end_time - start_time))
+
+echo "Runtime: $runtime s"
+
+jq -n --arg i "$runtime" '
+[
+  {
+    "name": "Ingest DS3",
+    "unit": "s",
+    "value": ($i | tonumber ),
+  }
+]
+' > benchmark.json

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,131 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+concurrency: benchmark
+
+jobs:
+
+  bench:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      # deployments permission to deploy GitHub pages website
+      deployments: write
+      # contents permission to update benchmark contents in gh-pages branch
+      contents: write
+
+    steps:
+
+      - name: Maximize build space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo rm -Rf ${JAVA_HOME_8_X64}
+          sudo rm -Rf ${JAVA_HOME_11_X64}
+          sudo rm -Rf ${JAVA_HOME_17_X64}
+          sudo rm -Rf ${RUBY_PATH}
+          df -h
+
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Setup cargo-binstall
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install oidc CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo binstall -y --force oidc-cli
+
+      - name: Install HTTPie
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install httpie
+
+      - name: Build
+        run: |
+          cargo build --bin trustd --release
+
+      - name: Run
+        env:
+          NO_COLOR: "true"
+        run:
+          nohup cargo run --bin trustd --release &> trustd.log &
+
+      - name: Wait for the backend to be up
+        run: |
+          URL="http://localhost:8080/.well-known/trustify"
+          TIMEOUT=300  # 5 minutes
+          INTERVAL=5   # Interval between retries in seconds
+          START_TIME=$(date +%s)
+          
+          while true; do
+            # Check if the endpoint is up
+            if curl -s --fail "$URL"; then
+              echo
+              echo "Endpoint is up!"
+              exit 0
+            fi
+            
+            # Check if timeout has passed
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+            
+            if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
+              echo "Timeout reached. Endpoint is still down."
+              exit 1
+            fi
+            
+            echo "Endpoint is down. Retrying in $INTERVAL seconds..."
+            sleep "$INTERVAL"
+          done
+
+      - name: Setup OIDC
+        run: |
+          oidc create confidential trustify --issuer http://localhost:8090/realms/trustify --client-id walker --client-secret R8A6KFeyxJsMDBhjfHbpZTIF0GWt43HP --force # no-secret
+
+      - name: Run DS3 ingestion
+        run: |
+          .github/scripts/benchmark.sh
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+
+        with:
+          tool: 'customSmallerIsBetter'
+          output-file-path: benchmark.json
+          fail-on-alert: true
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable Job Summary for PRs
+          summary-always: true
+          # Push and deploy GitHub pages branch automatically
+          auto-push: ${{ github.event_name != 'pull_request' }}
+          # Enable alert commit comment
+          comment-on-alert: true
+          # Mention @rhysd in the commit comment
+          # alert-comment-cc-users: '@rhysd'
+
+      - name: Upload container logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs
+          path: |
+            trustd.log
+          if-no-files-found: error

--- a/etc/datasets/Makefile
+++ b/etc/datasets/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all: ds1.zip ds3.zip
+
+.PHONY: ds1.zip
+ds1.zip:
+	-rm ds1.zip
+	cd ds1 && zip -r ../ds1.zip .
+
+.PHONY: ds3.zip
+ds3.zip:
+	-rm ds3.zip
+	cd ds3 && zip -r ../ds3.zip .


### PR DESCRIPTION
This adds an benchmark test for ingesting dataset 3: https://github.com/trustification/trustify/tree/main/etc/datasets/ds3

It will measure, record, and compare performance over time on the main branch, and alert on PRs. There's a also a published version of the data, which can be previewed on my personal fork: https://ctron.github.io/trustify/dev/bench/

Right now, there is only a single test. Which doesn't use any specific benchmark tool. However, we can extend this, using `cargo bench` or `criterion-rs` in the future.