### PR TITLE
chore: add a document id for advisories

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -13,11 +13,15 @@ use trustify_common::{
 #[graphql(concrete(name = "Advisory", params()))]
 #[sea_orm(table_name = "advisory")]
 pub struct Model {
+    /// The database internal ID
     #[sea_orm(primary_key)]
     pub id: Uuid,
+    /// A unique document identifier
     #[graphql(name = "name")]
     pub identifier: String,
     pub version: Option<String>,
+    /// An ID as claimed by the document
+    pub document_id: String,
     pub deprecated: bool,
     pub issuer_id: Option<Uuid>,
     pub published: Option<OffsetDateTime>,

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -92,6 +92,7 @@ mod m0000710_create_user_prefs;
 mod m0000720_alter_sbom_fix_null_array;
 mod m0000730_alter_importer_add_progress;
 mod m0000740_ensure_get_purl_fns;
+mod m0000750_alter_advisory_add_document_id;
 
 pub struct Migrator;
 
@@ -191,6 +192,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000720_alter_sbom_fix_null_array::Migration),
             Box::new(m0000730_alter_importer_add_progress::Migration),
             Box::new(m0000740_ensure_get_purl_fns::Migration),
+            Box::new(m0000750_alter_advisory_add_document_id::Migration),
         ]
     }
 }

