### PR TITLE
Add version and handle circular deps in analysis graphs

### DIFF
--- a/etc/test-data/spdx/simple.json
+++ b/etc/test-data/spdx/simple.json
@@ -5,12 +5,12 @@
     "creators": [
       "Trustify"
     ],
-    "comment": "This is an example for an SBOM with looping refs. Based upon an existing SBOM.",
+    "comment": "This is a simple example for an spdx SBOM.",
     "licenseListVersion": "3.8"
   },
   "dataLicense": "CC0-1.0",
   "documentNamespace": "uri:just-an-example",
-  "name": "loop",
+  "name": "simple",
   "packages": [
 
     {
@@ -25,8 +25,8 @@
         },
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:/app:redhat:simple:1::el9",
-          "referenceType": "cpe22Type"
+          "referenceLocator": "cpe:/a:redhat:simple:1::el9",
+          "referenceType": "cpe23Type"
         }
       ],
       "filesAnalyzed": false,
@@ -158,11 +158,6 @@
           "referenceCategory": "PACKAGE_MANAGER",
           "referenceLocator": "pkg:rpm/redhat/EE@0.0.0?arch=src",
           "referenceType": "purl"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:/a:redhat:simple:1::el9",
-          "referenceType": "cpe22Type"
         }
       ],
       "filesAnalyzed": false,
@@ -181,13 +176,8 @@
       "downloadLocation": "foo",
       "externalRefs": [
         {
-          "referenceCategory": "PACKAGE_MANAGER",
-          "referenceLocator": "pkg:rpm/redhat/FF@0.0.0",
-          "referenceType": "purl"
-        },
-        {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:/a:redhat:simple:1::el9",
+          "referenceLocator": "cpe:/a:redhat:a-FF:1:*:*:*:*:*",
           "referenceType": "cpe22Type"
         }
       ],

--- a/modules/analysis/src/endpoints.rs
+++ b/modules/analysis/src/endpoints.rs
@@ -324,7 +324,7 @@ mod test {
             "pkg://rpm/redhat/B@0.0.0"
         );
 
-        Ok(assert_eq!(&response["total"], 2))
+        Ok(assert_eq!(&response["total"], 3))
     }
 
     #[test_context(TrustifyContext)]

--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -27,6 +27,7 @@ pub struct PackageNode {
     pub node_id: String,
     pub purl: String,
     pub name: String,
+    pub version: String,
     pub published: String,
     pub document_id: String,
     pub product_name: String,
@@ -44,6 +45,7 @@ pub struct AncNode {
     pub node_id: String,
     pub purl: String,
     pub name: String,
+    pub version: String,
 }
 
 impl fmt::Display for AncNode {
@@ -58,6 +60,7 @@ pub struct AncestorSummary {
     pub node_id: String,
     pub purl: String,
     pub name: String,
+    pub version: String,
     pub published: String,
     pub document_id: String,
     pub product_name: String,
@@ -71,6 +74,7 @@ pub struct DepNode {
     pub node_id: String,
     pub purl: String,
     pub name: String,
+    pub version: String,
     #[schema(no_recursion)]
     pub deps: Vec<DepNode>,
 }
@@ -85,6 +89,7 @@ pub struct DepSummary {
     pub node_id: String,
     pub purl: String,
     pub name: String,
+    pub version: String,
     pub published: String,
     pub document_id: String,
     pub product_name: String,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2245,6 +2245,7 @@ components:
       - node_id
       - purl
       - name
+      - version
       properties:
         name:
           type: string
@@ -2254,6 +2255,8 @@ components:
           type: string
         sbom_id:
           type: string
+        version:
+          type: string
     AncestorSummary:
       type: object
       required:
@@ -2261,6 +2264,7 @@ components:
       - node_id
       - purl
       - name
+      - version
       - published
       - document_id
       - product_name
@@ -2286,6 +2290,8 @@ components:
         purl:
           type: string
         sbom_id:
+          type: string
+        version:
           type: string
     BasePurlDetails:
       allOf:
@@ -2453,6 +2459,7 @@ components:
       - node_id
       - purl
       - name
+      - version
       - deps
       properties:
         deps:
@@ -2467,6 +2474,8 @@ components:
           type: string
         sbom_id:
           type: string
+        version:
+          type: string
     DepSummary:
       type: object
       required:
@@ -2474,6 +2483,7 @@ components:
       - node_id
       - purl
       - name
+      - version
       - published
       - document_id
       - product_name
@@ -2499,6 +2509,8 @@ components:
         purl:
           type: string
         sbom_id:
+          type: string
+        version:
           type: string
     Id:
       type: string


### PR DESCRIPTION
This PR contains a few interconnected changes to analysis graph:

* add **version** to node
* enable filtering with **version**
* ensure we handle circular dependencies (ex. _etc/test-data/spdx-ubi-examples/v2.json_)
*  heavy refactoring of graph routines

Additionally we should no longer extract name from the component **pURL** - as often a component will  not have a pURL ! - so we retrieve from **sbom_node**. 

**Note**:  We can further refactor in retrieve_ fns but left that till whenever we contemplate doing a MRU style forest of graphs.
