### PR TITLE
fix: always create "described by" relationships

### DIFF
--- a/etc/test-data/cyclonedx/simple_cpe.json
+++ b/etc/test-data/cyclonedx/simple_cpe.json
@@ -1,0 +1,33 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T13:30:00Z",
+    "component": {
+      "name": "simple",
+      "type": "application",
+      "cpe": "cpe:/a:redhat:simple:0.0"
+    }
+  },
+  "components": [
+    {
+      "name": "A",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/A@0.0.0?arch=src",
+      "type": "library"
+    },
+    {
+      "name": "B",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/B@0.0.0?arch=src",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "A",
+      "dependsOn": ["B"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/simple_cpe_2.json
+++ b/etc/test-data/cyclonedx/simple_cpe_2.json
@@ -1,0 +1,38 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T13:30:00Z",
+    "component": {
+      "name": "simple",
+      "type": "application",
+      "cpe": "cpe:/a:redhat:simple:0.0",
+      "bom-ref": "simple"
+    }
+  },
+  "components": [
+    {
+      "name": "A",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/A@0.0.0?arch=src",
+      "type": "library"
+    },
+    {
+      "name": "B",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/B@0.0.0?arch=src",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "simple",
+      "dependsOn": ["A"]
+    },
+    {
+      "ref": "A",
+      "dependsOn": ["B"]
+    }
+  ]
+}

--- a/etc/test-data/cyclonedx/simple_cpe_3.json
+++ b/etc/test-data/cyclonedx/simple_cpe_3.json
@@ -1,0 +1,38 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "timestamp": "1970-01-01T13:30:00Z",
+    "component": {
+      "name": "simple",
+      "type": "application",
+      "bom-ref": "simple"
+    }
+  },
+  "components": [
+    {
+      "name": "A",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/A@0.0.0?arch=src",
+      "cpe": "cpe:/a:redhat:simple:0.0",
+      "type": "library"
+    },
+    {
+      "name": "B",
+      "version": "1",
+      "purl": "pkg:rpm/redhat/B@0.0.0?arch=src",
+      "type": "library"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "simple",
+      "dependsOn": ["A"]
+    },
+    {
+      "ref": "A",
+      "dependsOn": ["B"]
+    }
+  ]
+}

--- a/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
@@ -1,0 +1,108 @@
+use test_context::test_context;
+use test_log::test;
+use trustify_module_fundamental::sbom::service::SbomService;
+use trustify_test_context::TrustifyContext;
+
+/// test to see if we ingest the CPE from the metadata component, not having an explicit reference.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("cyclonedx/simple_cpe.json").await?;
+
+    let service = SbomService::new(ctx.db.clone());
+
+    let packages = service
+        .describes_packages(
+            result.id.try_as_uid().expect("Must be a UID"),
+            Default::default(),
+            (),
+        )
+        .await?;
+
+    assert_eq!(packages.total, 1);
+    assert_eq!(packages.items.len(), 1);
+
+    let package = &packages.items[0];
+    assert_eq!(package.cpe, vec!["cpe:/a:redhat:simple:0.0:*:*:*"]);
+
+    Ok(())
+}
+
+/// test to see if we ingest the CPE from the metadata component, having an explicit reference.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("cyclonedx/simple_cpe_2.json").await?;
+
+    let service = SbomService::new(ctx.db.clone());
+
+    let packages = service
+        .describes_packages(
+            result.id.try_as_uid().expect("Must be a UID"),
+            Default::default(),
+            (),
+        )
+        .await?;
+
+    assert_eq!(packages.total, 1);
+    assert_eq!(packages.items.len(), 1);
+
+    let package = &packages.items[0];
+    assert_eq!(package.cpe, vec!["cpe:/a:redhat:simple:0.0:*:*:*"]);
+
+    Ok(())
+}
+
+/// test to see if we ingest the CPE for any other component.
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx.ingest_document("cyclonedx/simple_cpe_3.json").await?;
+
+    let service = SbomService::new(ctx.db.clone());
+
+    let packages = service
+        .describes_packages(
+            result.id.try_as_uid().expect("Must be a UID"),
+            Default::default(),
+            (),
+        )
+        .await?;
+
+    assert_eq!(packages.total, 1);
+    assert_eq!(packages.items.len(), 1);
+
+    let package = &packages.items[0];
+    assert_eq!(package.cpe, Vec::<String>::new());
+
+    // now fetch all
+
+    let packages = service
+        .fetch_sbom_packages(
+            result.id.try_as_uid().expect("Must be a UID"),
+            Default::default(),
+            Default::default(),
+            (),
+        )
+        .await?;
+
+    assert_eq!(packages.total, 3);
+    assert_eq!(packages.items.len(), 3);
+
+    // ensure the cpe one is present
+
+    let count = packages
+        .items
+        .iter()
+        .filter(|p| {
+            p.cpe
+                .iter()
+                .any(|cpe| cpe == "cpe:/a:redhat:simple:0.0:*:*:*")
+        })
+        .count();
+    assert_eq!(count, 1);
+
+    // done
+
+    Ok(())
+}

--- a/modules/fundamental/tests/sbom/cyclonedx/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/mod.rs
@@ -1,3 +1,5 @@
+mod cpe;
+
 use super::*;
 use std::str::FromStr;
 use test_context::test_context;

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -59,6 +59,7 @@ impl TrustifyContext {
         }
     }
 
+    /// The paths are relative to `<workspace>/etc/test-data`.
     pub async fn ingest_documents<'a, P: IntoIterator<Item = &'a str>>(
         &self,
         paths: P,
@@ -70,11 +71,16 @@ impl TrustifyContext {
         Ok(results)
     }
 
-    /// Same as [`self.ingest_document_as`], but with a format of [`Format::Unknown`].
+    /// Same as [`Self::ingest_document_as`], but with a format of [`Format::Unknown`].
+    ///
+    /// The path is relative to `<workspace>/etc/test-data`.
     pub async fn ingest_document(&self, path: &str) -> Result<IngestResult, anyhow::Error> {
         self.ingest_document_as(path, Format::Unknown).await
     }
 
+    /// Ingest a document with a specific format.
+    ///
+    /// The path is relative to `<workspace>/etc/test-data`.
     pub async fn ingest_document_as(
         &self,
         path: &str,
@@ -138,6 +144,7 @@ impl AsyncTestContext for TrustifyContext {
     }
 }
 
+/// return an absolute part, relative to `<workspace>/etc/test-data`.
 fn absolute(path: impl AsRef<Path>) -> Result<PathBuf, anyhow::Error> {
     let workspace_root: PathBuf = env!("CARGO_WORKSPACE_ROOT").into();
     let test_data = workspace_root.join("etc/test-data");
@@ -152,6 +159,8 @@ pub async fn document_bytes(path: &str) -> Result<Bytes, anyhow::Error> {
 }
 
 /// Load a test document as-is, no decompression.
+///
+/// The path is relative to `<workspace>/etc/test-data`.
 pub async fn document_bytes_raw(path: &str) -> Result<Bytes, anyhow::Error> {
     let bytes = tokio::fs::read(absolute(path)?).await?;
     Ok(bytes.into())


### PR DESCRIPTION
In cases where the metadata component doesn't have an explicit `bom-ref`, we now create an artificial one, so that the relationship gets created.

CycloneDX doesn't need such a reference for the relationship, but we do. So instead of ignoring the information, we create an artificial value. Just like primary IDs in the database.

Also, improve some test coverage.