### PR TITLE
Set implied relationships for SBOM components in analysis graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8596,6 +8596,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "utoipa-actix-web",
+ "uuid",
  "zip",
 ]
 

--- a/entity/src/relationship.rs
+++ b/entity/src/relationship.rs
@@ -48,6 +48,8 @@ pub enum Relationship {
     DescribedBy,
     #[sea_orm(num_value = 14)]
     PackageOf,
+    #[sea_orm(num_value = 15)]
+    Undefined,
 }
 
 impl fmt::Display for Relationship {

--- a/modules/analysis/Cargo.toml
+++ b/modules/analysis/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras", "uuid"] }
 utoipa-actix-web = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 actix-http = { workspace = true }

--- a/modules/analysis/src/endpoints.rs
+++ b/modules/analysis/src/endpoints.rs
@@ -321,6 +321,10 @@ mod test {
         );
         assert_eq!(
             response["items"][0]["deps"][0]["purl"],
+            "pkg:rpm/redhat/EE@0.0.0?arch=src"
+        );
+        assert_eq!(
+            response["items"][0]["deps"][1]["purl"],
             "pkg:rpm/redhat/B@0.0.0"
         );
 
@@ -344,6 +348,10 @@ mod test {
         );
         assert_eq!(
             response["items"][0]["deps"][0]["purl"],
+            "pkg:rpm/redhat/EE@0.0.0?arch=src"
+        );
+        assert_eq!(
+            response["items"][0]["deps"][1]["purl"],
             "pkg:rpm/redhat/B@0.0.0"
         );
 
@@ -429,7 +437,7 @@ mod test {
         let uri = format!("/api/v1/analysis/root-component?q=sbom_id={}", sbom_id);
         let request: Request = TestRequest::get().uri(uri.clone().as_str()).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
-        assert_eq!(&response["total"], 7);
+        assert_eq!(&response["total"], 8);
 
         // negative test
         let uri = "/api/v1/analysis/root-component?q=sbom_id=urn:uuid:99999999-9999-9999-9999-999999999999";

--- a/modules/analysis/src/model.rs
+++ b/modules/analysis/src/model.rs
@@ -43,6 +43,7 @@ impl fmt::Display for PackageNode {
 pub struct AncNode {
     pub sbom_id: String,
     pub node_id: String,
+    pub relationship: String,
     pub purl: String,
     pub name: String,
     pub version: String,
@@ -139,6 +140,11 @@ impl GraphMap {
     // Retrieve a reference to a graph by its key (read access)
     pub fn get(&self, key: &str) -> Option<&Graph<PackageNode, Relationship, petgraph::Directed>> {
         self.map.get(key)
+    }
+
+    // Retrieve all sbom ids(read access)
+    pub fn sbom_ids(&self) -> Vec<String> {
+        self.map.keys().cloned().collect()
     }
 
     // Get the singleton instance of GraphMap

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2243,6 +2243,7 @@ components:
       required:
       - sbom_id
       - node_id
+      - relationship
       - purl
       - name
       - version
@@ -2252,6 +2253,8 @@ components:
         node_id:
           type: string
         purl:
+          type: string
+        relationship:
           type: string
         sbom_id:
           type: string
@@ -3344,6 +3347,7 @@ components:
       - dev_tool_of
       - described_by
       - package_of
+      - undefined
     Report:
       type: object
       required:


### PR DESCRIPTION
SPDX/cyclonedx both allow defining components without any explicit relationship.

 In our internal logical database we consider existence of a component, in an SBOM to have an implied **Undefined** relationship with the **DESCRIBES** component. 

This PR ensures we do the similar in analysis graph.

Example;

Where **quarkus-vertx-http** component has no defined relationship (in _etc/test-data/spdx/quarkus-bom-3.2.11.Final-redhat-00001.json_)

```
>curl -H "Authorization:$(oidc token testing-client --bearer)" "http://localhost:8080/api/v1/analysis/root-component/quarkus-vertx-http"  | jq | bat --language=json
```

Previously this would list no ancestor component as no explicit dependency was defined in the SBOM thus no relationship was set in analysis graph.

```
{
      "sbom_id": "01934961-44a7-7b51-8675-2e613fde4334",
      "node_id": "SPDXRef-dfe6bb5c-fc2e-4115-a11e-75947122dbc0",
      "purl": "pkg:maven/io.quarkus/quarkus-vertx-http-deployment@3.2.11.Final-redhat-00001?type=jar&repository_url=https://maven.repository.redhat.com/ga/",
      "name": "quarkus-vertx-http-deployment",
      "version": "3.2.11.Final-redhat-00001",
      "published": "2024-05-28 09:26:01+00",
      "document_id": "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.11.Final-redhat-00001",
      "product_name": "quarkus-bom",
      "product_version": "3.2.11.Final-redhat-00001",
      "ancestors": []
}
```

Now we get an ancestor component with **relationship** key:

```
{
      "sbom_id": "01934961-44a7-7b51-8675-2e613fde4334",
      "node_id": "SPDXRef-dfe6bb5c-fc2e-4115-a11e-75947122dbc0",
      "purl": "pkg:maven/io.quarkus/quarkus-vertx-http-deployment@3.2.11.Final-redhat-00001?type=jar&repository_url=https://maven.repository.redhat.com/ga/",
      "name": "quarkus-vertx-http-deployment",
      "version": "3.2.11.Final-redhat-00001",
      "published": "2024-05-28 09:26:01+00",
      "document_id": "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.11.Final-redhat-00001",
      "product_name": "quarkus-bom",
      "product_version": "3.2.11.Final-redhat-00001",
      "ancestors": [
        {
          "sbom_id": "01934961-44a7-7b51-8675-2e613fde4334",
          "node_id": "SPDXRef-2d16b9fa-2dfb-44e5-abab-dc32fcd49628",
          "relationship": "Undefined",
          "purl": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.11.Final-redhat-00001?type=pom&repository_url=https://maven.repository.redhat.com/ga/",
          "name": "quarkus-bom",
          "version": "3.2.11.Final-redhat-00001"
        }
      ]
}
```

This work supports correlation work litigated in #1014