### PR TITLE
fix: re-walk all files if the commit cannot be found

### DIFF
--- a/entity/src/importer.rs
+++ b/entity/src/importer.rs
@@ -16,6 +16,7 @@ pub struct Model {
 
     pub progress_current: Option<i32>,
     pub progress_total: Option<i32>,
+    pub progress_message: Option<String>,
 
     /// an importer specific continuation token
     pub continuation: Option<serde_json::Value>,

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -89,6 +89,7 @@ mod m0000690_alter_sbom_details;
 mod m0000700_advisory_add_reserved;
 mod m0000710_create_user_prefs;
 mod m0000720_alter_sbom_fix_null_array;
+mod m0000730_alter_importer_add_progress;
 
 pub struct Migrator;
 
@@ -185,6 +186,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000700_advisory_add_reserved::Migration),
             Box::new(m0000710_create_user_prefs::Migration),
             Box::new(m0000720_alter_sbom_fix_null_array::Migration),
+            Box::new(m0000730_alter_importer_add_progress::Migration),
         ]
     }
 }

--- a/migration/src/m0000730_alter_importer_add_progress.rs
+++ b/migration/src/m0000730_alter_importer_add_progress.rs
@@ -1,0 +1,44 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Importer::Table)
+                    .add_column(
+                        ColumnDef::new(Importer::ProgressMessage)
+                            .string()
+                            .null()
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Importer::Table)
+                    .drop_column(Importer::ProgressMessage)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Importer {
+    Table,
+    ProgressMessage,
+}

--- a/modules/importer/src/runner/common/walker/git.rs
+++ b/modules/importer/src/runner/common/walker/git.rs
@@ -192,6 +192,9 @@ where
         // clone or open repository
 
         let result = info_span!("clone repository").in_scope(|| {
+            self.progress
+                .message_sync(format!("Cloning repository: {}", self.source));
+
             let mut builder = RepoBuilder::new();
 
             if let Some(branch) = &self.branch {
@@ -213,6 +216,10 @@ where
 
                 info_span!("fetching updates").in_scope(|| {
                     log::info!("Fetching updates");
+
+                    self.progress
+                        .message_sync(format!("Fetching updates: {}", self.source));
+
                     let mut remote = repo.find_remote("origin")?;
 
                     let mut fo = Self::create_fetch_options();

--- a/modules/importer/src/server/context.rs
+++ b/modules/importer/src/server/context.rs
@@ -46,10 +46,7 @@ impl RunContext for ServiceRunContext {
     }
 
     fn progress(&self, _message: String) -> impl Progress + Send + 'static {
-        ServiceProgress {
-            name: self.name.clone(),
-            service: self.service.clone(),
-        }
+        ServiceProgress::new(self.name.clone(), self.service.clone())
     }
 }
 

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -132,6 +132,7 @@ impl ImporterService {
 
             progress_current: Set(None),
             progress_total: Set(None),
+            progress_message: Set(None),
 
             continuation: Set(None),
 
@@ -269,6 +270,10 @@ impl ImporterService {
             ),
             (importer::Column::ProgressCurrent, Expr::value(i32::null())),
             (importer::Column::ProgressTotal, Expr::value(i32::null())),
+            (
+                importer::Column::ProgressMessage,
+                Expr::value(String::null()),
+            ),
             (importer::Column::LastChange, Expr::value(now)),
             (importer::Column::Continuation, Expr::value(continuation)),
         ];
@@ -355,6 +360,10 @@ impl ImporterService {
                 (importer::Column::ProgressCurrent, Expr::value(i32::null())),
                 (importer::Column::ProgressTotal, Expr::value(i32::null())),
                 (
+                    importer::Column::ProgressMessage,
+                    Expr::value(String::null()),
+                ),
+                (
                     importer::Column::Continuation,
                     Expr::value(None::<serde_json::Value>),
                 ),
@@ -378,7 +387,27 @@ impl ImporterService {
             vec![
                 (importer::Column::ProgressCurrent, Expr::value(current)),
                 (importer::Column::ProgressTotal, Expr::value(total)),
+                (
+                    importer::Column::ProgressMessage,
+                    Expr::value(String::null()),
+                ),
             ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self))]
+    pub async fn set_progress_message(
+        &self,
+        name: &str,
+        expected_revision: Option<&str>,
+        message: &str,
+    ) -> Result<(), Error> {
+        self.update(
+            &self.db,
+            name,
+            expected_revision,
+            vec![(importer::Column::ProgressMessage, Expr::value(message))],
         )
         .await
     }

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -44,7 +44,7 @@ fn mock_importer(result: &Importer, source: impl Into<String>) -> Importer {
             last_success: None,
             last_error: None,
             last_run: None,
-            progress: None,
+            progress: Default::default(),
             continuation: serde_json::Value::Null,
         },
     }
@@ -96,7 +96,7 @@ async fn test_default(ctx: TrustifyContext) {
                 last_success: None,
                 last_run: None,
                 last_error: None,
-                progress: None,
+                progress: Default::default(),
                 continuation: serde_json::Value::Null,
             }
         }]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2590,10 +2590,8 @@ components:
           format: date-time
           description: The last successful run
         progress:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/Progress'
-            description: The current progress, if available.
+          $ref: '#/components/schemas/Progress'
+          description: The current progress.
         state:
           $ref: '#/components/schemas/State'
           description: The current state of the importer
@@ -3171,6 +3169,17 @@ components:
         version:
           type: string
     Progress:
+      allOf:
+      - oneOf:
+        - type: 'null'
+        - $ref: '#/components/schemas/ProgressDetails'
+      - type: object
+        properties:
+          message:
+            type:
+            - string
+            - 'null'
+    ProgressDetails:
       type: object
       required:
       - current


### PR DESCRIPTION
If we can find a previous commit, we reset and create a fresh clone of the repository.

This can happen if there was a force push to the original repository.