### PR TITLE
fix: s3 storage config options and encoding case insensitivity

### DIFF
--- a/modules/storage/src/config.rs
+++ b/modules/storage/src/config.rs
@@ -44,7 +44,6 @@ pub struct StorageConfig {
         long,
         env = "TRUSTD_STORAGE_COMPRESSION",
         default_value_t = Compression::None,
-        conflicts_with = "s3"
     )]
     pub compression: Compression,
 

--- a/modules/storage/src/service/compression/mod.rs
+++ b/modules/storage/src/service/compression/mod.rs
@@ -11,7 +11,9 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, BufReader, ReadBuf};
 )]
 pub enum Compression {
     #[default]
+    #[strum(ascii_case_insensitive)]
     None,
+    #[strum(ascii_case_insensitive)]
     Zstd,
 }
 
@@ -104,5 +106,21 @@ where
             InnerDecompression::None(ref mut r) => Pin::new(r).poll_read(cx, buf),
             InnerDecompression::Zstd(ref mut r) => Pin::new(r).poll_read(cx, buf),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn compression_from_str() {
+        assert_eq!(Ok(Compression::None), Compression::from_str("none"));
+        assert_eq!(Ok(Compression::None), Compression::from_str("None"));
+        assert_eq!(Ok(Compression::None), Compression::from_str("NONE"));
+        assert_eq!(Ok(Compression::Zstd), Compression::from_str("zstd"));
+        assert_eq!(Ok(Compression::Zstd), Compression::from_str("Zstd"));
+        assert_eq!(Ok(Compression::Zstd), Compression::from_str("ZSTD"));
     }
 }


### PR DESCRIPTION
I confirmed that both compressed and uncompressed files rendered correctly when downloaded via the trustify app using [this bucket](https://us-east-1.console.aws.amazon.com/s3/buckets/trustify-jcrossley?region=us-east-1)