### PR TITLE
Enable sea_orm's debug logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ rstest = "0.22"
 rust-s3 = "0.35"
 sbom-walker = { version = "0.9.0", default-features = false, features = ["crypto-openssl", "cyclonedx-bom", "spdx-rs"] }
 schemars = "0.8"
-sea-orm = "~1.0" # See https://www.sea-ql.org/blog/2024-08-04-sea-orm-1.0/#release-planning
+sea-orm = { version = "~1.0", features = ["debug-print"] } # See https://www.sea-ql.org/blog/2024-08-04-sea-orm-1.0/#release-planning
 sea-orm-migration = "~1.0"
 sea-query = "0.31.0"
 semver = "1"


### PR DESCRIPTION
Fixes #894

Took me too long to figure out that we need to [enable a sea_orm feature](https://www.sea-ql.org/SeaORM/docs/install-and-config/debug-log/). Once done, you can see sea_orm statements in tests after setting the `RUST_LOG` env var:

`RUST_LOG=sea_orm=debug`

Or more specifically,

`RUST_LOG=none,sea_orm::driver::sqlx_postgres=debug`