### PR TITLE
feat: csaf correlation - correlate vulnerability to purls and sboms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8521,6 +8521,7 @@ dependencies = [
  "itertools 0.13.0",
  "jsonpath-rust",
  "langchain-rust",
+ "lenient_semver",
  "log",
  "osv",
  "packageurl",

--- a/entity/src/cpe.rs
+++ b/entity/src/cpe.rs
@@ -28,11 +28,35 @@ pub enum Relation {
         to = "super::sbom_package_cpe_ref::Column::CpeId"
     )]
     SbomPackage,
+    #[sea_orm(
+        belongs_to = "super::product::Entity",
+        from = "Column::Product",
+        to = "super::product::Column::CpeKey"
+    )]
+    Product,
+    #[sea_orm(
+        belongs_to = "super::product_status::Entity",
+        from = "Column::Id",
+        to = "super::product_status::Column::ContextCpeId"
+    )]
+    ProductStatus,
 }
 
 impl Related<super::sbom_package_cpe_ref::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::SbomPackage.def()
+    }
+}
+
+impl Related<super::product::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Product.def()
+    }
+}
+
+impl Related<super::product_status::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ProductStatus.def()
     }
 }
 

--- a/entity/src/product.rs
+++ b/entity/src/product.rs
@@ -21,6 +21,11 @@ pub enum Relation {
     Vendor,
     #[sea_orm(has_many = "super::product_version::Entity")]
     ProductVersion,
+    #[sea_orm(
+        has_many = "super::cpe::Entity"
+        from = "Column::CpeKey"
+        to = "super::cpe::Column::Product")]
+    Cpe,
 }
 
 impl Related<organization::Entity> for Entity {
@@ -32,6 +37,12 @@ impl Related<organization::Entity> for Entity {
 impl Related<super::product_version::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::ProductVersion.def()
+    }
+}
+
+impl Related<super::cpe::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cpe.def()
     }
 }
 

--- a/entity/src/product_status.rs
+++ b/entity/src/product_status.rs
@@ -8,7 +8,7 @@ pub struct Model {
     pub advisory_id: Uuid,
     pub vulnerability_id: String,
     pub status_id: Uuid,
-    pub component: Option<String>,
+    pub package: Option<String>,
     pub product_version_range_id: Uuid,
     pub context_cpe_id: Option<Uuid>,
 }

--- a/entity/src/product_status.rs
+++ b/entity/src/product_status.rs
@@ -8,7 +8,7 @@ pub struct Model {
     pub advisory_id: Uuid,
     pub vulnerability_id: String,
     pub status_id: Uuid,
-    pub base_purl_id: Option<Uuid>,
+    pub component: Option<String>,
     pub product_version_range_id: Uuid,
     pub context_cpe_id: Option<Uuid>,
 }
@@ -20,12 +20,6 @@ pub enum Relation {
         to = "super::product_version_range::Column::Id"
     )]
     ProductVersionRange,
-
-    #[sea_orm(belongs_to = "super::base_purl::Entity",
-        from = "Column::BasePurlId"
-        to = "super::base_purl::Column::Id"
-    )]
-    BasePurl,
 
     #[sea_orm(belongs_to = "super::vulnerability::Entity",
         from = "Column::VulnerabilityId"
@@ -61,12 +55,6 @@ pub enum Relation {
 impl Related<super::product_version_range::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::ProductVersionRange.def()
-    }
-}
-
-impl Related<super::base_purl::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::BasePurl.def()
     }
 }
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -81,6 +81,7 @@ mod m0000625_alter_qualified_purl_purl_column;
 mod m0000630_create_product_version_range;
 mod m0000631_alter_product_cpe_key;
 mod m0000640_create_product_status;
+mod m0000641_update_product_status;
 mod m0000650_alter_advisory_tracking;
 mod m0000660_purl_id_indexes;
 mod m0000670_version_cmp;
