### PR TITLE
ci: disable musl builds for now

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -20,8 +20,8 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
+          #- x86_64-unknown-linux-musl
+          #- aarch64-unknown-linux-musl
           - x86_64-apple-darwin
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
@@ -37,15 +37,15 @@ jobs:
             # Cross' Ubuntu container is based on 20.04. Its OpenSSL version is too old for us.
             args: --features vendored
 
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-22.04
-            args: --features vendored
-            install: |
-              sudo apt install -y musl-tools
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-22.04
-            cross: "true"
-            args: --features vendored
+          #- target: x86_64-unknown-linux-musl
+          #  os: ubuntu-22.04
+          #  args: --features vendored
+          #  install: |
+          #    sudo apt install -y musl-tools
+          #- target: aarch64-unknown-linux-musl
+          #  os: ubuntu-22.04
+          #  cross: "true"
+          #  args: --features vendored
 
           - target: x86_64-apple-darwin
             os: macos-13


### PR DESCRIPTION
The reason for this, that we enable sqlx's TLS mode. Which requires, openssl, even for the build-dependency. In combination with musl, this creates some major problems, as vendoring doesn't seem to work.

For now, we just disable musl.