--- a/migration/src/m0000750_alter_advisory_add_document_id.rs
+++ b/migration/src/m0000750_alter_advisory_add_document_id.rs
@@ -1,0 +1,69 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // create, with null
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .add_column(
+                        ColumnDef::new(Advisory::DocumentId)
+                            .string()
+                            .null()
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // update from id field
+
+        manager
+            .get_connection()
+            .execute_unprepared(r#"UPDATE advisory SET document_id = identifier"#)
+            .await?;
+
+        // set to not null
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .modify_column(
+                        ColumnDef::new(Advisory::DocumentId)
+                            .string()
+                            .not_null()
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Advisory::Table)
+                    .drop_column(Advisory::DocumentId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Advisory {
+    Table,
+    DocumentId,
+}

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -33,6 +33,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-1".to_string(),
                 title: Some("RHSA-1".to_string()),
                 version: None,
                 issuer: None,
@@ -70,6 +71,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: None,
@@ -118,6 +120,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-1".to_string(),
                 title: Some("RHSA-1".to_string()),
                 version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
@@ -136,6 +139,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
@@ -213,6 +217,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-1".to_string(),
                 title: Some("RHSA-1".to_string()),
                 version: None,
                 issuer: Some("Red Hat Product Security".to_string()),
@@ -231,6 +236,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: Some("Red Hat Product Security".to_string()),

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -24,6 +24,9 @@ pub struct AdvisoryHead {
     /// The identifier of the advisory, as assigned by the issuing organization.
     pub identifier: String,
 
+    /// The identifier of the advisory, as provided by the document.
+    pub document_id: String,
+
     /// The issuer of the advisory, if known. If no issuer is able to be
     /// determined, this field will not be included in a response.
     #[schema(required)]
@@ -74,6 +77,7 @@ impl AdvisoryHead {
         Ok(Self {
             uuid: advisory.id,
             identifier: advisory.identifier.clone(),
+            document_id: advisory.document_id.clone(),
             issuer,
             published: advisory.published,
             modified: advisory.modified,
@@ -101,6 +105,7 @@ impl AdvisoryHead {
             heads.push(Self {
                 uuid: advisory.id,
                 identifier: advisory.identifier.clone(),
+                document_id: advisory.document_id.clone(),
                 issuer,
                 published: advisory.published,
                 modified: advisory.modified,

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -21,6 +21,7 @@ use trustify_test_context::TrustifyContext;
 
 pub async fn ingest_sample_advisory<'a>(
     ctx: &'a TrustifyContext,
+    id: &'a str,
     title: &'a str,
 ) -> Result<AdvisoryContext<'a>, trustify_module_ingestor::graph::error::Error> {
     ctx.graph
@@ -29,6 +30,7 @@ pub async fn ingest_sample_advisory<'a>(
             ("source", "http://redhat.com/"),
             &Digests::digest(title),
             AdvisoryInformation {
+                id: id.to_string(),
                 title: Some(title.to_string()),
                 version: None,
                 issuer: None,
@@ -42,7 +44,7 @@ pub async fn ingest_sample_advisory<'a>(
 }
 
 pub async fn ingest_and_link_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let advisory = ingest_sample_advisory(ctx, "RHSA-1").await?;
+    let advisory = ingest_sample_advisory(ctx, "RHSA-1", "RHSA-1").await?;
 
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, Transactional::None)
@@ -72,7 +74,7 @@ pub async fn ingest_and_link_advisory(ctx: &TrustifyContext) -> Result<(), anyho
 async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ingest_and_link_advisory(ctx).await?;
 
-    ingest_sample_advisory(ctx, "RHSA-2").await?;
+    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
@@ -90,7 +92,7 @@ async fn all_advisories_filtered_by_average_score(
 ) -> Result<(), anyhow::Error> {
     ingest_and_link_advisory(ctx).await?;
 
-    ingest_sample_advisory(ctx, "RHSA-2").await?;
+    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
@@ -113,7 +115,7 @@ async fn all_advisories_filtered_by_average_severity(
 ) -> Result<(), anyhow::Error> {
     ingest_and_link_advisory(ctx).await?;
 
-    ingest_sample_advisory(ctx, "RHSA-2").await?;
+    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let fetched = fetch
@@ -136,7 +138,7 @@ async fn all_advisories_filtered_by_average_severity(
 async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digests = Digests::digest("RHSA-1");
 
-    let advisory = ingest_sample_advisory(ctx, "RHSA-1").await?;
+    let advisory = ingest_sample_advisory(ctx, "RHSA-1", "RHSA-1").await?;
 
     let advisory_vuln: trustify_module_ingestor::graph::advisory::advisory_vulnerability::AdvisoryVulnerabilityContext<'_> = advisory
         .link_to_vulnerability("CVE-123", None, Transactional::None)
@@ -184,7 +186,7 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    ingest_sample_advisory(ctx, "RHSA-2").await?;
+    ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
     let fetch = AdvisoryService::new(ctx.db.clone());
     let jenny256 = Id::sha256(&digests.sha256);
@@ -234,7 +236,7 @@ async fn single_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digests = Digests::digest("RHSA-1");
 
-    let advisory = ingest_sample_advisory(ctx, "RHSA-1").await?;
+    let advisory = ingest_sample_advisory(ctx, "RHSA-1", "RHSA-1").await?;
 
     let advisory_vuln = advisory
         .link_to_vulnerability("CVE-123", None, Transactional::None)

--- a/modules/fundamental/src/ai/service/tools/advisory_info.rs
+++ b/modules/fundamental/src/ai/service/tools/advisory_info.rs
@@ -150,7 +150,7 @@ mod tests {
     #[test(actix_web::test)]
     async fn advisory_info_tool(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         crate::advisory::service::test::ingest_and_link_advisory(ctx).await?;
-        crate::advisory::service::test::ingest_sample_advisory(ctx, "RHSA-2").await?;
+        crate::advisory::service::test::ingest_sample_advisory(ctx, "RHSA-2", "RHSA-2").await?;
 
         let tool = Rc::new(AdvisoryInfo(AdvisoryService::new(ctx.db.clone())));
 

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -23,6 +23,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://captpickles.com/"),
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
+                id: "CAPT-1".to_string(),
                 title: Some("CAPT-1".to_string()),
                 version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),
@@ -40,6 +41,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://captpickles.com/"),
             &Digests::digest("EMPORIUM-1"),
             AdvisoryInformation {
+                id: "EMPORIUM-1".to_string(),
                 title: Some("EMPORIUM-1".to_string()),
                 version: None,
                 issuer: Some("Capt Pickles Boutique Emporium".to_string()),
@@ -82,6 +84,7 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://captpickles.com/"),
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
+                id: "CAPT-1".to_string(),
                 title: Some("Pickles can experience a buffer overflow".to_string()),
                 version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -16,6 +16,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://captpickles.com/"),
             &Digests::digest("CPIC-1"),
             AdvisoryInformation {
+                id: "CAPT-1".to_string(),
                 title: Some("CAPT-1".to_string()),
                 version: None,
                 issuer: Some("Capt Pickles Industrial Conglomerate".to_string()),

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -29,6 +29,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             ("source", "http://captpickles.com/"),
             &Digests::digest("CAPT-1"),
             AdvisoryInformation {
+                id: "CAPT-1".to_string(),
                 title: Some("CAPT-1".to_string()),
                 version: None,
                 issuer: None,
@@ -67,6 +68,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: None,
@@ -111,6 +113,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-1".to_string(),
                 title: Some("RHSA-1".to_string()),
                 version: None,
                 issuer: None,
@@ -150,6 +153,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: None,
@@ -204,6 +208,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-1"),
             AdvisoryInformation {
+                id: "RHSA-1".to_string(),
                 title: Some("RHSA-1".to_string()),
                 version: None,
                 issuer: None,
@@ -243,6 +248,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
             ("source", "http://redhat.com/"),
             &Digests::digest("RHSA-2"),
             AdvisoryInformation {
+                id: "RHSA-2".to_string(),
                 title: Some("RHSA-2".to_string()),
                 version: None,
                 issuer: None,

--- a/modules/graphql/src/advisory.rs
+++ b/modules/graphql/src/advisory.rs
@@ -28,6 +28,7 @@ impl AdvisoryQuery {
                 withdrawn: advisory.advisory.withdrawn,
                 title: advisory.advisory.title,
                 source_document_id: advisory.advisory.source_document_id,
+                document_id: advisory.advisory.document_id,
             }),
             Ok(None) => Err(FieldError::new("Advisory not found")),
             Err(err) => Err(FieldError::from(err)),
@@ -57,6 +58,7 @@ impl AdvisoryQuery {
                     withdrawn: advisory.advisory.withdrawn,
                     title: advisory.advisory.title,
                     source_document_id: advisory.advisory.source_document_id,
+                    document_id: advisory.advisory.document_id,
                 })
             })
             .collect()

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -30,6 +30,7 @@ impl<'a> From<Information<'a>> for AdvisoryInformation {
     fn from(value: Information<'a>) -> Self {
         let value = value.0;
         Self {
+            id: value.document.tracking.id.clone(),
             // TODO: consider failing if the version doesn't parse
             version: parse_csaf_version(value),
             title: Some(value.document.title.clone()),

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -64,6 +64,7 @@ impl<'g> CveLoader<'g> {
         let reserved_date = information.reserved;
         let title = information.title.clone();
         let advisory_info = AdvisoryInformation {
+            id: id.to_string(),
             title: information.title.clone(),
             // TODO: check if we have some kind of version information
             version: None,

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -57,6 +57,7 @@ impl<'g> OsvLoader<'g> {
         });
 
         let information = AdvisoryInformation {
+            id: osv.id.clone(),
             title: osv.summary.clone(),
             // TODO(#899): check if we have some kind of version information
             version: None,

--- a/modules/ingestor/tests/db.rs
+++ b/modules/ingestor/tests/db.rs
@@ -132,6 +132,7 @@ async fn create_set(ctx: &TrustifyContext) -> anyhow::Result<()> {
             let modified = published + Duration::days(i as i64);
 
             let info = AdvisoryInformation {
+                id,
                 title: None,
                 issuer: None,
                 published: Some(published),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2078,12 +2078,16 @@ components:
       required:
       - uuid
       - identifier
+      - document_id
       - issuer
       - published
       - withdrawn
       - title
       - labels
       properties:
+        document_id:
+          type: string
+          description: The identifier of the advisory, as provided by the document.
         identifier:
           type: string
           description: The identifier of the advisory, as assigned by the issuing organization.


### PR DESCRIPTION
Fix an issue for the UI, where the document ID was reported as `https://www.redhat.com/#CVE-2023-0044` for CSAF documents. However, in v1 the ID was `CVE-2023-0044`.

This is due to the fact that we have a list of IDs for each advisory: an internal DB one (`id`), one that uniquely identifies the docment (`identifier`), and now one which carries the ID as reported by the document (`document_id`). The latter one should be show in the UI.

@carlosthe19916 This also means that at the UI needs to pick up the new field, once this PR is merged.