@@ -178,6 +179,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000630_create_product_version_range::Migration),
             Box::new(m0000631_alter_product_cpe_key::Migration),
             Box::new(m0000640_create_product_status::Migration),
+            Box::new(m0000641_update_product_status::Migration),
             Box::new(m0000650_alter_advisory_tracking::Migration),
             Box::new(m0000660_purl_id_indexes::Migration),
             Box::new(m0000670_version_cmp::Migration),

--- a/migration/src/m0000641_update_product_status.rs
+++ b/migration/src/m0000641_update_product_status.rs
@@ -1,0 +1,72 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductStatus::Table)
+                    .drop_column(ProductStatus::BasePurlId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductStatus::Table)
+                    .add_column(ColumnDef::new(ProductStatus::Component).string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductStatus::Table)
+                    .drop_column(ProductStatus::Component)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductStatus::Table)
+                    .add_column(ColumnDef::new(ProductStatus::BasePurlId).uuid())
+                    .add_foreign_key(
+                        TableForeignKey::new()
+                            .from_tbl(ProductStatus::Table)
+                            .from_col(ProductStatus::BasePurlId)
+                            .to_tbl(BasePurl::Table)
+                            .to_col(BasePurl::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum ProductStatus {
+    Table,
+    BasePurlId,
+    Component,
+}
+
+#[derive(DeriveIden)]
+enum BasePurl {
+    Table,
+    Id,
+}

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -22,6 +22,7 @@ base64 = { workspace = true }
 cpe = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
+lenient_semver = { workspace = true }
 langchain-rust = { workspace = true }
 log = { workspace = true }
 sea-orm = { workspace = true }

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -93,7 +93,7 @@ impl SbomDetails {
             .distinct_on([
                 (product_status::Entity, product_status::Column::ContextCpeId),
                 (product_status::Entity, product_status::Column::StatusId),
-                (product_status::Entity, product_status::Column::Component),
+                (product_status::Entity, product_status::Column::Package),
                 (
                     product_status::Entity,
                     product_status::Column::VulnerabilityId,
@@ -101,7 +101,7 @@ impl SbomDetails {
             ])
             .order_by_asc(product_status::Column::ContextCpeId)
             .order_by_asc(product_status::Column::StatusId)
-            .order_by_asc(product_status::Column::Component)
+            .order_by_asc(product_status::Column::Package)
             .order_by_asc(product_status::Column::VulnerabilityId);
 
         let product_advisory_statuses = product_advisory_info
@@ -247,9 +247,9 @@ impl SbomAdvisory {
             let advisory_cpe: Option<OwnedUri> = (&product.cpe).try_into().ok();
 
             let mut packages = vec![];
-            if let Some(component) = &product.product_status.component {
+            if let Some(package) = &product.product_status.package {
                 let package = SbomPackage {
-                    name: component.to_string(),
+                    name: package.to_string(),
                     ..Default::default()
                 };
                 packages.push(package);
@@ -261,7 +261,7 @@ impl SbomAdvisory {
                 context: advisory_cpe
                     .as_ref()
                     .map(|e| StatusContext::Cpe(e.to_string())),
-                packages, // TODO find packages based on component
+                packages, // TODO find purls based on package names
             };
 
             match advisories.entry(product.advisory.id) {

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -98,7 +98,7 @@ impl SbomSummary {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject, Default)]
 #[graphql(concrete(name = "SbomPackage", params()))]
 pub struct SbomPackage {
     pub id: String,

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -473,15 +473,15 @@ impl VulnerabilityAdvisoryStatus {
         }
 
         for product in products {
-            if let Some(component) = &product.product_status.component {
+            if let Some(package) = &product.product_status.package {
                 let status_entry = statuses
                     .entry(product.status.slug.clone())
                     .or_insert(vec![]);
                 // TODO: If we have an SBOM in the result, we should try to locate the real purl
-                // in that SBOM by the component name
-                let purl = generic_purl(component);
+                // in that SBOM by the package name
+                let purl = generic_purl(package);
                 // This is creating a fake Purl that does not exists in the database
-                // Maybe we should model this differently, e.g. introduce component instead of purl
+                // Maybe we should model this differently, e.g. introduce package instead of purl
                 // in case there's no SBOM ot purl can't be found
                 let base_purl = BasePurlHead {
                     uuid: Default::default(),

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -4,12 +4,13 @@ use crate::{
     sbom::model::SbomHead,
     Error,
 };
+use ::cpe::cpe::Cpe;
 use ::cpe::uri::OwnedUri;
 use sea_orm::{
     ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoIdentity, LoaderTrait, ModelTrait,
-    PaginatorTrait, QueryFilter, QueryResult, QuerySelect, RelationTrait, Select,
+    PaginatorTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, RelationTrait, Select,
 };
-use sea_query::{Asterisk, Expr, Func, IntoCondition, JoinType, SimpleExpr};
+use sea_query::{Asterisk, Expr, Func, IntoCondition, JoinType, NullOrdering, SimpleExpr};
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use trustify_common::{
@@ -22,6 +23,7 @@ use trustify_common::{
     purl::Purl,
 };
 use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
+use trustify_entity::{self as entity};
 use trustify_entity::{
     advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization, purl_status,
     qualified_purl, sbom, sbom_node, sbom_package, sbom_package_cpe_ref, sbom_package_purl_ref,
@@ -206,6 +208,62 @@ impl VulnerabilityAdvisorySummary {
             .group_by(sbom_package::Column::NodeId)
             .group_by(cpe::Column::Id);
 
+        let product_status_query = entity::product_status::Entity::find()
+            .join(
+                JoinType::Join,
+                entity::product_status::Relation::ContextCpe.def(),
+            )
+            .join(
+                JoinType::Join,
+                entity::product_status::Relation::Status.def(),
+            )
+            .join(
+                JoinType::Join,
+                entity::product_status::Relation::ProductVersionRange.def(),
+            )
+            .join(
+                JoinType::Join,
+                entity::product_version_range::Relation::VersionRange.def(),
+            )
+            .join(JoinType::Join, entity::cpe::Relation::Product.def())
+            .join(
+                JoinType::Join,
+                entity::product::Relation::ProductVersion.def(),
+            )
+            .join(
+                JoinType::LeftJoin,
+                entity::product_version::Relation::Sbom.def(),
+            )
+            //.join(JoinType::LeftJoin, entity::sbom::Relation::Node.def())
+            // TODO: The join below significantly speeds things up over the simple one above
+            // Needs more investigation
+            .join(
+                JoinType::LeftJoin,
+                entity::sbom::Relation::Node
+                    .def()
+                    .on_condition(|left, right| {
+                        Expr::col((right, entity::sbom_node::Column::NodeId))
+                            .eq(Expr::col((left, entity::sbom::Column::NodeId)))
+                            .into_condition()
+                    }),
+            )
+            .filter(entity::product_status::Column::VulnerabilityId.eq(&vulnerability.id))
+            .filter(SimpleExpr::FunctionCall(
+                Func::cust(VersionMatches)
+                    .arg(Expr::col((
+                        entity::product_version::Entity,
+                        entity::product_version::Column::Version,
+                    )))
+                    .arg(Expr::col((entity::version_range::Entity, Asterisk))),
+            ))
+            .distinct_on([(entity::cpe::Entity, entity::cpe::Column::Id)])
+            .order_by_desc(entity::cpe::Column::Id)
+            .order_by_with_nulls(
+                entity::product_version::Column::SbomId,
+                sea_orm::Order::Desc,
+                NullOrdering::Last,
+            );
+
         let vuln_purl_statuses = purl_status_query
             .try_into_multi_model::<PurlStatusCatcher>()?
             .all(tx)
@@ -213,6 +271,11 @@ impl VulnerabilityAdvisorySummary {
 
         let vuln_sbom_statuses = sbom_status_query
             .try_into_multi_model::<SbomStatusCatcher>()?
+            .all(tx)
+            .await?;
+
+        let vuln_product_statuses = product_status_query
+            .try_into_multi_model::<ProductStatusCatcher>()?
             .all(tx)
             .await?;
 
@@ -246,8 +309,18 @@ impl VulnerabilityAdvisorySummary {
                 )
                 .await?,
                 cvss3_scores,
-                purls: VulnerabilityAdvisoryStatus::from_models(purl_statuses, tx).await?,
-                sboms: VulnerabilitySbomStatus::from_models(sbom_statuses, tx).await?,
+                purls: VulnerabilityAdvisoryStatus::from_models(
+                    purl_statuses,
+                    vuln_product_statuses.iter(),
+                    tx,
+                )
+                .await?,
+                sboms: VulnerabilitySbomStatus::from_models(
+                    sbom_statuses,
+                    vuln_product_statuses.iter(),
+                    tx,
+                )
+                .await?,
                 number_of_vulnerabilities,
             });
         }
@@ -370,13 +443,19 @@ pub struct VulnerabilityAdvisoryStatus {
 }
 
 impl VulnerabilityAdvisoryStatus {
-    async fn from_models<'i, I: Iterator<Item = &'i PurlStatusCatcher>>(
-        models: I,
+    async fn from_models<
+        'i,
+        'j,
+        I: Iterator<Item = &'i PurlStatusCatcher>,
+        J: Iterator<Item = &'j ProductStatusCatcher>,
+    >(
+        purls: I,
+        products: J,
         _tx: &ConnectionOrTransaction<'_>,
     ) -> Result<HashMap<String, Vec<Self>>, Error> {
         let mut statuses = HashMap::new();
 
-        for each in models {
+        for each in purls {
             let context = each.cpe.as_ref().and_then(|cpe| {
                 let cpe: Result<OwnedUri, _> = cpe.try_into();
                 cpe.ok().map(|cpe| StatusContext::Cpe(cpe.to_string()))
@@ -393,7 +472,53 @@ impl VulnerabilityAdvisoryStatus {
             });
         }
 
+        for product in products {
+            if let Some(component) = &product.product_status.component {
+                let status_entry = statuses
+                    .entry(product.status.slug.clone())
+                    .or_insert(vec![]);
+                // TODO: If we have an SBOM in the result, we should try to locate the real purl
+                // in that SBOM by the component name
+                let purl = generic_purl(component);
+                // This is creating a fake Purl that does not exists in the database
+                // Maybe we should model this differently, e.g. introduce component instead of purl
+                // in case there's no SBOM ot purl can't be found
+                let base_purl = BasePurlHead {
+                    uuid: Default::default(),
+                    purl,
+                };
+                let context = StatusContext::Cpe(product.cpe.to_string());
+                status_entry.push(VulnerabilityAdvisoryStatus {
+                    base_purl,
+                    version: "*".to_string(),
+                    context: Some(context),
+                });
+            }
+        }
+
         Ok(statuses)
+    }
+}
+
+/// Parse purl from generic identifiers
+fn generic_purl(name: &str) -> Purl {
+    // try to extract at least name and optionally namespace
+    // usually separate by /
+    // e.g. io.quarkus/quarkus-vertx-http
+    let parts = name.split('/').collect::<Vec<_>>();
+
+    let (namespace, name) = if parts.len() >= 2 {
+        (Some(parts[0]), parts[1])
+    } else {
+        (None, parts[0])
+    };
+
+    Purl {
+        ty: "generic".to_string(),
+        namespace: namespace.map(|s| s.to_string()),
+        name: name.to_string(),
+        version: None,
+        qualifiers: Default::default(),
     }
 }
 
@@ -437,6 +562,53 @@ impl FromQueryResultMultiModel for SbomStatusCatcher {
     }
 }
 
+#[derive(Debug)]
+struct ProductStatusCatcher {
+    product_status: entity::product_status::Model,
+    cpe: entity::cpe::Model,
+    status: entity::status::Model,
+    product_version: Option<entity::product_version::Model>,
+    sbom: Option<entity::sbom::Model>,
+    sbom_node: Option<entity::sbom_node::Model>,
+}
+
+impl FromQueryResult for ProductStatusCatcher {
+    fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
+        Ok(Self {
+            product_status: Self::from_query_result_multi_model(
+                res,
+                "",
+                entity::product_status::Entity,
+            )?,
+            cpe: Self::from_query_result_multi_model(res, "", entity::cpe::Entity)?,
+            status: Self::from_query_result_multi_model(res, "", entity::status::Entity)?,
+            product_version: Self::from_query_result_multi_model_optional(
+                res,
+                "",
+                entity::product_version::Entity,
+            )?,
+            sbom: Self::from_query_result_multi_model_optional(res, "", entity::sbom::Entity)?,
+            sbom_node: Self::from_query_result_multi_model_optional(
+                res,
+                "",
+                entity::sbom_node::Entity,
+            )?,
+        })
+    }
+}
+
+impl FromQueryResultMultiModel for ProductStatusCatcher {
+    fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr> {
+        select
+            .try_model_columns(entity::product_status::Entity)?
+            .try_model_columns(entity::cpe::Entity)?
+            .try_model_columns(entity::status::Entity)?
+            .try_model_columns(entity::product_version::Entity)?
+            .try_model_columns(entity::sbom::Entity)?
+            .try_model_columns(entity::sbom_node::Entity)
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct VulnerabilitySbomStatus {
     #[serde(flatten)]
@@ -450,12 +622,14 @@ pub struct VulnerabilitySbomStatus {
 }
 
 impl VulnerabilitySbomStatus {
-    async fn from_models<'i, I>(
+    async fn from_models<'i, 'j, I, J>(
         sbom_purl_status: I,
+        products: J,
         tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error>
     where
         I: Iterator<Item = &'i SbomStatusCatcher> + Clone,
+        J: Iterator<Item = &'j ProductStatusCatcher> + Clone,
     {
         let mut sboms = HashMap::new();
 
@@ -473,6 +647,46 @@ impl VulnerabilitySbomStatus {
                     cpe: sbom_cpe,
                     status: Default::default(),
                 });
+            }
+        }
+
+        for product in products.clone() {
+            if let Some(sbom) = &product.sbom {
+                let advisory_cpe = (&product.cpe).try_into().ok();
+                let entry = VulnerabilitySbomStatus {
+                    head: SbomHead::from_entity(sbom, product.sbom_node.clone(), tx).await?,
+                    version: product
+                        .product_version
+                        .as_ref()
+                        .map(|pv| pv.version.clone()),
+                    cpe: advisory_cpe,
+                    status: vec![product.status.slug.clone()].into_iter().collect(),
+                };
+                sboms
+                    .entry(&sbom.sbom_id)
+                    .and_modify(|value| {
+                        match &value.cpe {
+                            Some(cpe) => {
+                                // This is where the matching logic for multiple advisory entries lives
+                                // At the moment we try to use the biggest range we have.
+                                // For example: if we have entries for 2.0, 2.7 and 2.13 we will choose the last one
+                                if let Some(version) = &product.cpe.version {
+                                    let version_semver = lenient_semver::parse(version);
+                                    let current_version = &cpe.version().clone().to_string();
+                                    let current_semver = lenient_semver::parse(current_version);
+
+                                    if match (&version_semver, &current_semver) {
+                                        (Ok(v1), Ok(v2)) => v1 > v2,
+                                        _ => false,
+                                    } {
+                                        *value = entry.clone()
+                                    }
+                                }
+                            }
+                            None => *value = entry.clone(),
+                        }
+                    })
+                    .or_insert(entry);
             }
         }
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -207,11 +207,35 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let vuln_service = VulnerabilityService::new(ctx.db.clone());
+    let sbom_service = SbomService::new(ctx.db.clone());
 
-    ctx.ingest_documents(["csaf/cve-2023-0044.json"]).await?;
+    let ingest_results = ctx
+        .ingest_documents([
+            "csaf/cve-2023-0044.json",
+            "quarkus/v2/quarkus-bom-2.13.8.Final-redhat-00004.json",
+        ])
+        .await?;
 
-    let vuln = service
+    let quarkus_id = ingest_results[1].id.clone();
+
+    let quarkus_sbom = sbom_service
+        .fetch_sbom_details(quarkus_id, Transactional::None)
+        .await?;
+
+    assert!(quarkus_sbom.is_some());
+
+    let quarkus_sbom = quarkus_sbom.unwrap();
+
+    log::debug!("{}", serde_json::to_string_pretty(&quarkus_sbom)?);
+
+    assert!(!quarkus_sbom.advisories.is_empty());
+    let quarkus_adv = &quarkus_sbom.advisories[0].status[0];
+
+    assert_eq!(quarkus_adv.status, "fixed");
+    assert_eq!(quarkus_adv.vulnerability_id, "CVE-2023-0044");
+
+    let vuln = vuln_service
         .fetch_vulnerability("CVE-2023-0044", Default::default(), Transactional::None)
         .await?;
 
@@ -242,6 +266,21 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     } else {
         panic!("Expected Cpe context");
     }
+
+    // Now, ensure that vuln->sbom mapping is good.
+    let mut sboms: Vec<_> = vuln.advisories[0]
+        .sboms
+        .iter()
+        .map(|i| i.head.document_id.as_str())
+        .collect();
+    sboms.sort();
+
+    assert_eq!(
+        sboms,
+        [
+            "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-2.13.8.Final-redhat-00004",
+        ],
+    );
 
     Ok(())
 }

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -147,24 +147,24 @@ impl<'a> StatusCreator<'a> {
             };
 
             if let Some(range) = &product_version_range {
-                let components = if product.components.is_empty() {
+                let packages = if product.packages.is_empty() {
                     // If there are no components associated to this product, ingest just a product status
                     vec![None]
                 } else {
                     product
-                        .components
+                        .packages
                         .iter()
                         .map(|c| Some(c.to_string()))
                         .collect()
                 };
 
-                for component in components {
+                for package in packages {
                     let base_product = product_status::ActiveModel {
                         id: Default::default(),
                         product_version_range_id: Set(range.id),
                         advisory_id: Set(self.advisory_id),
                         vulnerability_id: Set(self.vulnerability_id.clone()),
-                        component: Set(component),
+                        package: Set(package),
                         context_cpe_id: Set(product.cpe.as_ref().map(Cpe::uuid)),
                         status_id: Set(status_id.id),
                     };
@@ -177,7 +177,8 @@ impl<'a> StatusCreator<'a> {
                 }
             }
 
-            for purl in &product.packages {
+            for purl in &product.purls {
+                let purl = purl.clone();
                 // Ingest purl status
                 let info = match purl.version.clone() {
                     Some(version) => VersionInfo {

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -146,22 +146,33 @@ impl<'a> StatusCreator<'a> {
                 None => None,
             };
 
-            // If there are no components associated to this product
-            // Ingest product status
-            if product.packages.is_empty() {
-                if let Some(range) = &product_version_range {
+            if let Some(range) = &product_version_range {
+                let components = if product.components.is_empty() {
+                    // If there are no components associated to this product, ingest just a product status
+                    vec![None]
+                } else {
+                    product
+                        .components
+                        .iter()
+                        .map(|c| Some(c.to_string()))
+                        .collect()
+                };
+
+                for component in components {
                     let base_product = product_status::ActiveModel {
                         id: Default::default(),
                         product_version_range_id: Set(range.id),
                         advisory_id: Set(self.advisory_id),
                         vulnerability_id: Set(self.vulnerability_id.clone()),
-                        base_purl_id: Set(None),
+                        component: Set(component),
                         context_cpe_id: Set(product.cpe.as_ref().map(Cpe::uuid)),
                         status_id: Set(status_id.id),
                     };
+
                     if let Some(cpe) = &product.cpe {
                         cpes.add(cpe.clone());
                     }
+
                     product_statuses.push(base_product);
                 }
             }
@@ -187,21 +198,6 @@ impl<'a> StatusCreator<'a> {
                 };
 
                 self.entries.insert(purl_status);
-
-                // Ingest matching product status
-                if let Some(ver) = &product_version_range {
-                    let product_status = product_status::ActiveModel {
-                        id: Default::default(),
-                        product_version_range_id: Set(ver.id),
-                        advisory_id: Set(self.advisory_id),
-                        vulnerability_id: Set(self.vulnerability_id.clone()),
-                        base_purl_id: Set(Some(purl.package_uuid())),
-                        context_cpe_id: Set(product.cpe.as_ref().map(Cpe::uuid)),
-                        status_id: Set(status_id.id),
-                    };
-
-                    product_statuses.push(product_status);
-                }
             }
         }
 

--- a/modules/ingestor/src/service/advisory/csaf/product_status.rs
+++ b/modules/ingestor/src/service/advisory/csaf/product_status.rs
@@ -12,8 +12,8 @@ pub struct ProductStatus {
     pub version: Option<VersionInfo>,
     pub cpe: Option<trustify_common::cpe::Cpe>,
     pub status: &'static str,
-    pub packages: Vec<Purl>,
-    pub components: Vec<String>,
+    pub purls: Vec<Purl>,
+    pub packages: Vec<String>,
 }
 
 impl ProductStatus {
@@ -29,24 +29,24 @@ impl ProductStatus {
             BranchCategory::Vendor => {
                 self.vendor = Some(branch.name.clone());
             }
-            // Get component/package info
+            // Get package/purl info
             BranchCategory::ProductVersion => {
                 match branch.product.clone() {
                     Some(full_name) => match full_name.product_identification_helper {
                         Some(id_helper) => match id_helper.purl {
-                            Some(purl) => self.packages.push(purl.into()),
-                            None => self.components.push(branch.name.clone()),
+                            Some(purl) => self.purls.push(purl.into()),
+                            None => self.packages.push(branch.name.clone()),
                         },
-                        None => self.components.push(full_name.product_id.0),
+                        None => self.packages.push(full_name.product_id.0),
                     },
-                    None => self.components.push(branch.name.clone()),
+                    None => self.packages.push(branch.name.clone()),
                 };
             }
             // For everything else, for now see if we can get any purls
             _ => {
                 if let Some(purl) = branch_purl(branch) {
                     let purl = Purl::from(purl.clone());
-                    self.packages.push(purl);
+                    self.purls.push(purl);
                 }
             }
         }


### PR DESCRIPTION
This PR should be able to correlate VEX advisories from CSAF files that don't have product identifier helpers (purls) to correct sboms.

To test it, run a local instance of trustify

Ingest one of the [datasets](https://github.com/trustification/trustify/blob/main/etc/datasets/README.md) (ds1 and ds3 should both work)

`http POST localhost:8080/api/v1/dataset @etc/datasets/ds3.zip`

And inspect results for some of the documents, e.g. CVE-2023-0044 and quarkus-sbom

`http GET localhost:8080/api/v1/vulnerability/CVE-2023-0044 | jq .advisories`

(find uuid of quarkus-sbom and the provide it below)

`http GET http://localhost:8080/api/v1/sbom/urn%3Auuid%3A01931b9e-8c5f-7681-8343-c8265a1257f1/advisory
`
This PR doesn't link found components to actual SBOM purls. That will be done in a separate effort.
