### PR TITLE
fix: move number_of_packages to SbomHead

### DIFF
--- a/modules/fundamental/src/ai/endpoints/test.rs
+++ b/modules/fundamental/src/ai/endpoints/test.rs
@@ -66,8 +66,7 @@ async fn flags(ctx: &TrustifyContext) -> anyhow::Result<()> {
         json!({
             "completions": service.completions_enabled(),
         }),
-        "result:\n{}",
-        serde_json::to_string_pretty(&result)?
+        "result:\n{result:#?}"
     );
 
     Ok(())
@@ -88,12 +87,7 @@ async fn tools(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let expected: serde_json::Value =
         serde_json::from_str(include_str!("expected_tools_result.json"))?;
-    assert_eq!(
-        result,
-        expected,
-        "result:\n{}",
-        serde_json::to_string_pretty(&result)?
-    );
+    assert_eq!(result, expected, "result:\n{result:#?}");
 
     Ok(())
 }

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -328,7 +328,7 @@ async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     let request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
 
-    log::debug!("{}", serde_json::to_string_pretty(&response)?);
+    log::debug!("{response:#?}");
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -45,7 +45,7 @@ async fn get_sbom(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let uri = format!("/api/v1/sbom/{id}");
     let req = TestRequest::get().uri(&uri).to_request();
     let sbom: Value = app.call_and_read_body_json(req).await;
-    log::debug!("{}", serde_json::to_string_pretty(&sbom)?);
+    log::debug!("{sbom:#?}");
 
     // assert expected fields
     assert_eq!(sbom["id"], id);

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -31,7 +31,7 @@ async fn sbom_details_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let details = details.unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&details)?);
+    log::debug!("{details:#?}");
 
     let details = service
         .fetch_sbom_details(Id::Uuid(details.summary.head.id), Transactional::None)

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -2,11 +2,10 @@ use crate::test::caller;
 use crate::vulnerability::model::VulnerabilitySummary;
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
-use jsonpath_rust::JsonPathQuery;
-use serde_json::{json, Value};
+use serde_json::Value;
 use test_context::test_context;
 use test_log::test;
-use time::OffsetDateTime;
+use time::{macros::datetime, OffsetDateTime};
 use trustify_common::db::Transactional;
 use trustify_common::hashing::Digests;
 use trustify_common::model::PaginatedResults;
@@ -171,7 +170,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             "CVE-123",
             VulnerabilityInformation {
                 title: Some("Something wicked this way comes".to_string()),
-                published: Some(OffsetDateTime::now_utc()),
+                published: Some(datetime!(2019-01-01 0:00 UTC)),
                 reserved: None,
                 modified: None,
                 withdrawn: None,
@@ -183,18 +182,13 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let uri = "/api/v1/vulnerability/CVE-123";
     let request = TestRequest::get().uri(uri).to_request();
-    let response: Value = app.call_and_read_body_json(request).await;
+    let vuln: Value = app.call_and_read_body_json(request).await;
+    log::debug!("{:#?}", vuln);
 
-    log::debug!("{:#?}", response);
+    assert_eq!(vuln["identifier"], "CVE-123");
+    assert_eq!(vuln["title"], "Something wicked this way comes");
+    assert_eq!(vuln["published"], "2019-01-01T00:00:00Z");
 
-    let identifier = response.clone().path("$.identifier").unwrap();
-    let published = response.clone().path("$.published").unwrap();
-    let title = response.clone().path("$.title").unwrap();
-
-    assert_eq!(identifier, json!(["CVE-123"]));
-    assert_eq!(title, json!(["Something wicked this way comes"]));
-
-    assert!(published.get(0).is_some());
     Ok(())
 }
 
@@ -306,6 +300,34 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         .await;
     log::debug!("Code: {}", response.status());
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn get_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingest_documents(["cve/CVE-2024-26308.json", "spdx/SATELLITE-6.15-RHEL-8.json"])
+        .await?;
+
+    let app = caller(ctx).await?;
+    let vuln: Value = app
+        .call_and_read_body_json(
+            TestRequest::get()
+                .uri("/api/v1/vulnerability/CVE-2024-26308")
+                .to_request(),
+        )
+        .await;
+
+    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+
+    // assert expected fields
+    assert_eq!(vuln["normative"], true);
+    assert_eq!(vuln["identifier"], "CVE-2024-26308");
+    assert_eq!(
+        vuln["advisories"][0]["sboms"][0]["number_of_packages"],
+        2084
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -319,7 +319,7 @@ async fn get_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await;
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{vuln:#?}");
 
     // assert expected fields
     assert_eq!(vuln["normative"], true);

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -55,7 +55,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(2, vuln.advisories.len());
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{vuln:#?}");
 
     let rustsec_advisory = vuln
         .advisories
@@ -104,7 +104,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let vuln = vuln.unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{vuln:#?}");
 
     assert_eq!(2, vuln.advisories.len());
 
@@ -171,7 +171,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{vuln:#?}");
 
     assert_eq!(
         "pkg:maven/org.apache.commons/commons-compress",
@@ -227,7 +227,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let quarkus_sbom = quarkus_sbom.unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&quarkus_sbom)?);
+    log::debug!("{quarkus_sbom:#?}");
 
     assert!(!quarkus_sbom.advisories.is_empty());
     let quarkus_adv = &quarkus_sbom.advisories[0].status[0];
@@ -243,7 +243,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let vuln = vuln.unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&vuln)?);
+    log::debug!("{vuln:#?}");
 
     assert_eq!(1, vuln.advisories.len());
 
@@ -254,7 +254,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(cve_advisory.is_some());
     let cve_advisory = cve_advisory.unwrap();
 
-    log::debug!("{}", serde_json::to_string_pretty(&cve_advisory)?);
+    log::debug!("{cve_advisory:#?}");
 
     assert_eq!(
         "pkg:generic/io.quarkus/quarkus-vertx-http",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3034,17 +3034,11 @@ components:
             - type: object
               required:
               - described_by
-              - number_of_packages
               properties:
                 described_by:
                   type: array
                   items:
                     $ref: '#/components/schemas/SbomPackage'
-                number_of_packages:
-                  type: integer
-                  format: int64
-                  description: The number of packages this SBOM has
-                  minimum: 0
         total:
           type: integer
           format: int64
@@ -3427,6 +3421,7 @@ components:
       - published
       - authors
       - name
+      - number_of_packages
       properties:
         authors:
           type: array
@@ -3444,6 +3439,11 @@ components:
           $ref: '#/components/schemas/Labels'
         name:
           type: string
+        number_of_packages:
+          type: integer
+          format: int64
+          description: The number of packages this SBOM has
+          minimum: 0
         published:
           type:
           - string
@@ -3542,17 +3542,11 @@ components:
       - type: object
         required:
         - described_by
-        - number_of_packages
         properties:
           described_by:
             type: array
             items:
               $ref: '#/components/schemas/SbomPackage'
-          number_of_packages:
-            type: integer
-            format: int64
-            description: The number of packages this SBOM has
-            minimum: 0
     Severity:
       type: string
       description: |-


### PR DESCRIPTION
Fixes #1006 by making the sbom #packages available in `/api/v1/vulnerability/{id}` as well as `/api/v1/sbom/{id}`