### PR TITLE
refactor: drop Transactional and ConnectionOrTransaction

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -38,7 +38,7 @@ impl Model {
         let db = ctx.data::<Arc<db::Database>>()?;
         if let Some(found) = self
             .find_related(organization::Entity)
-            .one(&db.connection(&db::Transactional::None))
+            .one(db.as_ref())
             .await?
         {
             Ok(found)
@@ -51,7 +51,7 @@ impl Model {
         let db = ctx.data::<Arc<db::Database>>()?;
         Ok(self
             .find_related(vulnerability::Entity)
-            .all(&db.connection(&db::Transactional::None))
+            .all(db.as_ref())
             .await?)
     }
 }

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -22,8 +22,6 @@ pub(crate) mod trustify_benches {
     use sea_orm::ConnectionTrait;
     use test_context::AsyncTestContext;
     use tokio::runtime::Runtime;
-
-    use trustify_common::db::Transactional;
     use trustify_entity::labels::Labels;
     use trustify_module_ingestor::service::Format;
     use trustify_test_context::{document, TrustifyContext};
@@ -156,15 +154,11 @@ pub(crate) mod trustify_benches {
             "vulnerability",
         ] {
             ctx.db
-                .clone()
-                .connection(&Transactional::None)
                 .execute_unprepared(format!("DELETE FROM {table} WHERE 1=1").as_str())
                 .await
                 .expect("DELETE ok");
         }
         ctx.db
-            .clone()
-            .connection(&Transactional::None)
             .execute_unprepared("VACUUM ANALYZE")
             .await
             .expect("vacuum analyze ok");

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -1,6 +1,7 @@
 use crate::advisory::service::AdvisoryService;
 use actix_web::{patch, put, web, HttpResponse, Responder};
 use trustify_auth::{authorizer::Require, UpdateAdvisory};
+use trustify_common::db::Database;
 use trustify_common::id::Id;
 use trustify_entity::labels::Labels;
 
@@ -20,12 +21,16 @@ use trustify_entity::labels::Labels;
 #[put("/v1/advisory/{id}/label")]
 pub async fn set(
     advisory: web::Data<AdvisoryService>,
+    db: web::Data<Database>,
     id: web::Path<Id>,
     web::Json(labels): web::Json<Labels>,
     _: Require<UpdateAdvisory>,
 ) -> actix_web::Result<impl Responder> {
     Ok(
-        match advisory.set_labels(id.into_inner(), labels, ()).await? {
+        match advisory
+            .set_labels(id.into_inner(), labels, db.as_ref())
+            .await?
+        {
             Some(()) => HttpResponse::NoContent(),
             None => HttpResponse::NotFound(),
         },

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use test_context::test_context;
 use test_log::test;
 use time::OffsetDateTime;
-use trustify_common::{db::Transactional, hashing::Digests, id::Id, model::PaginatedResults};
+use trustify_common::{hashing::Digests, id::Id, model::PaginatedResults};
 use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
     PrivilegesRequired, Scope, UserInteraction,
@@ -41,12 +41,12 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let advisory_vuln = advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
     advisory_vuln
         .ingest_cvss3_score(
@@ -61,7 +61,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 i: Integrity::None,
                 a: Availability::None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -79,7 +79,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -128,7 +128,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -147,12 +147,12 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let advisory_vuln = advisory2
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
     advisory_vuln
         .ingest_cvss3_score(
@@ -167,7 +167,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 i: Integrity::None,
                 a: Availability::None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -225,7 +225,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -244,14 +244,14 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let uuid = advisory.advisory.id;
 
     let advisory_vuln = advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
     advisory_vuln
         .ingest_cvss3_score(
@@ -266,7 +266,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 i: Integrity::None,
                 a: Availability::None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -1,7 +1,6 @@
 use crate::{vulnerability::model::VulnerabilityHead, Error};
-use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
@@ -30,10 +29,10 @@ pub struct AdvisoryVulnerabilityHead {
 }
 
 impl AdvisoryVulnerabilityHead {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         advisory: &advisory::Model,
         vulnerability: &vulnerability::Model,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let cvss3 = cvss3::Entity::find()
             .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
@@ -68,10 +67,10 @@ impl AdvisoryVulnerabilityHead {
         }
     }
 
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         advisory: &advisory::Model,
         vulnerabilities: &[vulnerability::Model],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let cvss3s = vulnerabilities
             .load_many(
@@ -122,10 +121,10 @@ pub struct AdvisoryVulnerabilitySummary {
 }
 
 impl AdvisoryVulnerabilitySummary {
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         advisory: &advisory::Model,
         vulnerabilities: &[vulnerability::Model],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut cvss3s = vulnerabilities
             .load_many(

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -1,6 +1,6 @@
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
 use serde::{Deserialize, Serialize};
-use trustify_common::{db::ConnectionOrTransaction, memo::Memo};
+use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::score::Score;
 use trustify_entity::{advisory_vulnerability, vulnerability};
 use utoipa::ToSchema;
@@ -32,9 +32,9 @@ pub struct AdvisorySummary {
 }
 
 impl AdvisorySummary {
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         entities: &[AdvisoryCatcher],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut summaries = Vec::with_capacity(entities.len());
 
@@ -63,7 +63,7 @@ impl AdvisorySummary {
                 )
                 .await?,
                 source_document: if let Some(doc) = &each.source_document {
-                    Some(SourceDocument::from_entity(doc, tx).await?)
+                    Some(SourceDocument::from_entity(doc).await?)
                 } else {
                     None
                 },

--- a/modules/fundamental/src/ai/endpoints/mod.rs
+++ b/modules/fundamental/src/ai/endpoints/mod.rs
@@ -35,10 +35,11 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 #[post("/v1/ai/completions")]
 pub async fn completions(
     service: web::Data<AiService>,
+    db: web::Data<Database>,
     request: web::Json<ChatState>,
     _: Require<Ai>,
 ) -> actix_web::Result<impl Responder> {
-    let response = service.completions(&request, ()).await?;
+    let response = service.completions(&request, db.as_ref()).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 

--- a/modules/fundamental/src/ai/service/mod.rs
+++ b/modules/fundamental/src/ai/service/mod.rs
@@ -19,10 +19,11 @@ use langchain_rust::{
     prompt_args,
     tools::Tool,
 };
+use sea_orm::ConnectionTrait;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
-use trustify_common::db::{Database, Transactional};
+use trustify_common::db::Database;
 
 pub const PREFIX: &str = include_str!("prefix.txt");
 
@@ -173,10 +174,10 @@ impl AiService {
             .await
     }
 
-    pub async fn completions<TX: AsRef<Transactional>>(
+    pub async fn completions<C: ConnectionTrait>(
         &self,
         request: &ChatState,
-        _tx: TX,
+        _connection: &C,
     ) -> Result<ChatState, Error> {
         let llm = match self.llm.clone() {
             Some(llm) => llm,

--- a/modules/fundamental/src/ai/service/tools/mod.rs
+++ b/modules/fundamental/src/ai/service/tools/mod.rs
@@ -1,19 +1,12 @@
-use crate::advisory::service::AdvisoryService;
-use crate::ai::service::tools::advisory_info::AdvisoryInfo;
-use crate::ai::service::tools::cve_info::CVEInfo;
-use crate::ai::service::tools::logger::ToolLogger;
-use crate::ai::service::tools::package_info::PackageInfo;
-use crate::ai::service::tools::sbom_info::SbomInfo;
-use crate::purl::service::PurlService;
-use crate::sbom::service::SbomService;
-use crate::vulnerability::service::VulnerabilityService;
+use crate::ai::service::tools::{
+    advisory_info::AdvisoryInfo, cve_info::CVEInfo, logger::ToolLogger, package_info::PackageInfo,
+    sbom_info::SbomInfo,
+};
 use langchain_rust::tools::Tool;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::error::Error;
-use std::sync::Arc;
-use trustify_common::db::Database;
-use trustify_common::model::PaginatedResults;
+use std::{error::Error, sync::Arc};
+use trustify_common::{db::Database, model::PaginatedResults};
 
 pub mod advisory_info;
 pub mod cve_info;
@@ -26,13 +19,10 @@ pub mod sbom_info;
 pub fn new(db: Database) -> Vec<Arc<dyn Tool>> {
     vec![
         // Arc::new(ToolLogger(ProductInfo(ProductService::new(db.clone())))),
-        Arc::new(ToolLogger(CVEInfo(VulnerabilityService::new(db.clone())))),
-        Arc::new(ToolLogger(AdvisoryInfo(AdvisoryService::new(db.clone())))),
-        Arc::new(ToolLogger(PackageInfo((
-            PurlService::new(db.clone()),
-            SbomService::new(db.clone()),
-        )))),
-        Arc::new(ToolLogger(SbomInfo(SbomService::new(db.clone())))),
+        Arc::new(ToolLogger(CVEInfo::new(db.clone()))),
+        Arc::new(ToolLogger(AdvisoryInfo::new(db.clone()))),
+        Arc::new(ToolLogger(PackageInfo::new(db.clone()))),
+        Arc::new(ToolLogger(SbomInfo::new(db.clone()))),
     ]
 }
 

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -6,7 +6,6 @@ use serde_json::{json, Value};
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::query::Query;
-use trustify_common::db::Transactional;
 use trustify_common::hashing::Digests;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
@@ -31,7 +30,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -49,7 +48,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -92,18 +91,18 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
 
-    let service = crate::organization::service::OrganizationService::new(ctx.db.clone());
+    let service = crate::organization::service::OrganizationService::new();
 
     let orgs = service
-        .fetch_organizations(Query::default(), Paginated::default(), ())
+        .fetch_organizations(Query::default(), Paginated::default(), &ctx.db)
         .await?;
 
     assert_eq!(1, orgs.total);

--- a/modules/fundamental/src/organization/model/details/mod.rs
+++ b/modules/fundamental/src/organization/model/details/mod.rs
@@ -1,9 +1,8 @@
-use sea_orm::ModelTrait;
+use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::advisory::model::AdvisoryHead;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::{advisory, organization};
 
 use crate::organization::model::OrganizationHead;
@@ -19,13 +18,13 @@ pub struct OrganizationDetails {
 }
 
 impl OrganizationDetails {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         org: &organization::Model,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let advisories = org.find_related(advisory::Entity).all(tx).await?;
         Ok(OrganizationDetails {
-            head: OrganizationHead::from_entity(org, tx).await?,
+            head: OrganizationHead::from_entity(org).await?,
             advisories: AdvisoryHead::from_entities(&advisories, tx).await?,
         })
     }

--- a/modules/fundamental/src/organization/model/mod.rs
+++ b/modules/fundamental/src/organization/model/mod.rs
@@ -8,7 +8,6 @@ mod summary;
 use crate::Error;
 pub use details::*;
 pub use summary::*;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::organization;
 
 /// An organization who may issue advisories, product SBOMs, or
@@ -31,10 +30,7 @@ pub struct OrganizationHead {
 }
 
 impl OrganizationHead {
-    pub async fn from_entity(
-        organization: &organization::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(organization: &organization::Model) -> Result<Self, Error> {
         Ok(OrganizationHead {
             id: organization.id,
             name: organization.name.clone(),

--- a/modules/fundamental/src/organization/model/summary.rs
+++ b/modules/fundamental/src/organization/model/summary.rs
@@ -1,7 +1,6 @@
 use crate::organization::model::OrganizationHead;
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::organization;
 use utoipa::ToSchema;
 
@@ -12,24 +11,18 @@ pub struct OrganizationSummary {
 }
 
 impl OrganizationSummary {
-    pub async fn from_entity(
-        organization: &organization::Model,
-        tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(organization: &organization::Model) -> Result<Self, Error> {
         Ok(OrganizationSummary {
-            head: OrganizationHead::from_entity(organization, tx).await?,
+            head: OrganizationHead::from_entity(organization).await?,
         })
     }
 
-    pub async fn from_entities(
-        organizations: &[organization::Model],
-        tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Vec<Self>, Error> {
+    pub async fn from_entities(organizations: &[organization::Model]) -> Result<Vec<Self>, Error> {
         let mut summaries = Vec::new();
 
         for org in organizations {
             summaries.push(OrganizationSummary {
-                head: OrganizationHead::from_entity(org, tx).await?,
+                head: OrganizationHead::from_entity(org).await?,
             });
         }
 

--- a/modules/fundamental/src/organization/service/test.rs
+++ b/modules/fundamental/src/organization/service/test.rs
@@ -24,14 +24,14 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
-    let service = crate::organization::service::OrganizationService::new(ctx.db.clone());
+    let service = crate::organization::service::OrganizationService::new();
 
     let orgs = service
-        .fetch_organizations(Query::default(), Paginated::default(), ())
+        .fetch_organizations(Query::default(), Paginated::default(), &ctx.db)
         .await?;
 
     assert_eq!(1, orgs.total);

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -22,7 +22,7 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 vendor: Some("Red Hat".to_string()),
                 cpe: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -33,7 +33,7 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 vendor: Some("Red Hat".to_string()),
                 cpe: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -62,14 +62,14 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 vendor: Some("Red Hat".to_string()),
                 cpe: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(ctx.db.clone());
+    let service = crate::product::service::ProductService::new();
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), ())
+        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
         .await?;
 
     assert_eq!(1, products.total);
@@ -102,14 +102,14 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 vendor: Some("Red Hat".to_string()),
                 cpe: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
-    let service = crate::product::service::ProductService::new(ctx.db.clone());
+    let service = crate::product::service::ProductService::new();
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), ())
+        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
         .await?;
 
     assert_eq!(1, products.total);
@@ -126,7 +126,7 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(response.status(), StatusCode::OK);
 
     let products = service
-        .fetch_products(Query::default(), Paginated::default(), ())
+        .fetch_products(Query::default(), Paginated::default(), &ctx.db)
         .await?;
 
     assert_eq!(0, products.total);

--- a/modules/fundamental/src/product/model/details.rs
+++ b/modules/fundamental/src/product/model/details.rs
@@ -2,11 +2,10 @@ use crate::organization::model::OrganizationSummary;
 use crate::product::model::{ProductHead, ProductVersionHead};
 use crate::Error;
 use itertools::izip;
-use sea_orm::LoaderTrait;
 use sea_orm::ModelTrait;
+use sea_orm::{ConnectionTrait, LoaderTrait};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::labels::Labels;
 use trustify_entity::{organization, product, product_version, sbom};
 use utoipa::ToSchema;
@@ -21,22 +20,22 @@ pub struct ProductDetails {
 }
 
 impl ProductDetails {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         product: &product::Model,
         org: Option<organization::Model>,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let product_versions = product
             .find_related(product_version::Entity)
             .all(tx)
             .await?;
         let vendor = if let Some(org) = org {
-            Some(OrganizationSummary::from_entity(&org, tx).await?)
+            Some(OrganizationSummary::from_entity(&org).await?)
         } else {
             None
         };
         Ok(ProductDetails {
-            head: ProductHead::from_entity(product, tx).await?,
+            head: ProductHead::from_entity(product).await?,
             versions: ProductVersionDetails::from_entities(&product_versions, tx).await?,
             vendor,
         })
@@ -54,29 +53,28 @@ impl ProductVersionDetails {
     pub async fn from_entity(
         product_version: &product_version::Model,
         sbom: Option<sbom::Model>,
-        tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Self, Error> {
         let sbom = if let Some(sbom) = sbom {
-            Some(ProductSbomHead::from_entity(&sbom, tx).await?)
+            Some(ProductSbomHead::from_entity(&sbom).await?)
         } else {
             None
         };
 
         Ok(ProductVersionDetails {
-            head: ProductVersionHead::from_entity(product_version, tx).await?,
+            head: ProductVersionHead::from_entity(product_version).await?,
             sbom,
         })
     }
 
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         product_versions: &[product_version::Model],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut details = Vec::new();
         let sboms = product_versions.load_one(sbom::Entity, tx).await?;
 
         for (version, sbom) in izip!(product_versions, sboms) {
-            details.push(ProductVersionDetails::from_entity(version, sbom, tx).await?);
+            details.push(ProductVersionDetails::from_entity(version, sbom).await?);
         }
 
         Ok(details)
@@ -92,10 +90,7 @@ pub struct ProductSbomHead {
 }
 
 impl ProductSbomHead {
-    pub async fn from_entity(
-        sbom: &trustify_entity::sbom::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(sbom: &sbom::Model) -> Result<Self, Error> {
         Ok(ProductSbomHead {
             labels: sbom.labels.clone(),
             published: sbom.published,

--- a/modules/fundamental/src/product/model/mod.rs
+++ b/modules/fundamental/src/product/model/mod.rs
@@ -6,7 +6,6 @@ pub mod details;
 pub mod summary;
 
 use crate::Error;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::{product, product_version};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -18,10 +17,7 @@ pub struct ProductHead {
 }
 
 impl ProductHead {
-    pub async fn from_entity(
-        product: &product::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(product: &product::Model) -> Result<Self, Error> {
         Ok(ProductHead {
             id: product.id,
             name: product.name.clone(),
@@ -45,10 +41,7 @@ pub struct ProductVersionHead {
 }
 
 impl ProductVersionHead {
-    pub async fn from_entity(
-        product_version: &product_version::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(product_version: &product_version::Model) -> Result<Self, Error> {
         Ok(ProductVersionHead {
             id: product_version.id,
             version: product_version.version.clone(),
@@ -58,12 +51,11 @@ impl ProductVersionHead {
 
     pub async fn from_entities(
         product_versions: &[product_version::Model],
-        tx: &ConnectionOrTransaction<'_>,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
 
         for entity in product_versions {
-            heads.push(ProductVersionHead::from_entity(entity, tx).await?);
+            heads.push(ProductVersionHead::from_entity(entity).await?);
         }
 
         Ok(heads)

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -1,33 +1,32 @@
 use super::model::summary::ProductSummary;
-use crate::product::model::details::ProductDetails;
-use crate::Error;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-use trustify_common::db::limiter::LimiterTrait;
-use trustify_common::db::query::{Filtering, Query};
-use trustify_common::db::{Database, Transactional};
-use trustify_common::model::{Paginated, PaginatedResults};
+use crate::{product::model::details::ProductDetails, Error};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use trustify_common::{
+    db::{
+        limiter::LimiterTrait,
+        query::{Filtering, Query},
+    },
+    model::{Paginated, PaginatedResults},
+};
 use trustify_entity::product;
 use uuid::Uuid;
 
-pub struct ProductService {
-    db: Database,
-}
+#[derive(Default)]
+pub struct ProductService {}
 
 impl ProductService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new() -> Self {
+        Self {}
     }
 
-    pub async fn fetch_products<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn fetch_products<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,
         paginated: Paginated,
-        tx: TX,
+        connection: &C,
     ) -> Result<PaginatedResults<ProductSummary>, Error> {
-        let connection = self.db.connection(&tx);
-
         let limiter = product::Entity::find().filtering(search)?.limiting(
-            &connection,
+            connection,
             paginated.offset,
             paginated.limit,
         );
@@ -36,41 +35,37 @@ impl ProductService {
 
         Ok(PaginatedResults {
             total,
-            items: ProductSummary::from_entities(&limiter.fetch().await?, &connection).await?,
+            items: ProductSummary::from_entities(&limiter.fetch().await?, connection).await?,
         })
     }
 
-    pub async fn fetch_product<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn fetch_product<C: ConnectionTrait + Sync + Send>(
         &self,
         id: Uuid,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<ProductDetails>, Error> {
-        let connection = self.db.connection(&tx);
-
         if let Some(product) = product::Entity::find()
             .find_also_related(trustify_entity::organization::Entity)
             .filter(product::Column::Id.eq(id))
-            .one(&connection)
+            .one(connection)
             .await?
         {
             Ok(Some(
-                ProductDetails::from_entity(&product.0, product.1, &connection).await?,
+                ProductDetails::from_entity(&product.0, product.1, connection).await?,
             ))
         } else {
             Ok(None)
         }
     }
 
-    pub async fn delete_product<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn delete_product<C: ConnectionTrait + Sync + Send>(
         &self,
         id: Uuid,
-        tx: TX,
+        connection: &C,
     ) -> Result<u64, Error> {
-        let connection = self.db.connection(&tx);
-
         let query = product::Entity::delete_by_id(id);
 
-        let result = query.exec(&connection).await?;
+        let result = query.exec(connection).await?;
 
         Ok(result.rows_affected)
     }

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -10,59 +10,59 @@ use serde_json::Value;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::Transactional;
+use trustify_common::db::Database;
 use trustify_common::model::PaginatedResults;
 use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
 use trustify_test_context::{call::CallService, TrustifyContext};
 
-async fn setup(graph: &Graph) -> Result<(), anyhow::Error> {
+async fn setup(db: &Database, graph: &Graph) -> Result<(), anyhow::Error> {
     let log4j = graph
-        .ingest_package(&Purl::from_str("pkg:maven/org.apache/log4j")?, ())
+        .ingest_package(&Purl::from_str("pkg:maven/org.apache/log4j")?, db)
         .await?;
 
     let log4j_123 = log4j
-        .ingest_package_version(&Purl::from_str("pkg:maven/org.apache/log4j@1.2.3")?, ())
+        .ingest_package_version(&Purl::from_str("pkg:maven/org.apache/log4j@1.2.3")?, db)
         .await?;
 
     log4j_123
         .ingest_qualified_package(
             &Purl::from_str("pkg:maven/org.apache/log4j@1.2.3?jdk=11")?,
-            (),
+            db,
         )
         .await?;
 
     log4j_123
         .ingest_qualified_package(
             &Purl::from_str("pkg:maven/org.apache/log4j@1.2.3?jdk=17")?,
-            (),
+            db,
         )
         .await?;
 
     let log4j_345 = log4j
-        .ingest_package_version(&Purl::from_str("pkg:maven/org.apache/log4j@3.4.5")?, ())
+        .ingest_package_version(&Purl::from_str("pkg:maven/org.apache/log4j@3.4.5")?, db)
         .await?;
 
     log4j_345
         .ingest_qualified_package(
             &Purl::from_str("pkg:maven/org.apache/log4j@3.4.5?repository_url=http://jboss.org/")?,
-            (),
+            db,
         )
         .await?;
 
     log4j_345
         .ingest_qualified_package(
             &Purl::from_str("pkg:maven/org.apache/log4j@3.4.5?repository_url=http://jboss.org/")?,
-            (),
+            db,
         )
         .await?;
 
     let sendmail = graph
-        .ingest_package(&Purl::from_str("pkg:rpm/sendmail")?, ())
+        .ingest_package(&Purl::from_str("pkg:rpm/sendmail")?, db)
         .await?;
 
     let _sendmail_444 = sendmail
-        .ingest_package_version(&Purl::from_str("pkg:rpm/sendmail@4.4.4")?, ())
+        .ingest_package_version(&Purl::from_str("pkg:rpm/sendmail@4.4.4")?, db)
         .await?;
 
     Ok(())
@@ -71,7 +71,7 @@ async fn setup(graph: &Graph) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type";
@@ -99,7 +99,7 @@ async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn r#type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven";
@@ -130,7 +130,7 @@ async fn r#type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn type_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j";
@@ -161,7 +161,7 @@ async fn type_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
@@ -188,7 +188,7 @@ async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
@@ -218,7 +218,7 @@ async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
@@ -238,7 +238,7 @@ async fn version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn base(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/type/maven/org.apache/log4j";
@@ -257,7 +257,7 @@ async fn base(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn base_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl/base?q=log4j";
@@ -272,7 +272,7 @@ async fn base_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl?q=log4j";
@@ -287,7 +287,7 @@ async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    setup(&ctx.graph).await?;
+    setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
     let uri = "/api/v1/purl?q=type%3Dmaven";
@@ -304,10 +304,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
 async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingestor
         .graph()
-        .ingest_qualified_package(
-            &Purl::from_str("pkg:cargo/hyper@0.14.1")?,
-            Transactional::None,
-        )
+        .ingest_qualified_package(&Purl::from_str("pkg:cargo/hyper@0.14.1")?, &ctx.db)
         .await?;
 
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])

--- a/modules/fundamental/src/purl/model/details/base_purl.rs
+++ b/modules/fundamental/src/purl/model/details/base_purl.rs
@@ -1,9 +1,8 @@
 use crate::purl::model::summary::versioned_purl::VersionedPurlSummary;
 use crate::purl::model::BasePurlHead;
 use crate::Error;
-use sea_orm::ModelTrait;
+use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::{base_purl, versioned_purl};
 use utoipa::ToSchema;
 
@@ -15,14 +14,14 @@ pub struct BasePurlDetails {
 }
 
 impl BasePurlDetails {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         package: &base_purl::Model,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let package_versions = package.find_related(versioned_purl::Entity).all(tx).await?;
 
         Ok(Self {
-            head: BasePurlHead::from_entity(package, tx).await?,
+            head: BasePurlHead::from_entity(package).await?,
             versions: VersionedPurlSummary::from_entities_with_common_package(
                 package,
                 &package_versions,

--- a/modules/fundamental/src/purl/model/summary/base_purl.rs
+++ b/modules/fundamental/src/purl/model/summary/base_purl.rs
@@ -1,7 +1,6 @@
 use crate::purl::model::BasePurlHead;
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::base_purl;
 use utoipa::ToSchema;
 
@@ -12,15 +11,12 @@ pub struct BasePurlSummary {
 }
 
 impl BasePurlSummary {
-    pub async fn from_entities(
-        entities: &Vec<base_purl::Model>,
-        tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Vec<Self>, Error> {
+    pub async fn from_entities(entities: &Vec<base_purl::Model>) -> Result<Vec<Self>, Error> {
         let mut summaries = Vec::new();
 
         for entity in entities {
             summaries.push(BasePurlSummary {
-                head: BasePurlHead::from_entity(entity, tx).await?,
+                head: BasePurlHead::from_entity(entity).await?,
             })
         }
 

--- a/modules/fundamental/src/purl/model/summary/type.rs
+++ b/modules/fundamental/src/purl/model/summary/type.rs
@@ -1,8 +1,9 @@
 use crate::purl::model::TypeHead;
 use crate::Error;
-use sea_orm::{ColumnTrait, DeriveColumn, EntityTrait, EnumIter, QueryFilter, QuerySelect};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DeriveColumn, EntityTrait, EnumIter, QueryFilter, QuerySelect,
+};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::{base_purl, qualified_purl, versioned_purl};
 use utoipa::ToSchema;
 
@@ -21,9 +22,9 @@ pub struct TypeCounts {
 }
 
 impl TypeSummary {
-    pub async fn from_names(
+    pub async fn from_names<C: ConnectionTrait>(
         names: &Vec<String>,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
         enum QueryAs {

--- a/modules/fundamental/src/sbom/endpoints/label.rs
+++ b/modules/fundamental/src/sbom/endpoints/label.rs
@@ -1,6 +1,7 @@
 use crate::sbom::service::SbomService;
 use actix_web::{patch, put, web, HttpResponse, Responder};
 use trustify_auth::{authorizer::Require, UpdateSbom};
+use trustify_common::db::Database;
 use trustify_common::id::Id;
 use trustify_entity::labels::Labels;
 
@@ -51,12 +52,18 @@ pub async fn update(
 #[put("/v1/sbom/{id}/label")]
 pub async fn set(
     sbom: web::Data<SbomService>,
+    db: web::Data<Database>,
     id: web::Path<Id>,
     web::Json(labels): web::Json<Labels>,
     _: Require<UpdateSbom>,
 ) -> actix_web::Result<impl Responder> {
-    Ok(match sbom.set_labels(id.into_inner(), labels, ()).await? {
-        Some(()) => HttpResponse::NoContent(),
-        None => HttpResponse::NotFound(),
-    })
+    Ok(
+        match sbom
+            .set_labels(id.into_inner(), labels, db.as_ref())
+            .await?
+        {
+            Some(()) => HttpResponse::NoContent(),
+            None => HttpResponse::NotFound(),
+        },
+    )
 }

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -2,7 +2,6 @@ use crate::sbom::service::SbomService;
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::Transactional;
 use trustify_common::id::Id;
 use trustify_common::purl::Purl;
 use trustify_test_context::TrustifyContext;
@@ -23,9 +22,7 @@ async fn sbom_details_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let id_3_2_12 = results[3].id.clone();
 
-    let details = service
-        .fetch_sbom_details(id_3_2_12, Transactional::None)
-        .await?;
+    let details = service.fetch_sbom_details(id_3_2_12, &ctx.db).await?;
 
     assert!(details.is_some());
 
@@ -34,7 +31,7 @@ async fn sbom_details_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     log::debug!("{details:#?}");
 
     let details = service
-        .fetch_sbom_details(Id::Uuid(details.summary.head.id), Transactional::None)
+        .fetch_sbom_details(Id::Uuid(details.summary.head.id), &ctx.db)
         .await?;
 
     assert!(details.is_some());
@@ -64,7 +61,7 @@ async fn count_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 both.qualifier_uuid(),
                 one.qualifier_uuid(),
             ],
-            (),
+            &ctx.db,
         )
         .await?;
 

--- a/modules/fundamental/src/source_document/model/mod.rs
+++ b/modules/fundamental/src/source_document/model/mod.rs
@@ -1,7 +1,6 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::id::{Id, IdError};
 use trustify_entity::source_document;
 use trustify_module_storage::service::StorageKey;
@@ -16,10 +15,7 @@ pub struct SourceDocument {
 }
 
 impl SourceDocument {
-    pub async fn from_entity(
-        source_document: &source_document::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(source_document: &source_document::Model) -> Result<Self, Error> {
         Ok(Self {
             sha256: format!("sha256:{}", source_document.sha256),
             sha384: format!("sha384:{}", source_document.sha384),

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -7,19 +7,22 @@ use crate::{
         model::{VulnerabilityDetails, VulnerabilitySummary},
         service::VulnerabilityService,
     },
+    Error,
     Error::Internal,
 };
 use actix_web::{delete, get, web, HttpResponse, Responder};
+use sea_orm::TransactionTrait;
 use trustify_auth::{authorizer::Require, DeleteVulnerability, ReadAdvisory};
 use trustify_common::{
-    db::{query::Query, Database, Transactional},
+    db::{query::Query, Database},
     model::{Paginated, PaginatedResults},
 };
 
 pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
-    let service = VulnerabilityService::new(db);
+    let service = VulnerabilityService::new();
     config
         .app_data(web::Data::new(service))
+        .app_data(web::Data::new(db))
         .service(all)
         .service(delete)
         .service(get);
@@ -40,6 +43,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 /// List vulnerabilities
 pub async fn all(
     state: web::Data<VulnerabilityService>,
+    db: web::Data<Database>,
     web::Query(search): web::Query<Query>,
     web::Query(paginated): web::Query<Paginated>,
     web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
@@ -47,7 +51,7 @@ pub async fn all(
 ) -> actix_web::Result<impl Responder> {
     Ok(HttpResponse::Ok().json(
         state
-            .fetch_vulnerabilities(search, paginated, deprecated, Transactional::None)
+            .fetch_vulnerabilities(search, paginated, deprecated, db.as_ref())
             .await?,
     ))
 }
@@ -67,12 +71,13 @@ pub async fn all(
 /// Retrieve vulnerability details
 pub async fn get(
     state: web::Data<VulnerabilityService>,
+    db: web::Data<Database>,
     id: web::Path<String>,
     web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
     _: Require<ReadAdvisory>,
 ) -> actix_web::Result<impl Responder> {
     let vuln = state
-        .fetch_vulnerability(&id, deprecated, Transactional::None)
+        .fetch_vulnerability(&id, deprecated, db.as_ref())
         .await?;
     if let Some(vuln) = vuln {
         Ok(HttpResponse::Ok().json(vuln))
@@ -96,26 +101,32 @@ pub async fn get(
 /// Delete vulnerability
 pub async fn delete(
     state: web::Data<VulnerabilityService>,
+    db: web::Data<Database>,
     id: web::Path<String>,
     _: Require<DeleteVulnerability>,
-) -> actix_web::Result<impl Responder> {
+) -> Result<impl Responder, Error> {
+    let tx = db.begin().await?;
+
     let vuln = state
         // we ignore deprecated advisories, as we delete the vulnerability anyway.
         .fetch_vulnerability(
             &id,
             trustify_module_ingestor::common::Deprecation::Ignore,
-            Transactional::None,
+            &tx,
         )
         .await?;
 
     if let Some(vuln) = vuln {
         let rows_affected = state
-            .delete_vulnerability(&vuln.head.identifier, ())
+            .delete_vulnerability(&vuln.head.identifier, &tx)
             .await?;
         match rows_affected {
             0 => Ok(HttpResponse::NotFound().finish()),
-            1 => Ok(HttpResponse::Ok().json(vuln)),
-            _ => Err(Internal("Unexpected number of rows affected".into()).into()),
+            1 => {
+                tx.commit().await?;
+                Ok(HttpResponse::Ok().json(vuln))
+            }
+            _ => Err(Internal("Unexpected number of rows affected".into())),
         }
     } else {
         Ok(HttpResponse::NotFound().finish())

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -6,15 +6,14 @@ use serde_json::Value;
 use test_context::test_context;
 use test_log::test;
 use time::{macros::datetime, OffsetDateTime};
-use trustify_common::db::Transactional;
-use trustify_common::hashing::Digests;
-use trustify_common::model::PaginatedResults;
+use trustify_common::{hashing::Digests, model::PaginatedResults};
 use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
     PrivilegesRequired, Scope, UserInteraction,
 };
-use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
-use trustify_module_ingestor::graph::vulnerability::VulnerabilityInformation;
+use trustify_module_ingestor::graph::{
+    advisory::AdvisoryInformation, vulnerability::VulnerabilityInformation,
+};
 use trustify_test_context::{call::CallService, TrustifyContext};
 
 #[test_context(TrustifyContext)]
@@ -37,12 +36,12 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let advisory_vuln = advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
     advisory_vuln
         .ingest_cvss3_score(
@@ -57,7 +56,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
                 i: Integrity::None,
                 a: Availability::None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -76,16 +75,20 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     advisory
-        .link_to_vulnerability("CVE-345", None, Transactional::None)
+        .link_to_vulnerability("CVE-345", None, &ctx.db)
         .await?;
 
-    ctx.graph.ingest_vulnerability("CVE-123", (), ()).await?;
-    ctx.graph.ingest_vulnerability("CVE-345", (), ()).await?;
+    ctx.graph
+        .ingest_vulnerability("CVE-123", (), &ctx.db)
+        .await?;
+    ctx.graph
+        .ingest_vulnerability("CVE-345", (), &ctx.db)
+        .await?;
 
     let uri = "/api/v1/vulnerability";
 
@@ -121,12 +124,12 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let advisory_vuln = advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
 
     advisory_vuln
@@ -142,7 +145,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 i: Integrity::High,
                 a: Availability::Low,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -161,12 +164,12 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     advisory
-        .link_to_vulnerability("CVE-345", None, Transactional::None)
+        .link_to_vulnerability("CVE-345", None, &ctx.db)
         .await?;
 
     ctx.graph
@@ -180,7 +183,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 withdrawn: None,
                 cwes: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -216,12 +219,12 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     let advisory_vuln = advisory
-        .link_to_vulnerability("CVE-123", None, Transactional::None)
+        .link_to_vulnerability("CVE-123", None, &ctx.db)
         .await?;
 
     advisory_vuln
@@ -237,7 +240,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 i: Integrity::High,
                 a: Availability::Low,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -256,12 +259,12 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 modified: None,
                 withdrawn: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 
     advisory
-        .link_to_vulnerability("CVE-345", None, Transactional::None)
+        .link_to_vulnerability("CVE-345", None, &ctx.db)
         .await?;
 
     ctx.graph
@@ -275,7 +278,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 withdrawn: None,
                 cwes: None,
             },
-            (),
+            &ctx.db,
         )
         .await?;
 

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -3,9 +3,9 @@ mod vulnerability_advisory;
 pub use vulnerability_advisory::*;
 
 use crate::{vulnerability::model::VulnerabilityHead, Error};
-use sea_orm::ModelTrait;
+use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
-use trustify_common::{db::ConnectionOrTransaction, memo::Memo};
+use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
 use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
@@ -29,10 +29,10 @@ pub struct VulnerabilityDetails {
 }
 
 impl VulnerabilityDetails {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         deprecation: Deprecation,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let advisory_vulnerabilities = vulnerability
             .find_related(advisory_vulnerability::Entity)

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -7,8 +7,9 @@ use crate::{
 use ::cpe::cpe::Cpe;
 use ::cpe::uri::OwnedUri;
 use sea_orm::{
-    ColumnTrait, DbErr, EntityTrait, FromQueryResult, IntoIdentity, LoaderTrait, ModelTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, RelationTrait, Select,
+    ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, IntoIdentity, LoaderTrait,
+    ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, QueryResult, QuerySelect, RelationTrait,
+    Select,
 };
 use sea_query::{Asterisk, Expr, Func, IntoCondition, JoinType, NullOrdering, SimpleExpr};
 use serde::{Deserialize, Serialize};
@@ -17,17 +18,16 @@ use trustify_common::{
     cpe::CpeCompare,
     db::{
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
-        ConnectionOrTransaction, VersionMatches,
+        VersionMatches,
     },
     memo::Memo,
     purl::Purl,
 };
 use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
-use trustify_entity::{self as entity};
 use trustify_entity::{
-    advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization, purl_status,
-    qualified_purl, sbom, sbom_node, sbom_package, sbom_package_cpe_ref, sbom_package_purl_ref,
-    status, version_range, versioned_purl, vulnerability,
+    self as entity, advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization,
+    purl_status, qualified_purl, sbom, sbom_node, sbom_package, sbom_package_cpe_ref,
+    sbom_package_purl_ref, status, version_range, versioned_purl, vulnerability,
 };
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -43,10 +43,10 @@ pub struct VulnerabilityAdvisoryHead {
 }
 
 impl VulnerabilityAdvisoryHead {
-    pub async fn from_entity(
+    pub async fn from_entity<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         advisory_vulnerability: &advisory_vulnerability::Model,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let cvss3 = cvss3::Entity::find()
             .filter(cvss3::Column::AdvisoryId.eq(advisory_vulnerability.advisory_id))
@@ -74,11 +74,11 @@ impl VulnerabilityAdvisoryHead {
             Err(Error::Data("Underlying advisory is missing".to_string()))
         }
     }
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         vuln_advisories: &[advisory::Model],
         vuln_cvss3s: &[cvss3::Model],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let mut heads = Vec::new();
 
@@ -127,11 +127,11 @@ pub struct VulnerabilityAdvisorySummary {
 }
 
 impl VulnerabilityAdvisorySummary {
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         vulnerability: &vulnerability::Model,
         advisory_vulnerabilities: &[advisory_vulnerability::Model],
         vuln_cvss3: &[cvss3::Model],
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let purl_status_query = purl_status::Entity::find()
             .left_join(status::Entity)
@@ -304,7 +304,6 @@ impl VulnerabilityAdvisorySummary {
                 purls: VulnerabilityAdvisoryStatus::from_models(
                     purl_statuses,
                     vuln_product_statuses.iter(),
-                    tx,
                 )
                 .await?,
                 sboms: VulnerabilitySbomStatus::from_models(
@@ -443,7 +442,6 @@ impl VulnerabilityAdvisoryStatus {
     >(
         purls: I,
         products: J,
-        _tx: &ConnectionOrTransaction<'_>,
     ) -> Result<HashMap<String, Vec<Self>>, Error> {
         let mut statuses = HashMap::new();
 
@@ -614,14 +612,15 @@ pub struct VulnerabilitySbomStatus {
 }
 
 impl VulnerabilitySbomStatus {
-    async fn from_models<'i, 'j, I, J>(
+    async fn from_models<'i, 'j, I, J, C>(
         sbom_purl_status: I,
         products: J,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error>
     where
         I: Iterator<Item = &'i SbomStatusCatcher> + Clone,
         J: Iterator<Item = &'j ProductStatusCatcher> + Clone,
+        C: ConnectionTrait,
     {
         let mut sboms = HashMap::new();
 

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -3,13 +3,12 @@ mod summary;
 
 use async_graphql::SimpleObject;
 pub use details::*;
-use sea_orm::{ColumnTrait, ModelTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, ModelTrait, QueryFilter};
 pub use summary::*;
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::memo::Memo;
 use trustify_entity::{advisory_vulnerability, vulnerability, vulnerability_description};
 use utoipa::ToSchema;
@@ -68,10 +67,10 @@ pub struct VulnerabilityHead {
 }
 
 impl VulnerabilityHead {
-    pub async fn from_vulnerability_entity(
+    pub async fn from_vulnerability_entity<C: ConnectionTrait>(
         entity: &vulnerability::Model,
         description: Memo<vulnerability_description::Model>,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Self, Error> {
         let description = match description {
             Memo::Provided(inner) => inner.map(|inner| inner.description),

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -2,9 +2,8 @@ use crate::{
     vulnerability::model::{VulnerabilityAdvisoryHead, VulnerabilityHead},
     Error,
 };
-use sea_orm::{ColumnTrait, EntityTrait, LoaderTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::{
@@ -31,11 +30,11 @@ pub struct VulnerabilitySummary {
 }
 
 impl VulnerabilitySummary {
-    pub async fn from_entities(
+    pub async fn from_entities<C: ConnectionTrait>(
         vulnerabilities: &[vulnerability::Model],
         averages: &[(Option<f64>, Option<Severity>)],
         deprecation: Deprecation,
-        tx: &ConnectionOrTransaction<'_>,
+        tx: &C,
     ) -> Result<Vec<Self>, Error> {
         let advisories = vulnerabilities
             .load_many_to_many(

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -9,7 +9,6 @@ use trustify_common::{
         limiter::LimiterAsModelTrait,
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         query::{Columns, Filtering, Query},
-        Database, Transactional,
     },
     model::{Paginated, PaginatedResults},
 };
@@ -19,24 +18,21 @@ use trustify_entity::{
 };
 use trustify_module_ingestor::common::Deprecation;
 
-pub struct VulnerabilityService {
-    db: Database,
-}
+#[derive(Default)]
+pub struct VulnerabilityService {}
 
 impl VulnerabilityService {
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new() -> Self {
+        Self {}
     }
 
-    pub async fn fetch_vulnerabilities<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn fetch_vulnerabilities<C: ConnectionTrait + Sync + Send>(
         &self,
         search: Query,
         paginated: Paginated,
         deprecation: Deprecation,
-        tx: TX,
+        connection: &C,
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
-        let connection = self.db.connection(&tx);
-
         let inner_query = vulnerability::Entity::find()
             .left_join(cvss3::Entity)
             .expr_as_(
@@ -102,7 +98,7 @@ impl VulnerabilityService {
                     }),
             )?
             .try_limiting_as_multi_model::<VulnerabilityCatcher>(
-                &connection,
+                connection,
                 paginated.offset,
                 paginated.limit,
             )?;
@@ -124,42 +120,38 @@ impl VulnerabilityService {
                 &vulnerabilities,
                 &averages,
                 deprecation,
-                &connection,
+                connection,
             )
             .await?,
         })
     }
 
-    pub async fn fetch_vulnerability<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn fetch_vulnerability<C: ConnectionTrait + Sync + Send>(
         &self,
         identifier: &str,
         deprecation: Deprecation,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<VulnerabilityDetails>, Error> {
-        let connection = self.db.connection(&tx);
-
         if let Some(vulnerability) = vulnerability::Entity::find_by_id(identifier)
-            .one(&connection)
+            .one(connection)
             .await?
         {
             Ok(Some(
-                VulnerabilityDetails::from_entity(&vulnerability, deprecation, &connection).await?,
+                VulnerabilityDetails::from_entity(&vulnerability, deprecation, connection).await?,
             ))
         } else {
             Ok(None)
         }
     }
 
-    pub async fn delete_vulnerability<TX: AsRef<Transactional> + Sync + Send>(
+    pub async fn delete_vulnerability<C: ConnectionTrait + Sync + Send>(
         &self,
         id: &str,
-        tx: TX,
+        connection: &C,
     ) -> Result<u64, Error> {
-        let connection = self.db.connection(&tx);
-
         let query = vulnerability::Entity::delete_by_id(id);
 
-        let result = query.exec(&connection).await?;
+        let result = query.exec(connection).await?;
 
         Ok(result.rows_affected)
     }

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -5,7 +5,6 @@ use crate::vulnerability::service::VulnerabilityService;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::query::{q, Query};
-use trustify_common::db::Transactional;
 use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
 use trustify_test_context::TrustifyContext;
@@ -13,7 +12,7 @@ use trustify_test_context::TrustifyContext;
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let service = VulnerabilityService::new();
 
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
         .await?;
@@ -23,7 +22,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
             Query::default(),
             Paginated::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -42,13 +41,13 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let service = VulnerabilityService::new();
 
     ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
         .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2021-32714", Default::default(), Transactional::None)
+        .fetch_vulnerability("CVE-2021-32714", Default::default(), &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -88,7 +87,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let service = VulnerabilityService::new();
 
     ctx.ingest_documents([
         "cve/CVE-2024-29025.json",
@@ -99,7 +98,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     .await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), Transactional::None)
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -116,7 +115,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let vuln_service = VulnerabilityService::new(ctx.db.clone());
+    let vuln_service = VulnerabilityService::new();
     let sbom_service = SbomService::new(ctx.db.clone());
 
     // Ingest a CVE declaring the vulnerability present in versions
@@ -133,9 +132,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let sat_id = ingest_results[1].id.clone();
 
-    let sat_sbom = sbom_service
-        .fetch_sbom_details(sat_id, Transactional::None)
-        .await?;
+    let sat_sbom = sbom_service.fetch_sbom_details(sat_id, &ctx.db).await?;
     assert!(sat_sbom.is_some());
 
     let sat_sbom = sat_sbom.unwrap();
@@ -157,9 +154,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let quarkus_id = ingest_results[3].id.clone();
 
-    let quarkus_sbom = sbom_service
-        .fetch_sbom_details(quarkus_id, Transactional::None)
-        .await?;
+    let quarkus_sbom = sbom_service.fetch_sbom_details(quarkus_id, &ctx.db).await?;
 
     assert!(quarkus_sbom.is_some());
 
@@ -169,7 +164,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(quarkus_sbom.advisories.is_empty());
 
     let vuln = vuln_service
-        .fetch_vulnerability("CVE-2024-26308", Default::default(), Transactional::None)
+        .fetch_vulnerability("CVE-2024-26308", Default::default(), &ctx.db)
         .await?
         .unwrap();
 
@@ -209,9 +204,9 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let vuln_service = VulnerabilityService::new(ctx.db.clone());
+    let vuln_service = VulnerabilityService::new();
     let sbom_service = SbomService::new(ctx.db.clone());
-    let purl_service = PurlService::new(ctx.db.clone());
+    let purl_service = PurlService::new();
 
     let ingest_results = ctx
         .ingest_documents([
@@ -222,9 +217,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let quarkus_id = ingest_results[1].id.clone();
 
-    let quarkus_sbom = sbom_service
-        .fetch_sbom_details(quarkus_id, Transactional::None)
-        .await?;
+    let quarkus_sbom = sbom_service.fetch_sbom_details(quarkus_id, &ctx.db).await?;
 
     assert!(quarkus_sbom.is_some());
 
@@ -239,7 +232,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(quarkus_adv.vulnerability.identifier, "CVE-2023-0044");
 
     let vuln = vuln_service
-        .fetch_vulnerability("CVE-2023-0044", Default::default(), Transactional::None)
+        .fetch_vulnerability("CVE-2023-0044", Default::default(), &ctx.db)
         .await?;
 
     assert!(vuln.is_some());
@@ -290,7 +283,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .purl_by_purl(
             &Purl::try_from("pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004")?,
             Default::default(),
-            Transactional::None,
+            &ctx.db,
         )
         .await?;
 
@@ -311,12 +304,12 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let service = VulnerabilityService::new();
 
     ctx.ingest_documents(["cve/CVE-2024-29025.json"]).await?;
 
     let vuln = service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), ())
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
         .await?
         .expect("Vulnerability not found");
 
@@ -324,15 +317,15 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 
     let id = &vuln.advisories[0].head.head.identifier;
 
-    let affected = service.delete_vulnerability(id, ()).await?;
+    let affected = service.delete_vulnerability(id, &ctx.db).await?;
     assert_eq!(1, affected);
 
     assert!(service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), ())
+        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
         .await?
         .is_none());
 
-    let affected = service.delete_vulnerability(id, ()).await?;
+    let affected = service.delete_vulnerability(id, &ctx.db).await?;
     assert_eq!(0, affected);
 
     Ok(())
@@ -341,7 +334,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
 async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let service = VulnerabilityService::new(ctx.db.clone());
+    let service = VulnerabilityService::new();
 
     ctx.ingest_documents([
         "csaf/CVE-2023-20862.json",
@@ -351,7 +344,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     .await?;
 
     let vulns = service
-        .fetch_vulnerabilities(q(""), Paginated::default(), Default::default(), ())
+        .fetch_vulnerabilities(q(""), Paginated::default(), Default::default(), &ctx.db)
         .await?;
     assert_eq!(5, vulns.items.len());
     let vulns = service
@@ -359,7 +352,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
             q("average_score>9"),
             Paginated::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
     assert_eq!(1, vulns.items.len());
@@ -369,7 +362,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
             q("average_severity=critical"),
             Paginated::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
     assert_eq!(1, vulns.items.len());
@@ -379,7 +372,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
             q("average_severity<high"),
             Paginated::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
     assert_eq!(1, vulns.items.len());
@@ -392,12 +385,17 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
             q("average_severity>=high"),
             Paginated::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
     assert_eq!(4, vulns.items.len());
     let vulns = service
-        .fetch_vulnerabilities(q("20862"), Paginated::default(), Default::default(), ())
+        .fetch_vulnerabilities(
+            q("20862"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-20862");

--- a/modules/fundamental/src/weakness/model.rs
+++ b/modules/fundamental/src/weakness/model.rs
@@ -1,6 +1,5 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use trustify_common::db::ConnectionOrTransaction;
 use trustify_entity::weakness;
 use utoipa::ToSchema;
 
@@ -17,22 +16,16 @@ pub struct WeaknessSummary {
 }
 
 impl WeaknessSummary {
-    pub async fn from_entities(
-        entities: &[weakness::Model],
-        tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Vec<Self>, Error> {
+    pub async fn from_entities(entities: &[weakness::Model]) -> Result<Vec<Self>, Error> {
         let mut summaries = Vec::new();
         for each in entities {
-            summaries.push(Self::from_entity(each, tx).await?)
+            summaries.push(Self::from_entity(each).await?)
         }
 
         Ok(summaries)
     }
 
-    pub async fn from_entity(
-        entity: &weakness::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(entity: &weakness::Model) -> Result<Self, Error> {
         Ok(Self {
             head: WeaknessHead {
                 id: entity.id.clone(),
@@ -59,10 +52,7 @@ pub struct WeaknessDetails {
 }
 
 impl WeaknessDetails {
-    pub async fn from_entity(
-        entity: &weakness::Model,
-        _tx: &ConnectionOrTransaction<'_>,
-    ) -> Result<Self, Error> {
+    pub async fn from_entity(entity: &weakness::Model) -> Result<Self, Error> {
         Ok(Self {
             head: WeaknessHead {
                 id: entity.id.clone(),

--- a/modules/fundamental/src/weakness/service/mod.rs
+++ b/modules/fundamental/src/weakness/service/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     weakness::model::{WeaknessDetails, WeaknessSummary},
     Error,
 };
-use sea_orm::{EntityTrait, TransactionTrait};
+use sea_orm::EntityTrait;
 use trustify_common::{
     db::{
         limiter::LimiterTrait,
@@ -27,9 +27,6 @@ impl WeaknessService {
         query: Query,
         paginated: Paginated,
     ) -> Result<PaginatedResults<WeaknessSummary>, Error> {
-        let tx = self.db.begin().await?;
-        let tx = (&tx).into();
-
         let limiter = weakness::Entity::find().filtering(query)?.limiting(
             &self.db,
             paginated.offset,
@@ -40,17 +37,14 @@ impl WeaknessService {
         let items = limiter.fetch().await?;
 
         Ok(PaginatedResults {
-            items: WeaknessSummary::from_entities(&items, &tx).await?,
+            items: WeaknessSummary::from_entities(&items).await?,
             total,
         })
     }
 
     pub async fn get_weakness(&self, id: &str) -> Result<Option<WeaknessDetails>, Error> {
-        let tx = self.db.begin().await?;
-        let tx = (&tx).into();
-
         if let Some(found) = weakness::Entity::find_by_id(id).one(&self.db).await? {
-            Ok(Some(WeaknessDetails::from_entity(&found, &tx).await?))
+            Ok(Some(WeaknessDetails::from_entity(&found).await?))
         } else {
             Ok(None)
         }

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -30,22 +30,22 @@ async fn simple(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = AdvisoryService::new(ctx.db.clone());
     service
-        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // now test, find only one, for either ignore or consider
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 
     assert_eq!(v.advisories.len(), 1);
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -70,14 +70,14 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = AdvisoryService::new(ctx.db.clone());
     service
-        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // check info
 
-    let service = PurlService::new(ctx.db.clone());
+    let service = PurlService::new();
     let purls = service
-        .purls(Default::default(), Default::default(), ())
+        .purls(Default::default(), Default::default(), &ctx.db)
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
@@ -105,7 +105,7 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, ())
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must find something");
 

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -26,9 +26,9 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Default::default(), ())
+        .fetch_vulnerability("CVE-2023-33201", Default::default(), &ctx.db)
         .await?
         .expect("must exist");
 
@@ -51,9 +51,9 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info - non-deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -61,9 +61,9 @@ async fn change_ps_num_advisories(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info - with-deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2023-33201", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -86,9 +86,9 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let service = PurlService::new(ctx.db.clone());
+    let service = PurlService::new();
     let purls = service
-        .purls(Default::default(), Default::default(), ())
+        .purls(Default::default(), Default::default(), &ctx.db)
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
@@ -121,7 +121,7 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, ())
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must find something");
 
@@ -167,9 +167,9 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let service = PurlService::new(ctx.db.clone());
+    let service = PurlService::new();
     let purls = service
-        .purls(Default::default(), Default::default(), ())
+        .purls(Default::default(), Default::default(), &ctx.db)
         .await?;
 
     // pkg:rpm/redhat/eap7-bouncycastle-util@1.76.0-4.redhat_00001.1.el9eap?arch=noarch
@@ -202,7 +202,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, ())
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, &ctx.db)
         .await?
         .expect("must find something");
 

--- a/modules/fundamental/tests/advisory/cve/delete.rs
+++ b/modules/fundamental/tests/advisory/cve/delete.rs
@@ -13,7 +13,7 @@ use trustify_test_context::TrustifyContext;
 async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = twice(ctx, |cve| cve, update_mark_rejected).await?;
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
 
     // must be changed
 
@@ -23,13 +23,13 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = AdvisoryService::new(ctx.db.clone());
     service
-        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // check info
 
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -42,7 +42,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check with deprecated, should be the same result
 
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/cve/reingest.rs
+++ b/modules/fundamental/tests/advisory/cve/reingest.rs
@@ -17,9 +17,9 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Default::default(), ())
+        .fetch_vulnerability("CVE-2021-32714", Default::default(), &ctx.db)
         .await?
         .expect("must exist");
 
@@ -42,9 +42,9 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check without deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -56,9 +56,9 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check with deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2021-32714", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/osv/delete.rs
+++ b/modules/fundamental/tests/advisory/osv/delete.rs
@@ -13,7 +13,7 @@ use trustify_test_context::TrustifyContext;
 async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let (r1, r2) = twice(ctx, update_unmark_fixed, update_mark_fixed_again).await?;
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
 
     // must be changed
 
@@ -23,13 +23,13 @@ async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let service = AdvisoryService::new(ctx.db.clone());
     service
-        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), ())
+        .delete_advisory(r2.id.try_as_uid().expect("must be a UUID variant"), &ctx.db)
         .await?;
 
     // check info
 
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -38,7 +38,7 @@ async fn fixed(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // check with deprecated, should be the same result
 
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -21,9 +21,9 @@ async fn equal(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check info
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Default::default(), ())
+        .fetch_vulnerability("CVE-2020-5238", Default::default(), &ctx.db)
         .await?
         .expect("must exist");
 
@@ -46,9 +46,9 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check without deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, ())
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Ignore, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -58,9 +58,9 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check with deprecated
 
-    let vuln = VulnerabilityService::new(ctx.db.clone());
+    let vuln = VulnerabilityService::new();
     let v = vuln
-        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, ())
+        .fetch_vulnerability("CVE-2020-5238", Deprecation::Consider, &ctx.db)
         .await?
         .expect("must exist");
 
@@ -71,9 +71,9 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // check status
 
-    let service = PurlService::new(ctx.db.clone());
+    let service = PurlService::new();
     let purls = service
-        .purls(Default::default(), Default::default(), ())
+        .purls(Default::default(), Default::default(), &ctx.db)
         .await?;
 
     let purl = purls
@@ -98,7 +98,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, ())
+        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, &ctx.db)
         .await?
         .expect("must find something");
 

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -63,7 +63,7 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     let sbom = &result.files["spdx/quarkus-bom-2.13.8.Final-redhat-00004.json.bz2"];
     assert!(matches!(sbom.id, Id::Uuid(_)));
 
-    let sbom_summary = service.fetch_sbom_summary(sbom.id.clone(), ()).await?;
+    let sbom_summary = service.fetch_sbom_summary(sbom.id.clone(), &ctx.db).await?;
     assert!(sbom_summary.is_some());
     let sbom_summary = sbom_summary.unwrap();
     assert_eq!(sbom_summary.head.name, "quarkus-bom");

--- a/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/cpe.rs
@@ -15,7 +15,7 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .describes_packages(
             result.id.try_as_uid().expect("Must be a UID"),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -40,7 +40,7 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .describes_packages(
             result.id.try_as_uid().expect("Must be a UID"),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -65,7 +65,7 @@ async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .describes_packages(
             result.id.try_as_uid().expect("Must be a UID"),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -82,7 +82,7 @@ async fn simple_comp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             result.id.try_as_uid().expect("Must be a UID"),
             Default::default(),
             Default::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -55,13 +55,13 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_ne!(result1.id, result2.id);
 
     let mut sbom1 = sbom
-        .fetch_sbom_details(result1.id, ())
+        .fetch_sbom_details(result1.id, &ctx.db)
         .await?
         .expect("v1 must be found");
     log::info!("SBOM1: {sbom1:?}");
 
     let mut sbom2 = sbom
-        .fetch_sbom_details(result2.id, ())
+        .fetch_sbom_details(result2.id, &ctx.db)
         .await?
         .expect("v2 must be found");
     log::info!("SBOM2: {sbom2:?}");
@@ -89,7 +89,7 @@ async fn quarkus(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Purl::from_str(purl).expect("must parse").qualifier_uuid(),
             Paginated::default(),
             Query::default(),
-            (),
+            &ctx.db,
         )
         .await?;
 
@@ -129,13 +129,13 @@ async fn nhc(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_ne!(result1.id, result2.id);
 
     let mut sbom1 = sbom
-        .fetch_sbom_details(result1.id, ())
+        .fetch_sbom_details(result1.id, &ctx.db)
         .await?
         .expect("v1 must be found");
     log::info!("SBOM1: {sbom1:?}");
 
     let mut sbom2 = sbom
-        .fetch_sbom_details(result2.id, ())
+        .fetch_sbom_details(result2.id, &ctx.db)
         .await?
         .expect("v2 must be found");
     log::info!("SBOM2: {sbom2:?}");
@@ -182,13 +182,13 @@ async fn nhc_same(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(result1.id, result2.id);
 
     let mut sbom1 = sbom
-        .fetch_sbom_details(result1.id, ())
+        .fetch_sbom_details(result1.id, &ctx.db)
         .await?
         .expect("v1 must be found");
     log::info!("SBOM1: {sbom1:?}");
 
     let mut sbom2 = sbom
-        .fetch_sbom_details(result2.id, ())
+        .fetch_sbom_details(result2.id, &ctx.db)
         .await?
         .expect("v2 must be found");
     log::info!("SBOM2: {sbom2:?}");
@@ -249,13 +249,13 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_ne!(result1.id, result2.id);
 
     let mut sbom1 = sbom
-        .fetch_sbom_details(result1.id, ())
+        .fetch_sbom_details(result1.id, &ctx.db)
         .await?
         .expect("v1 must be found");
     log::info!("SBOM1: {sbom1:?}");
 
     let mut sbom2 = sbom
-        .fetch_sbom_details(result2.id, ())
+        .fetch_sbom_details(result2.id, &ctx.db)
         .await?
         .expect("v2 must be found");
     log::info!("SBOM2: {sbom2:?}");
@@ -306,13 +306,13 @@ async fn syft_rerun(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_ne!(result1.id, result2.id);
 
     let mut sbom1 = sbom
-        .fetch_sbom_details(result1.id, ())
+        .fetch_sbom_details(result1.id, &ctx.db)
         .await?
         .expect("v1 must be found");
     log::info!("SBOM1: {sbom1:?}");
 
     let mut sbom2 = sbom
-        .fetch_sbom_details(result2.id, ())
+        .fetch_sbom_details(result2.id, &ctx.db)
         .await?
         .expect("v2 must be found");
     log::info!("SBOM2: {sbom2:?}");

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -2,7 +2,7 @@ use super::*;
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
-use trustify_common::{db::Transactional, model::Paginated};
+use trustify_common::model::Paginated;
 use trustify_module_fundamental::sbom::model::SbomPackage;
 use trustify_test_context::TrustifyContext;
 
@@ -15,7 +15,7 @@ async fn ingest_spdx_medium(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         "openshift-container-storage-4.8.z.json.xz",
         |WithContext { service, sbom, .. }| async move {
             let described = service
-                .describes_packages(sbom.sbom.sbom_id, Default::default(), ())
+                .describes_packages(sbom.sbom.sbom_id, Default::default(), &ctx.db)
                 .await?;
 
             log::debug!("{:#?}", described);
@@ -39,7 +39,7 @@ async fn ingest_spdx_medium(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
                         offset: 0,
                         limit: 1,
                     },
-                    (),
+                    &ctx.db,
                 )
                 .await?;
             assert_eq!(1, packages.items.len());
@@ -61,7 +61,7 @@ async fn ingest_spdx_large(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         "openshift-4.13.json.xz",
         |WithContext { service, sbom, .. }| async move {
             let described = service
-                .describes_packages(sbom.sbom.sbom_id, Default::default(), Transactional::None)
+                .describes_packages(sbom.sbom.sbom_id, Default::default(), &ctx.db)
                 .await?;
             log::debug!("{:#?}", described);
             assert_eq!(1, described.items.len());
@@ -85,7 +85,7 @@ async fn ingest_spdx_medium_cpes(ctx: &TrustifyContext) -> Result<(), anyhow::Er
         "rhel-br-9.2.0.json.xz",
         |WithContext { service, sbom, .. }| async move {
             let described = service
-                .describes_packages(sbom.sbom.sbom_id, Default::default(), ())
+                .describes_packages(sbom.sbom.sbom_id, Default::default(), &ctx.db)
                 .await?;
 
             log::debug!("{:#?}", described);
@@ -109,7 +109,7 @@ async fn ingest_spdx_medium_cpes(ctx: &TrustifyContext) -> Result<(), anyhow::Er
                         offset: 0,
                         limit: 1,
                     },
-                    (),
+                    &ctx.db,
                 )
                 .await?;
             assert_eq!(1, packages.items.len());

--- a/modules/graphql/src/advisory.rs
+++ b/modules/graphql/src/advisory.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{Context, FieldError, FieldResult, Object};
-use trustify_common::db::Transactional;
+use trustify_common::db::Database;
 use trustify_entity::advisory::Model as Advisory;
 use trustify_module_ingestor::graph::Graph;
 use uuid::Uuid;
@@ -12,8 +12,9 @@ pub struct AdvisoryQuery;
 #[Object]
 impl AdvisoryQuery {
     async fn get_advisory_by_id<'a>(&self, ctx: &Context<'a>, id: Uuid) -> FieldResult<Advisory> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
-        let advisory = graph.get_advisory_by_id(id, Transactional::None).await;
+        let advisory = graph.get_advisory_by_id(id, db.as_ref()).await;
 
         match advisory {
             Ok(Some(advisory)) => Ok(Advisory {
@@ -36,10 +37,11 @@ impl AdvisoryQuery {
     }
 
     async fn get_advisories<'a>(&self, ctx: &Context<'a>) -> FieldResult<Vec<Advisory>> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
 
         let advisories = graph
-            .get_advisories(Default::default(), Transactional::None)
+            .get_advisories(Default::default(), db.as_ref())
             .await
             .unwrap_or_default();
 

--- a/modules/graphql/src/organization.rs
+++ b/modules/graphql/src/organization.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
-
 use async_graphql::{Context, FieldError, FieldResult, Object};
-use trustify_common::db::Transactional;
+use std::sync::Arc;
+use trustify_common::db::Database;
 use trustify_entity::organization::Model as Organization;
 use trustify_module_ingestor::graph::Graph;
 
@@ -15,10 +14,9 @@ impl OrganizationQuery {
         ctx: &Context<'a>,
         name: String,
     ) -> FieldResult<Organization> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
-        let organization = graph
-            .get_organization_by_name(name, Transactional::None)
-            .await;
+        let organization = graph.get_organization_by_name(name, db.as_ref()).await;
 
         match organization {
             Ok(Some(organization)) => Ok(Organization {

--- a/modules/graphql/src/sbom.rs
+++ b/modules/graphql/src/sbom.rs
@@ -1,9 +1,7 @@
-use std::sync::Arc;
-
 use async_graphql::{Context, FieldError, FieldResult, Object};
-use trustify_common::db::Transactional;
-use trustify_entity::labels::Labels;
-use trustify_entity::sbom::Model as Sbom;
+use std::sync::Arc;
+use trustify_common::db::Database;
+use trustify_entity::{labels::Labels, sbom::Model as Sbom};
 use trustify_module_ingestor::graph::Graph;
 use uuid::Uuid;
 
@@ -13,8 +11,9 @@ pub struct SbomQuery;
 #[Object]
 impl SbomQuery {
     async fn get_sbom_by_id<'a>(&self, ctx: &Context<'a>, id: Uuid) -> FieldResult<Sbom> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
-        let sbom = graph.locate_sbom_by_id(id, Transactional::None).await;
+        let sbom = graph.locate_sbom_by_id(id, db.as_ref()).await;
 
         match sbom {
             Ok(Some(sbom_context)) => Ok(Sbom {
@@ -37,6 +36,7 @@ impl SbomQuery {
         ctx: &Context<'a>,
         labels: String,
     ) -> FieldResult<Vec<Sbom>> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
 
         let mut local_labels = Labels::new();
@@ -50,7 +50,7 @@ impl SbomQuery {
         }
 
         let sboms = graph
-            .locate_sboms_by_labels(local_labels, Transactional::None)
+            .locate_sboms_by_labels(local_labels, db.as_ref())
             .await
             .unwrap_or_default();
 

--- a/modules/graphql/src/sbomstatus.rs
+++ b/modules/graphql/src/sbomstatus.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Context, FieldResult, Object, SimpleObject};
 use std::{ops::Deref, sync::Arc};
 use trustify_common::{
-    db::{self, Transactional},
+    db::{self},
     id::Id,
 };
 use trustify_module_fundamental::{
@@ -30,7 +30,7 @@ impl SbomStatusQuery {
         let sbom_service = SbomService::new(db.deref().clone());
 
         let sbom_details: Option<SbomDetails> = sbom_service
-            .fetch_sbom_details(Id::Uuid(id), Transactional::None)
+            .fetch_sbom_details(Id::Uuid(id), db.as_ref())
             .await
             .unwrap_or_default();
 

--- a/modules/graphql/src/vulnerability.rs
+++ b/modules/graphql/src/vulnerability.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
-
 use async_graphql::{Context, FieldError, FieldResult, Object};
-use trustify_common::db::Transactional;
+use std::sync::Arc;
+use trustify_common::db::Database;
 use trustify_entity::vulnerability::Model as Vulnerability;
 use trustify_module_ingestor::graph::Graph;
 
@@ -15,10 +14,9 @@ impl VulnerabilityQuery {
         ctx: &Context<'a>,
         identifier: String,
     ) -> FieldResult<Vulnerability> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
-        let vulnerability = graph
-            .get_vulnerability(&identifier, Transactional::None)
-            .await;
+        let vulnerability = graph.get_vulnerability(&identifier, db.as_ref()).await;
 
         match vulnerability {
             Ok(Some(vulnerability)) => Ok(Vulnerability {
@@ -36,9 +34,10 @@ impl VulnerabilityQuery {
     }
 
     async fn get_vulnerabilities<'a>(&self, ctx: &Context<'a>) -> FieldResult<Vec<Vulnerability>> {
+        let db = ctx.data::<Arc<Database>>()?;
         let graph = ctx.data::<Arc<Graph>>()?;
         let vulnerabilities = graph
-            .get_vulnerabilities(Transactional::None)
+            .get_vulnerabilities(db.as_ref())
             .await
             .unwrap_or_default();
 

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -1,8 +1,11 @@
 use crate::graph::{advisory::AdvisoryContext, error::Error, vulnerability::VulnerabilityContext};
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoIdentity, NotSet, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoIdentity, NotSet, QueryFilter,
+    Set,
+};
 use sea_query::{Condition, Expr, IntoCondition};
 use tracing::instrument;
-use trustify_common::{cpe::Cpe, db::Transactional, purl::Purl};
+use trustify_common::{cpe::Cpe, purl::Purl};
 use trustify_cvss::cvss3::Cvss3Base;
 use trustify_entity::{
     self as entity, cvss3::Severity, purl_status, status, version_range,
@@ -130,25 +133,25 @@ impl<'g> From<(&AdvisoryContext<'g>, entity::advisory_vulnerability::Model)>
 }
 
 impl<'g> AdvisoryVulnerabilityContext<'g> {
-    pub async fn vulnerability<TX: AsRef<Transactional>>(
+    pub async fn vulnerability<C: ConnectionTrait>(
         &self,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<VulnerabilityContext>, Error> {
         Ok(
             vulnerability::Entity::find_by_id(&self.advisory_vulnerability.vulnerability_id)
-                .one(&self.advisory.graph.connection(&tx))
+                .one(connection)
                 .await?
                 .map(|vuln| VulnerabilityContext::new(self.advisory.graph, vuln)),
         )
     }
 
     /*
-    pub async fn get_fixed_package_version<TX: AsRef<Transactional>>(
+    pub async fn get_fixed_package_version<C: ConnectionTrait>(
         &self,
         purl: &Purl,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<FixedPackageVersionContext>, Error> {
-        if let Some(package_version) = self.advisory.graph.get_package_version(purl, &tx).await? {
+        if let Some(package_version) = self.advisory.graph.get_package_version(purl, connection).await? {
             Ok(entity::fixed_package_version::Entity::find()
                 .filter(
                     entity::fixed_package_version::Column::AdvisoryId.eq(self.advisory.advisory.id),
@@ -157,7 +160,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::fixed_package_version::Column::PackageVersionId
                         .eq(package_version.package_version.id),
                 )
-                .one(&self.advisory.graph.connection(&tx))
+                .one(&self.advisory.graph.connection(connection))
                 .await?
                 .map(|affected| FixedPackageVersionContext::new(self, affected)))
         } else {
@@ -165,12 +168,12 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn get_not_affected_package_version<TX: AsRef<Transactional>>(
+    pub async fn get_not_affected_package_version<C: ConnectionTrait>(
         &self,
         purl: &Purl,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<NotAffectedPackageVersionContext>, Error> {
-        if let Some(package_version) = self.advisory.graph.get_package_version(purl, &tx).await? {
+        if let Some(package_version) = self.advisory.graph.get_package_version(purl, connection).await? {
             Ok(entity::not_affected_package_version::Entity::find()
                 .filter(
                     entity::not_affected_package_version::Column::AdvisoryId
@@ -180,7 +183,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::not_affected_package_version::Column::PackageVersionId
                         .eq(package_version.package_version.id),
                 )
-                .one(&self.advisory.graph.connection(&tx))
+                .one(&self.advisory.graph.connection(connection))
                 .await?
                 .map(|not_affected_package_version| {
                     NotAffectedPackageVersionContext::new(self, not_affected_package_version)
@@ -190,17 +193,17 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn get_affected_package_range<TX: AsRef<Transactional>>(
+    pub async fn get_affected_package_range<C: ConnectionTrait>(
         &self,
         purl: &Purl,
         start: &str,
         end: &str,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<AffectedPackageVersionRangeContext>, Error> {
         if let Some(package_version_range) = self
             .advisory
             .graph
-            .get_package_version_range(purl, start, end, &tx)
+            .get_package_version_range(purl, start, end, connection)
             .await?
         {
             Ok(entity::affected_package_version_range::Entity::find()
@@ -212,7 +215,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     entity::affected_package_version_range::Column::PackageVersionRangeId
                         .eq(package_version_range.package_version_range.id),
                 )
-                .one(&self.advisory.graph.connection(&tx))
+                .one(&self.advisory.graph.connection(connection))
                 .await?
                 .map(|affected| AffectedPackageVersionRangeContext::new(self, affected)))
         } else {
@@ -220,19 +223,19 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         }
     }
 
-    pub async fn ingest_not_affected_package_version<TX: AsRef<Transactional>>(
+    pub async fn ingest_not_affected_package_version<C: ConnectionTrait>(
         &self,
         purl: &Purl,
-        tx: TX,
+        connection: &C,
     ) -> Result<NotAffectedPackageVersionContext, Error> {
-        if let Some(found) = self.get_not_affected_package_version(purl, &tx).await? {
+        if let Some(found) = self.get_not_affected_package_version(purl, connection).await? {
             return Ok(found);
         }
 
         let package_version = self
             .advisory
             .graph
-            .ingest_package_version(purl, &tx)
+            .ingest_package_version(purl, connection)
             .await?;
 
         let entity = entity::not_affected_package_version::ActiveModel {
@@ -244,23 +247,23 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok(NotAffectedPackageVersionContext::new(
             self,
-            entity.insert(&self.advisory.graph.connection(&tx)).await?,
+            entity.insert(&self.advisory.graph.connection(connection)).await?,
         ))
     }
 
-    pub async fn ingest_fixed_package_version<TX: AsRef<Transactional>>(
+    pub async fn ingest_fixed_package_version<C: ConnectionTrait>(
         &self,
         purl: &Purl,
-        tx: TX,
+        connection: &C,
     ) -> Result<FixedPackageVersionContext, Error> {
-        if let Some(found) = self.get_fixed_package_version(purl, &tx).await? {
+        if let Some(found) = self.get_fixed_package_version(purl, connection).await? {
             return Ok(found);
         }
 
         let package_version = self
             .advisory
             .graph
-            .ingest_package_version(purl, &tx)
+            .ingest_package_version(purl, connection)
             .await?;
 
         let entity = entity::fixed_package_version::ActiveModel {
@@ -272,30 +275,28 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok(FixedPackageVersionContext::new(
             self,
-            entity.insert(&self.advisory.graph.connection(&tx)).await?,
+            entity.insert(&self.advisory.graph.connection(connection)).await?,
         ))
     }
 
      */
 
-    #[instrument(skip(self, tx), ret)]
-    pub async fn ingest_package_status<TX: AsRef<Transactional>>(
+    #[instrument(skip(self, connection), ret)]
+    pub async fn ingest_package_status<C: ConnectionTrait>(
         &self,
         cpe_context: Option<Cpe>,
         purl: &Purl,
         status: &str,
         info: VersionInfo,
-        tx: TX,
+        connection: &C,
     ) -> Result<(), Error> {
-        let connection = self.advisory.graph.connection(&tx);
-
         let status = status::Entity::find()
             .filter(status::Column::Slug.eq(status))
-            .one(&connection)
+            .one(connection)
             .await?
             .ok_or(Error::InvalidStatus(status.to_string()))?;
 
-        let package = self.advisory.graph.ingest_package(purl, &tx).await?;
+        let package = self.advisory.graph.ingest_package(purl, connection).await?;
 
         let package_status = purl_status::Entity::find()
             .filter(purl_status::Column::BasePurlId.eq(package.base_purl.id))
@@ -303,7 +304,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             .filter(purl_status::Column::StatusId.eq(status.id))
             .left_join(version_range::Entity)
             .filter(info.clone().into_condition())
-            .one(&connection)
+            .one(connection)
             .await?;
 
         if package_status.is_some() {
@@ -312,7 +313,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         let version_range = info.into_active_model();
 
-        let version_range = version_range.insert(&connection).await?;
+        let version_range = version_range.insert(connection).await?;
 
         let package_status = purl_status::ActiveModel {
             id: Default::default(),
@@ -324,22 +325,22 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             context_cpe_id: NotSet,
         };
 
-        package_status.insert(&connection).await?;
+        package_status.insert(connection).await?;
 
         Ok(())
     }
 
     /*
     #[instrument(skip(self, tx), err)]
-    pub async fn ingest_affected_package_range<TX: AsRef<Transactional>>(
+    pub async fn ingest_affected_package_range<C: ConnectionTrait>(
         &self,
         purl: &Purl,
         start: &str,
         end: &str,
-        tx: TX,
+        connection: &C,
     ) -> Result<AffectedPackageVersionRangeContext, Error> {
         if let Some(found) = self
-            .get_affected_package_range(purl, start, end, &tx)
+            .get_affected_package_range(purl, start, end, connection)
             .await?
         {
             return Ok(found);
@@ -348,7 +349,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
         let package_version_range = self
             .advisory
             .graph
-            .ingest_package_version_range(purl, start, end, &tx)
+            .ingest_package_version_range(purl, start, end, connection)
             .await?;
 
         let entity = entity::affected_package_version_range::ActiveModel {
@@ -360,15 +361,15 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
 
         Ok(AffectedPackageVersionRangeContext::new(
             self,
-            entity.insert(&self.advisory.graph.connection(&tx)).await?,
+            entity.insert(&self.advisory.graph.connection(connection)).await?,
         ))
     }
 
      */
 
-    pub async fn cvss3_scores<TX: AsRef<Transactional>>(
+    pub async fn cvss3_scores<C: ConnectionTrait>(
         &self,
-        tx: TX,
+        connection: &C,
     ) -> Result<Vec<Cvss3Base>, Error> {
         Ok(entity::cvss3::Entity::find()
             .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
@@ -376,17 +377,17 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                 entity::cvss3::Column::VulnerabilityId
                     .eq(self.advisory_vulnerability.vulnerability_id.clone()),
             )
-            .all(&self.advisory.graph.connection(&tx))
+            .all(connection)
             .await?
             .drain(..)
             .map(|e| e.into())
             .collect())
     }
 
-    pub async fn get_cvss3_score<TX: AsRef<Transactional>>(
+    pub async fn get_cvss3_score<C: ConnectionTrait>(
         &self,
         minor_version: u8,
-        tx: TX,
+        connection: &C,
     ) -> Result<Option<Cvss3Base>, Error> {
         Ok(entity::cvss3::Entity::find()
             .filter(entity::cvss3::Column::AdvisoryId.eq(self.advisory_vulnerability.advisory_id))
@@ -395,18 +396,21 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
                     .eq(self.advisory_vulnerability.vulnerability_id.clone()),
             )
             .filter(entity::cvss3::Column::MinorVersion.eq(minor_version as i32))
-            .one(&self.advisory.graph.connection(&tx))
+            .one(connection)
             .await?
             .map(|cvss| cvss.into()))
     }
 
-    #[instrument(skip(self, tx), err)]
-    pub async fn ingest_cvss3_score<TX: AsRef<Transactional>>(
+    #[instrument(skip(self, connection), err)]
+    pub async fn ingest_cvss3_score<C: ConnectionTrait>(
         &self,
         cvss3: Cvss3Base,
-        tx: TX,
+        connection: &C,
     ) -> Result<Cvss3Base, Error> {
-        if let Some(found) = self.get_cvss3_score(cvss3.minor_version, &tx).await? {
+        if let Some(found) = self
+            .get_cvss3_score(cvss3.minor_version, connection)
+            .await?
+        {
             return Ok(found);
         }
 
@@ -426,10 +430,7 @@ impl<'g> AdvisoryVulnerabilityContext<'g> {
             severity: Set(Severity::from(cvss3.score().roundup().severity())),
         };
 
-        Ok(model
-            .insert(&self.advisory.graph.connection(&tx))
-            .await?
-            .into())
+        Ok(model.insert(connection).await?.into())
     }
 }
 
@@ -441,7 +442,6 @@ mod test {
     use crate::graph::Graph;
     use test_context::test_context;
     use test_log::test;
-    use trustify_common::db::Transactional;
     use trustify_common::hashing::Digests;
     use trustify_test_context::TrustifyContext;
 
@@ -450,8 +450,7 @@ mod test {
     async fn advisory_affected_vulnerability_assertions(
         ctx: TrustifyContext,
     ) -> Result<(), anyhow::Error> {
-        let db = ctx.db;
-        let system = Graph::new(db);
+        let system = Graph::new(ctx.db.clone());
 
         let advisory = system
             .ingest_advisory(
@@ -459,12 +458,12 @@ mod test {
                 ("source", "http://db.com/rhsa-ghsa-2"),
                 &Digests::digest("RHSA-GHSA-1"),
                 (),
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
         let advisory_vulnerability = advisory
-            .link_to_vulnerability("CVE-42", None, Transactional::None)
+            .link_to_vulnerability("CVE-42", None, &ctx.db)
             .await?;
 
         advisory_vulnerability
@@ -479,7 +478,7 @@ mod test {
                         Version::Exclusive("1.2.0".to_string()),
                     ),
                 },
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
@@ -492,7 +491,7 @@ mod test {
                     scheme: VersionScheme::Semver,
                     spec: VersionSpec::Exact("1.1.9".to_string()),
                 },
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
@@ -513,8 +512,7 @@ mod test {
     async fn advisory_not_affected_vulnerability_assertions(
         ctx: TrustifyContext,
     ) -> Result<(), anyhow::Error> {
-        let db = ctx.db;
-        let system = Graph::new(db);
+        let system = Graph::new(ctx.db.clone());
 
         let advisory = system
             .ingest_advisory(
@@ -522,12 +520,12 @@ mod test {
                 ("source", "http://db.com/rhsa-ghsa-2"),
                 &Digests::digest("RHSA-GHSA-1"),
                 (),
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
         let advisory_vulnerability = advisory
-            .link_to_vulnerability("INTERAL-77", None, Transactional::None)
+            .link_to_vulnerability("INTERAL-77", None, &ctx.db)
             .await?;
 
         advisory_vulnerability
@@ -542,7 +540,7 @@ mod test {
                         Version::Exclusive("1.2.0".to_string()),
                     ),
                 },
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
@@ -555,7 +553,7 @@ mod test {
                     scheme: VersionScheme::Semver,
                     spec: VersionSpec::Exact("1.1.9".to_string()),
                 },
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 

--- a/modules/ingestor/src/graph/cpe.rs
+++ b/modules/ingestor/src/graph/cpe.rs
@@ -6,59 +6,56 @@ use std::{
     fmt::{Debug, Formatter},
 };
 use tracing::instrument;
-use trustify_common::{
-    cpe::Cpe,
-    db::{chunk::EntityChunkedIter, Transactional},
-};
+use trustify_common::{cpe::Cpe, db::chunk::EntityChunkedIter};
 use trustify_entity::cpe;
 use uuid::Uuid;
 
 impl Graph {
-    pub async fn get_cpe<C: Into<Cpe>, TX: AsRef<Transactional>>(
+    pub async fn get_cpe<C: ConnectionTrait>(
         &self,
-        cpe: C,
-        tx: TX,
+        cpe: impl Into<Cpe>,
+        connection: &C,
     ) -> Result<Option<CpeContext>, Error> {
         let cpe = cpe.into();
 
         let query = cpe::Entity::find_by_id(cpe.uuid());
 
-        if let Some(found) = query.one(&self.connection(&tx)).await? {
+        if let Some(found) = query.one(connection).await? {
             Ok(Some((self, found).into()))
         } else {
             Ok(None)
         }
     }
 
-    pub async fn get_cpe_by_query<TX: AsRef<Transactional>>(
+    pub async fn get_cpe_by_query<C: ConnectionTrait>(
         &self,
         query: SelectStatement,
-        tx: TX,
+        connection: &C,
     ) -> Result<Vec<CpeContext>, Error> {
         Ok(cpe::Entity::find()
             .filter(cpe::Column::Id.in_subquery(query))
-            .all(&self.connection(&tx))
+            .all(connection)
             .await?
             .into_iter()
             .map(|cpe22| (self, cpe22).into())
             .collect())
     }
 
-    #[instrument(skip(self, tx), err(level=tracing::Level::INFO))]
-    pub async fn ingest_cpe22<C, TX>(&self, cpe: C, tx: TX) -> Result<CpeContext, Error>
-    where
-        C: Into<Cpe> + Debug,
-        TX: AsRef<Transactional>,
-    {
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
+    pub async fn ingest_cpe22<C: ConnectionTrait>(
+        &self,
+        cpe: impl Into<Cpe> + Debug,
+        connection: &C,
+    ) -> Result<CpeContext, Error> {
         let cpe = cpe.into();
 
-        if let Some(found) = self.get_cpe(cpe.clone(), &tx).await? {
+        if let Some(found) = self.get_cpe(cpe.clone(), connection).await? {
             return Ok(found);
         }
 
         let entity: cpe::ActiveModel = cpe.into();
 
-        Ok((self, entity.insert(&self.connection(&tx)).await?).into())
+        Ok((self, entity.insert(connection).await?).into())
     }
 }
 
@@ -129,13 +126,12 @@ mod test {
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn ingest_cpe(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-        let db = ctx.db;
-        let graph = Graph::new(db);
+        let graph = Graph::new(ctx.db.clone());
 
         let cpe = Cpe::from_str("cpe:/a:redhat:enterprise_linux:9::crb")?;
 
-        let c1 = graph.ingest_cpe22(cpe.clone(), ()).await?;
-        let c2 = graph.ingest_cpe22(cpe, ()).await?;
+        let c1 = graph.ingest_cpe22(cpe.clone(), &ctx.db).await?;
+        let c2 = graph.ingest_cpe22(cpe, &ctx.db).await?;
 
         assert_eq!(c1.cpe.id, c2.cpe.id);
 

--- a/modules/ingestor/src/graph/mod.rs
+++ b/modules/ingestor/src/graph/mod.rs
@@ -7,10 +7,8 @@ pub mod purl;
 pub mod sbom;
 pub mod vulnerability;
 
-use sea_orm::{DbErr, TransactionTrait};
+use sea_orm::DbErr;
 use std::fmt::Debug;
-use tracing::instrument;
-use trustify_common::db::{ConnectionOrTransaction, Transactional};
 
 #[derive(Debug, Clone)]
 pub struct Graph {
@@ -28,35 +26,5 @@ pub enum Error<E: Send> {
 impl Graph {
     pub fn new(db: trustify_common::db::Database) -> Self {
         Self { db }
-    }
-
-    /// Create a `Transactional::Some(_)` with a new transaction.
-    ///
-    /// The transaction will be rolled-back unless explicitly `commit()`'d before
-    /// it drops.
-    #[instrument]
-    pub async fn transaction(&self) -> Result<Transactional, error::Error> {
-        Ok(Transactional::Some(self.db.begin().await?))
-    }
-
-    pub fn connection<'db, TX: AsRef<Transactional>>(
-        &'db self,
-        tx: &'db TX,
-    ) -> ConnectionOrTransaction {
-        match tx.as_ref() {
-            Transactional::None => ConnectionOrTransaction::Connection(&self.db),
-            Transactional::Some(tx) => ConnectionOrTransaction::Transaction(tx),
-        }
-    }
-
-    pub async fn close(self) -> anyhow::Result<()> {
-        self.db.close().await
-    }
-
-    /// Ping the database.
-    ///
-    /// Intended to be used for health checks.
-    pub async fn ping(&self) -> anyhow::Result<()> {
-        self.db.ping().await
     }
 }

--- a/modules/ingestor/src/graph/purl/qualified_package.rs
+++ b/modules/ingestor/src/graph/purl/qualified_package.rs
@@ -1,15 +1,14 @@
 //! Support for a *fully-qualified* package.
 
-use crate::graph::error::Error;
-use crate::graph::purl::package_version::PackageVersionContext;
-use crate::graph::sbom::SbomContext;
-use std::collections::BTreeMap;
-use std::fmt::{Debug, Formatter};
-use std::hash::{Hash, Hasher};
-use trustify_common::db::Transactional;
+use crate::graph::{error::Error, purl::package_version::PackageVersionContext, sbom::SbomContext};
+use sea_orm::ConnectionTrait;
+use std::{
+    collections::BTreeMap,
+    fmt::{Debug, Formatter},
+    hash::{Hash, Hasher},
+};
 use trustify_common::purl::Purl;
-use trustify_entity as entity;
-use trustify_entity::qualified_purl;
+use trustify_entity::{self as entity, qualified_purl};
 
 #[derive(Clone)]
 pub struct QualifiedPackageContext<'g> {
@@ -59,9 +58,9 @@ impl<'g> QualifiedPackageContext<'g> {
             qualified_package,
         }
     }
-    pub async fn sboms_containing<TX: AsRef<Transactional>>(
+    pub async fn sboms_containing<C: ConnectionTrait>(
         &self,
-        _tx: TX,
+        _connection: &C,
     ) -> Result<Vec<SbomContext>, Error> {
         /*
         Ok(entity::sbom::Entity::find()

--- a/modules/ingestor/src/graph/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/graph/sbom/clearly_defined.rs
@@ -1,23 +1,20 @@
 use crate::graph::purl::creator::PurlCreator;
 use crate::graph::sbom::{LicenseCreator, LicenseInfo, SbomContext, SbomInformation};
-use sea_orm::{EntityTrait, Set};
+use sea_orm::{ConnectionTrait, EntityTrait, Set};
 use sea_query::OnConflict;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::instrument;
-use trustify_common::db::Transactional;
 use trustify_common::purl::Purl;
 use trustify_entity::purl_license_assertion;
 
 impl SbomContext {
-    #[instrument(skip(tx, curation), err)]
-    pub async fn ingest_clearly_defined_curation<TX: AsRef<Transactional>>(
+    #[instrument(skip(db, curation), err)]
+    pub async fn ingest_clearly_defined_curation<C: ConnectionTrait>(
         &self,
         curation: Curation,
-        tx: TX,
+        db: &C,
     ) -> Result<(), anyhow::Error> {
-        let db = &self.graph.db.connection(&tx);
-
         let mut purls = PurlCreator::new();
         let mut licenses = LicenseCreator::new();
 

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -3,13 +3,14 @@
 use crate::common::{Deprecation, DeprecationExt};
 use crate::{graph::advisory::AdvisoryContext, graph::error::Error, graph::Graph};
 use sea_orm::{
-    ActiveValue::Set, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QuerySelect, RelationTrait,
+    ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter,
+    QuerySelect, RelationTrait,
 };
 use sea_query::{JoinType, OnConflict};
 use std::fmt::{Debug, Formatter};
 use time::OffsetDateTime;
 use tracing::instrument;
-use trustify_common::db::{chunk::EntityChunkedIter, Transactional};
+use trustify_common::db::chunk::EntityChunkedIter;
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 use uuid::Uuid;
 
@@ -48,15 +49,14 @@ impl From<()> for VulnerabilityInformation {
 }
 
 impl Graph {
-    #[instrument(skip(self, tx), err(level=tracing::Level::INFO))]
-    pub async fn ingest_vulnerability(
+    #[instrument(skip(self, db), err(level=tracing::Level::INFO))]
+    pub async fn ingest_vulnerability<C: ConnectionTrait>(
         &self,
         identifier: &str,
         information: impl Into<VulnerabilityInformation> + Debug,
-        tx: impl AsRef<Transactional>,
+        db: &C,
     ) -> Result<VulnerabilityContext, Error> {
         let information = information.into();
-        let db = self.connection(&tx);
 
         let mut on_conflict = OnConflict::columns([vulnerability::Column::Id]);
         let on_conflict = match information.has_data() {
@@ -88,31 +88,31 @@ impl Graph {
 
         let result = vulnerability::Entity::insert(entity)
             .on_conflict(on_conflict)
-            .exec_with_returning(&db)
+            .exec_with_returning(db)
             .await?;
 
         Ok(VulnerabilityContext::new(self, result))
     }
 
-    #[instrument(skip(self, tx), err(level=tracing::Level::INFO))]
-    pub async fn get_vulnerability(
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
+    pub async fn get_vulnerability<C: ConnectionTrait>(
         &self,
         identifier: &str,
-        tx: impl AsRef<Transactional>,
+        connection: &C,
     ) -> Result<Option<VulnerabilityContext>, Error> {
         Ok(vulnerability::Entity::find_by_id(identifier)
-            .one(&self.connection(&tx))
+            .one(connection)
             .await?
             .map(|vuln| VulnerabilityContext::new(self, vuln)))
     }
 
-    #[instrument(skip(self, tx), err(level=tracing::Level::INFO))]
-    pub async fn get_vulnerabilities<TX: AsRef<Transactional>>(
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
+    pub async fn get_vulnerabilities<C: ConnectionTrait>(
         &self,
-        tx: TX,
+        connection: &C,
     ) -> Result<Vec<VulnerabilityContext>, Error> {
         Ok(vulnerability::Entity::find()
-            .all(&self.connection(&tx))
+            .all(connection)
             .await?
             .into_iter()
             .map(|vulnerability| VulnerabilityContext::new(self, vulnerability))
@@ -140,10 +140,10 @@ impl VulnerabilityContext {
         }
     }
 
-    pub async fn advisories<TX: AsRef<Transactional>>(
+    pub async fn advisories<C: ConnectionTrait>(
         &self,
         deprecation: Deprecation,
-        tx: TX,
+        connection: &C,
     ) -> Result<Vec<AdvisoryContext>, Error> {
         Ok(advisory::Entity::find()
             .with_deprecation(deprecation)
@@ -154,29 +154,29 @@ impl VulnerabilityContext {
             .filter(
                 advisory_vulnerability::Column::VulnerabilityId.eq(self.vulnerability.id.clone()),
             )
-            .all(&self.graph.connection(&tx))
+            .all(connection)
             .await?
             .drain(0..)
             .map(|advisory| AdvisoryContext::new(&self.graph, advisory))
             .collect())
     }
 
-    pub async fn add_description<TX: AsRef<Transactional>>(
+    pub async fn add_description<C: ConnectionTrait>(
         &self,
         advisory: Uuid,
         lang: &str,
         description: &str,
-        tx: TX,
+        connection: &C,
     ) -> Result<(), Error> {
-        self.add_descriptions(advisory, [(lang, description)], tx)
+        self.add_descriptions(advisory, [(lang, description)], connection)
             .await
     }
 
-    pub async fn add_descriptions<TX: AsRef<Transactional>>(
+    pub async fn add_descriptions<C: ConnectionTrait>(
         &self,
         advisory: Uuid,
         descriptions: impl IntoIterator<Item = (&str, &str)>,
-        tx: TX,
+        connection: &C,
     ) -> Result<(), Error> {
         let entries = descriptions.into_iter().map(|(lang, description)| {
             vulnerability_description::ActiveModel {
@@ -188,43 +188,39 @@ impl VulnerabilityContext {
             }
         });
 
-        let db = self.graph.connection(&tx);
-
         for batch in &entries.chunked() {
             vulnerability_description::Entity::insert_many(batch)
-                .exec(&db)
+                .exec(connection)
                 .await?;
         }
 
         Ok(())
     }
 
-    pub async fn drop_descriptions_for_advisory<TX: AsRef<Transactional>>(
+    pub async fn drop_descriptions_for_advisory<C: ConnectionTrait>(
         &self,
         advisory: Uuid,
-        tx: TX,
+        connection: &C,
     ) -> Result<(), Error> {
-        let db = self.graph.connection(&tx);
-
         vulnerability_description::Entity::delete_many()
             .filter(vulnerability_description::Column::AdvisoryId.eq(advisory))
-            .exec(&db)
+            .exec(connection)
             .await?;
 
         Ok(())
     }
 
     // Get all descriptions for a vulnerability
-    pub async fn descriptions<TX: AsRef<Transactional>>(
+    pub async fn descriptions<C: ConnectionTrait>(
         &self,
         lang: &str,
-        tx: TX,
+        connection: &C,
     ) -> Result<Vec<String>, Error> {
         Ok(self
             .vulnerability
             .find_related(vulnerability_description::Entity)
             .filter(vulnerability_description::Column::Lang.eq(lang))
-            .all(&self.graph.connection(&tx))
+            .all(connection)
             .await?
             .drain(..)
             .map(|e| e.description)
@@ -238,32 +234,22 @@ mod tests {
     use crate::graph::Graph;
     use test_context::test_context;
     use test_log::test;
-    use trustify_common::db::Transactional;
     use trustify_common::hashing::Digests;
     use trustify_test_context::TrustifyContext;
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]
     async fn ingest_cves(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
-        let db = ctx.db;
-        let system = Graph::new(db);
+        let system = Graph::new(ctx.db.clone());
 
-        let cve1 = system
-            .ingest_vulnerability("CVE-123", (), Transactional::None)
-            .await?;
-        let cve2 = system
-            .ingest_vulnerability("CVE-123", (), Transactional::None)
-            .await?;
-        let cve3 = system
-            .ingest_vulnerability("CVE-456", (), Transactional::None)
-            .await?;
+        let cve1 = system.ingest_vulnerability("CVE-123", (), &ctx.db).await?;
+        let cve2 = system.ingest_vulnerability("CVE-123", (), &ctx.db).await?;
+        let cve3 = system.ingest_vulnerability("CVE-456", (), &ctx.db).await?;
 
         assert_eq!(cve1.vulnerability.id, cve2.vulnerability.id);
         assert_ne!(cve1.vulnerability.id, cve3.vulnerability.id);
 
-        let not_found = system
-            .get_vulnerability("CVE-NOT_FOUND", Transactional::None)
-            .await?;
+        let not_found = system.get_vulnerability("CVE-NOT_FOUND", &ctx.db).await?;
 
         assert!(not_found.is_none());
 
@@ -280,7 +266,7 @@ mod tests {
                 ("source", "http://ghsa.io/GHSA-1"),
                 &Digests::digest("GHSA-1"),
                 (),
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
@@ -291,7 +277,7 @@ mod tests {
                 ("source", "http://rhsa.io/RHSA-1"),
                 &Digests::digest("RHSA-1"),
                 (),
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
@@ -302,34 +288,29 @@ mod tests {
                 ("source", "http://snyk.io/SNYK-1"),
                 &Digests::digest("SNYK-1"),
                 (),
-                Transactional::None,
+                &ctx.db,
             )
             .await?;
 
         advisory1
-            .link_to_vulnerability("CVE-8675309", None, Transactional::None)
+            .link_to_vulnerability("CVE-8675309", None, &ctx.db)
             .await?;
 
         advisory2
-            .link_to_vulnerability("CVE-8675309", None, Transactional::None)
+            .link_to_vulnerability("CVE-8675309", None, &ctx.db)
             .await?;
 
         ctx.graph
-            .ingest_vulnerability("CVE-8675309", (), Transactional::None)
+            .ingest_vulnerability("CVE-8675309", (), &ctx.db)
             .await?;
 
-        let cve = ctx
-            .graph
-            .get_vulnerability("CVE-8675309", Transactional::None)
-            .await?;
+        let cve = ctx.graph.get_vulnerability("CVE-8675309", &ctx.db).await?;
 
         assert!(cve.is_some(), "there should be some CVE");
 
         let cve = cve.unwrap();
 
-        let linked_advisories = cve
-            .advisories(Default::default(), Transactional::None)
-            .await?;
+        let linked_advisories = cve.advisories(Default::default(), &ctx.db).await?;
 
         assert_eq!(2, linked_advisories.len());
 

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -198,21 +198,24 @@ impl IngestorService {
 
         match fmt {
             Format::SPDX | Format::CycloneDX => {
-                let analysis_service = AnalysisService::new(self.graph.db.clone());
+                let analysis_service = AnalysisService::new();
                 if result.id.to_string().starts_with("urn:uuid:") {
                     match analysis_service // TODO: today we chop off 'urn:uuid:' prefix using .split_off on result.id
-                        .load_graphs(vec![result.id.to_string().split_off("urn:uuid:".len())], ())
+                        .load_graphs(
+                            vec![result.id.to_string().split_off("urn:uuid:".len())],
+                            &self.graph.db,
+                        )
                         .await
                     {
                         Ok(_) => log::debug!(
-                        "Analysis graph for sbom: {} loaded successfully.",
-                        result.id.value()
-                    ),
+                            "Analysis graph for sbom: {} loaded successfully.",
+                            result.id.value()
+                        ),
                         Err(e) => log::warn!(
-                        "Error loading sbom {} into analysis graph : {}",
-                        result.id.value(),
-                        e
-                    ),
+                            "Error loading sbom {} into analysis graph : {}",
+                            result.id.value(),
+                            e
+                        ),
                     }
                 }
             }

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -2,7 +2,7 @@ use crate::{graph::sbom::SbomInformation, graph::Graph, model::IngestResult, ser
 use anyhow::anyhow;
 use hex::ToHex;
 use jsonpath_rust::JsonPath;
-use sea_orm::EntityTrait;
+use sea_orm::{EntityTrait, TransactionTrait};
 use std::str::FromStr;
 use trustify_common::{
     hashing::Digests,
@@ -65,7 +65,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
         });
 
         if let Some(document_id) = document_id {
-            let tx = self.graph.transaction().await?;
+            let tx = self.graph.db.begin().await?;
 
             let sbom = self
                 .graph

--- a/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
@@ -1,6 +1,7 @@
 use crate::{
     graph::sbom::clearly_defined::Curation, graph::Graph, model::IngestResult, service::Error,
 };
+use sea_orm::TransactionTrait;
 use tracing::instrument;
 use trustify_common::{hashing::Digests, id::Id};
 use trustify_entity::labels::Labels;
@@ -21,7 +22,7 @@ impl<'g> ClearlyDefinedCurationLoader<'g> {
         curation: Curation,
         digests: &Digests,
     ) -> Result<IngestResult, Error> {
-        let tx = self.graph.transaction().await?;
+        let tx = self.graph.db.begin().await?;
 
         let sbom = self
             .graph

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -4,6 +4,7 @@ use crate::{
     service::Error,
 };
 use cyclonedx_bom::prelude::Bom;
+use sea_orm::TransactionTrait;
 use tracing::instrument;
 use trustify_common::{hashing::Digests, id::Id};
 use trustify_entity::labels::Labels;
@@ -32,7 +33,7 @@ impl<'g> CyclonedxLoader<'g> {
             sbom.serial_number,
         );
 
-        let tx = self.graph.transaction().await?;
+        let tx = self.graph.db.begin().await?;
 
         let document_id = sbom
             .serial_number

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -6,6 +6,7 @@ use crate::{
     model::IngestResult,
     service::{Error, Warnings},
 };
+use sea_orm::TransactionTrait;
 use serde_json::Value;
 use tracing::instrument;
 use trustify_common::{hashing::Digests, id::Id};
@@ -36,7 +37,7 @@ impl<'g> SpdxLoader<'g> {
             spdx.document_creation_information.document_name
         );
 
-        let tx = self.graph.transaction().await?;
+        let tx = self.graph.db.begin().await?;
 
         let labels = labels.add("type", "spdx");
 

--- a/modules/ingestor/src/service/weakness/mod.rs
+++ b/modules/ingestor/src/service/weakness/mod.rs
@@ -134,6 +134,7 @@ impl<'d> CweCatalogLoader<'d> {
                         .exec(&tx)
                         .await?;
                 }
+
                 tx.commit().await?;
             }
         }

--- a/modules/ingestor/tests/db.rs
+++ b/modules/ingestor/tests/db.rs
@@ -140,7 +140,9 @@ async fn create_set(ctx: &TrustifyContext) -> anyhow::Result<()> {
                 withdrawn: None,
                 version: None,
             };
-            graph.ingest_advisory(d, (), &digests, info, ()).await?;
+            graph
+                .ingest_advisory(d, (), &digests, info, &ctx.db)
+                .await?;
         }
     }
 

--- a/modules/ingestor/tests/reingest/csaf.rs
+++ b/modules/ingestor/tests/reingest/csaf.rs
@@ -36,31 +36,31 @@ async fn reingest(ctx: TrustifyContext) -> anyhow::Result<()> {
         };
         let adv = ctx
             .graph
-            .get_advisory_by_id(id, ())
+            .get_advisory_by_id(id, &ctx.db)
             .await?
             .expect("must be found");
 
-        assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+        assert_eq!(adv.vulnerabilities(&ctx.db).await?.len(), 1);
 
-        let all = adv.vulnerabilities(&()).await?;
+        let all = adv.vulnerabilities(&ctx.db).await?;
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].advisory_vulnerability.vulnerability_id,
             "CVE-2023-33201"
         );
 
-        let all = ctx.graph.get_vulnerabilities(()).await?;
+        let all = ctx.graph.get_vulnerabilities(&ctx.db).await?;
         assert_eq!(all.len(), 1);
 
         let vuln = ctx
             .graph
-            .get_vulnerability("CVE-2023-33201", ())
+            .get_vulnerability("CVE-2023-33201", &ctx.db)
             .await?
             .expect("Must be found");
 
         assert_eq!(vuln.vulnerability.id, "CVE-2023-33201");
 
-        let descriptions = vuln.descriptions("en", ()).await?;
+        let descriptions = vuln.descriptions("en", &ctx.db).await?;
         assert_eq!(descriptions.len(), 0);
 
         Ok(())

--- a/modules/ingestor/tests/reingest/cve.rs
+++ b/modules/ingestor/tests/reingest/cve.rs
@@ -18,11 +18,11 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         };
         let adv = ctx
             .graph
-            .get_advisory_by_id(id, ())
+            .get_advisory_by_id(id, &ctx.db)
             .await?
             .expect("must be found");
 
-        let mut adv_vulns = adv.vulnerabilities(()).await?;
+        let mut adv_vulns = adv.vulnerabilities(&ctx.db).await?;
         assert_eq!(adv_vulns.len(), 1);
         let adv_vuln = adv_vulns.pop().unwrap();
         assert_eq!(
@@ -30,16 +30,16 @@ async fn reingest(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             Some(datetime!(2021-05-12 0:00:00 UTC))
         );
 
-        let vulns = ctx.graph.get_vulnerabilities(()).await?;
+        let vulns = ctx.graph.get_vulnerabilities(&ctx.db).await?;
         assert_eq!(vulns.len(), 1);
 
         let vuln = ctx
             .graph
-            .get_vulnerability("CVE-2021-32714", ())
+            .get_vulnerability("CVE-2021-32714", &ctx.db)
             .await?
             .expect("Must be found");
 
-        let descriptions = vuln.descriptions("en", ()).await?;
+        let descriptions = vuln.descriptions("en", &ctx.db).await?;
         assert_eq!(descriptions.len(), 1);
 
         Ok(())

--- a/modules/ingestor/tests/reingest/osv.rs
+++ b/modules/ingestor/tests/reingest/osv.rs
@@ -104,31 +104,31 @@ async fn assert_common(
     };
     let adv = ctx
         .graph
-        .get_advisory_by_id(id, ())
+        .get_advisory_by_id(id, &ctx.db)
         .await?
         .expect("must be found");
 
-    assert_eq!(adv.vulnerabilities(()).await?.len(), 1);
+    assert_eq!(adv.vulnerabilities(&ctx.db).await?.len(), 1);
 
-    let all = adv.vulnerabilities(&()).await?;
+    let all = adv.vulnerabilities(&ctx.db).await?;
     assert_eq!(all.len(), 1);
     assert_eq!(
         all[0].advisory_vulnerability.vulnerability_id,
         expected_vuln_id
     );
 
-    let all = ctx.graph.get_vulnerabilities(()).await?;
+    let all = ctx.graph.get_vulnerabilities(&ctx.db).await?;
     assert_eq!(all.len(), 1);
 
     let vuln = ctx
         .graph
-        .get_vulnerability(expected_vuln_id, ())
+        .get_vulnerability(expected_vuln_id, &ctx.db)
         .await?
         .expect("Must be found");
 
     assert_eq!(vuln.vulnerability.id, expected_vuln_id);
 
-    let descriptions = vuln.descriptions("en", ()).await?;
+    let descriptions = vuln.descriptions("en", &ctx.db).await?;
     assert_eq!(descriptions.len(), 0);
 
     Ok(())


### PR DESCRIPTION
Directly use the `ConnectionTrait` from sea_orm.