### PR TITLE
Fix circular deps in analysis graph and add purl migration for get_purl psql func

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -91,6 +91,7 @@ mod m0000700_advisory_add_reserved;
 mod m0000710_create_user_prefs;
 mod m0000720_alter_sbom_fix_null_array;
 mod m0000730_alter_importer_add_progress;
+mod m0000740_ensure_get_purl_fns;
 
 pub struct Migrator;
 
@@ -189,6 +190,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000710_create_user_prefs::Migration),
             Box::new(m0000720_alter_sbom_fix_null_array::Migration),
             Box::new(m0000730_alter_importer_add_progress::Migration),
+            Box::new(m0000740_ensure_get_purl_fns::Migration),
         ]
     }
 }

--- a/migration/src/m0000740_ensure_get_purl_fns.rs
+++ b/migration/src/m0000740_ensure_get_purl_fns.rs
@@ -1,0 +1,26 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0000740_ensure_get_purl_fns/get_purl.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0000590_get_purl_fns/get_purl.sql"))
+            .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0000740_ensure_get_purl_fns/get_purl.sql
+++ b/migration/src/m0000740_ensure_get_purl_fns/get_purl.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION get_purl(qualified_purl_id UUID)
+RETURNS TEXT AS $$
+DECLARE
+result TEXT;
+BEGIN
+SELECT
+    COALESCE(
+            'pkg:' || bp.type ||
+            '/' || COALESCE(bp.namespace, '') || '/' ||
+            bp.name ||
+            '@' || vp.version ||
+            CASE
+                WHEN qp.qualifiers IS NOT NULL AND qp.qualifiers <> '{}'::jsonb THEN
+                    '?' || (
+                        SELECT string_agg(key || '=' || value, '&')
+                        FROM jsonb_each_text(qp.qualifiers)
+                    )
+                ELSE
+                    ''
+                END,
+            qualified_purl_id::text
+    )
+INTO result
+FROM
+    qualified_purl qp
+        LEFT JOIN versioned_purl vp ON vp.id = qp.versioned_purl_id
+        LEFT JOIN base_purl bp ON bp.id = vp.base_purl_id
+WHERE
+    qp.id = qualified_purl_id;
+
+RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -72,6 +72,7 @@ pub struct AncestorSummary {
 pub struct DepNode {
     pub sbom_id: String,
     pub node_id: String,
+    pub relationship: String,
     pub purl: String,
     pub name: String,
     pub version: String,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2457,6 +2457,7 @@ components:
       required:
       - sbom_id
       - node_id
+      - relationship
       - purl
       - name
       - version
@@ -2471,6 +2472,8 @@ components:
         node_id:
           type: string
         purl:
+          type: string
+        relationship:
           type: string
         sbom_id:
           type: string


### PR DESCRIPTION
Missed off a commit for analysis graph (which adds relationship and fixes deps circularity)... also we need to perform data migration to ensure **get_purl** psql function serialises to correct **pURL** format (which is used by analysis graph). 

While in the area, optimised the **get_purl** fn for performance.