### PR TITLE
fix: don't check if the bucket exists.

### DIFF
--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -35,7 +35,6 @@ impl S3Backend {
             CONTENT_ENCODING,
             HeaderValue::from_str(&compression.to_string())?,
         )]))?;
-        assert!(bucket.exists().await?, "S3 bucket not found");
         log::info!(
             "Using S3 bucket '{}' in '{}' for doc storage",
             bucket.name,


### PR DESCRIPTION
Performing an "exists" check requires the s3:ListAllMyBuckets permission. Which feels excessive for such a simple check.

Closes: https://github.com/trustification/trustify/issues/1038