### PR TITLE
fix(osv): treat `published` as optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,8 +4770,7 @@ dependencies = [
 [[package]]
 name = "osv"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e388ca803ae91b7bda3aac77567fe6bd0b89394baf6439c23147a5366dc72e"
+source = "git+http://github.com/ctron/osv?rev=b53f1590bbbdc663e3efe405f1fa2603e71e8680#b53f1590bbbdc663e3efe405f1fa2603e71e8680"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,8 @@ postgresql_commands = { version = "0.16.3", default-features = false, features =
 #cpe = { git = "https://github.com/ctron/cpe-rs", rev = "c3c05e637f6eff7dd4933c2f56d070ee2ddfb44b" }
 # required due to https://github.com/voteblake/csaf-rs/pull/29
 csaf = { git = "https://github.com/chirino/csaf-rs", rev = "414896904bc5e5287fd88b1daef5c27f70503d01" }
+# required due to https://github.com/gcmurphy/osv/pull/51
+osv = { git = "http://github.com/ctron/osv", rev = "b53f1590bbbdc663e3efe405f1fa2603e71e8680" }
 
 # to pickup fix: https://github.com/Abraxas-365/langchain-rust/pull/246
 #       and fix: https://github.com/Abraxas-365/langchain-rust/pull/250

--- a/etc/test-data/osv/PYSEC-2024-55.yaml
+++ b/etc/test-data/osv/PYSEC-2024-55.yaml
@@ -1,0 +1,12 @@
+id: PYSEC-2024-55
+modified: 0001-01-01T00:00:00Z
+details: Malicious package. Exfiltrated secrets to a target server.
+affected:
+  - package:
+      ecosystem: PyPI
+      name: cipherbcrypt
+      purl: pkg:pypi/cipherbcrypt
+    ranges:
+      - type: ECOSYSTEM
+        events:
+          - introduced: "0"

--- a/modules/fundamental/tests/advisory/osv/ingest.rs
+++ b/modules/fundamental/tests/advisory/osv/ingest.rs
@@ -1,0 +1,14 @@
+use test_context::test_context;
+use test_log::test;
+use trustify_module_ingestor::service::Format;
+use trustify_test_context::TrustifyContext;
+
+/// Test for <https://github.com/gcmurphy/osv/pull/51>
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn pypa_yaml(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    ctx.ingest_document_as("osv/PYSEC-2024-55.yaml", Format::OSV)
+        .await?;
+
+    Ok(())
+}

--- a/modules/fundamental/tests/advisory/osv/mod.rs
+++ b/modules/fundamental/tests/advisory/osv/mod.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::expect_used)]
 
 mod delete;
+mod ingest;
 mod reingest;
 
 use osv::schema::{Event, Vulnerability};

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -61,7 +61,7 @@ impl<'g> OsvLoader<'g> {
             // TODO(#899): check if we have some kind of version information
             version: None,
             issuer,
-            published: Some(osv.published.into_time()),
+            published: osv.published.map(ChronoExt::into_time),
             modified: Some(osv.modified.into_time()),
             withdrawn: osv.withdrawn.map(ChronoExt::into_time),
         };


### PR DESCRIPTION
The spec says it's optional. So let's make it optional.

Closes https://github.com/trustification/trustify/issues/990