### PR TITLE
Refactor query logic to support querying of nested structures

### DIFF
--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use sea_orm::entity::ColumnDef;
 use sea_orm::{sea_query, ColumnTrait, ColumnType, EntityTrait, IntoIdentity, Iterable};
-use sea_query::{Alias, ColumnRef, IntoColumnRef, IntoIden};
+use sea_query::{Alias, ColumnRef, Expr, IntoColumnRef, IntoIden};
 
 /// Context of columns which can be used for filtering and sorting.
 #[derive(Default, Debug, Clone)]
@@ -128,17 +128,18 @@ impl Columns {
     }
 
     /// Look up the column context for a given simple field name.
-    pub(crate) fn for_field(&self, field: &str) -> Option<(ColumnRef, ColumnDef)> {
+    /// Look up the column context for a given simple field name.
+    pub(crate) fn for_field(&self, field: &str) -> Option<(Expr, ColumnDef)> {
         self.columns
             .iter()
-            .find(|(col_ref, _)| {
-                matches!( col_ref,
+            .find(|(col, _)| {
+                matches!(col,
                    ColumnRef::Column(name)
                     | ColumnRef::TableColumn(_, name)
                     | ColumnRef::SchemaTableColumn(_, _, name)
                         if name.to_string().eq_ignore_ascii_case(field))
             })
-            .cloned()
+            .map(|(r, d)| (Expr::col(r.clone()), d.clone()))
     }
 
     pub(crate) fn translate(&self, field: &str, op: &str, value: &str) -> Option<String> {

--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -130,7 +130,7 @@ impl Columns {
 
     /// Look up the column context for a given simple field name.
     pub(crate) fn for_field(&self, field: &str) -> Option<(Expr, ColumnDef)> {
-        fn name_match(tgt: &str) -> impl Fn(&&(ColumnRef, ColumnDef)) -> bool + use<'_> {
+        fn name_match(tgt: &str) -> impl Fn(&&(ColumnRef, ColumnDef)) -> bool + '_ {
             |(col, _)| {
                 matches!(col,
                          ColumnRef::Column(name)

--- a/common/src/db/query/sort.rs
+++ b/common/src/db/query/sort.rs
@@ -1,15 +1,15 @@
 use super::{Columns, Error};
 use sea_orm::{Order, QueryOrder};
-use sea_query::{ColumnRef, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct Sort {
-    field: ColumnRef,
+    field: Expr,
     order: Order,
 }
 
 impl Sort {
     pub(crate) fn order_by<T: QueryOrder>(self, stmt: T) -> T {
-        stmt.order_by(SimpleExpr::Column(self.field), self.order)
+        stmt.order_by(self.field, self.order)
     }
     pub(crate) fn parse(s: &str, columns: &Columns) -> Result<Self, Error> {
         let (field, order) = match s.split(':').collect::<Vec<_>>()[..] {


### PR DESCRIPTION
We enhance the Filter and Sort structs to deal with more complex LHS expressions, e.g. `"table.column"->>'key'`, instead of just column names.

Specifically, this enables the querying of `JsonBinary` and `Json` columns.