### PR TITLE
chore: Enable persistent DB during tests

### DIFF
--- a/common/src/db/embedded.rs
+++ b/common/src/db/embedded.rs
@@ -4,31 +4,40 @@ use postgresql_embedded::{PostgreSQL, Settings, VersionReq};
 use std::path::Path;
 use tracing::{info_span, Instrument};
 
-/// Create common default settings for the embedded database
-fn default_settings() -> anyhow::Result<Settings> {
+/// Create common default settings for the embedded database.
+/// Use the bool `temp` parameter to indicate if the pg_data
+/// directory is temporary or not.
+fn default_settings(temp: bool) -> anyhow::Result<Settings> {
     let version = VersionReq::parse("=16.3.0").context("valid psql version")?;
     Ok(Settings {
         version,
         username: "postgres".to_string(),
         password: "trustify".to_string(),
-        temporary: true,
+        temporary: temp,
         ..Default::default()
     })
 }
 
 /// Create a new, embedded database instance
-pub async fn create() -> anyhow::Result<(Database, PostgreSQL)> {
-    create_for(default_settings()?).await
+/// Use the bool `temporary` parameter to indicate if the pg_data
+/// directory is temporary or not.
+pub async fn create(temporary: bool) -> anyhow::Result<(Database, PostgreSQL)> {
+    create_for(default_settings(temporary)?).await
 }
 
 /// Create a new, embedded database instance in a specific directory
-pub async fn create_in(base: impl AsRef<Path>) -> anyhow::Result<(Database, PostgreSQL)> {
+/// Use the bool `temporary` parameter to indicate if the pg_data
+/// directory is temporary or not.
+pub async fn create_in(
+    base: impl AsRef<Path>,
+    temporary: bool,
+) -> anyhow::Result<(Database, PostgreSQL)> {
     let base = base.as_ref();
 
     create_for(Settings {
         data_dir: base.join("data"),
         installation_dir: base.join("instance"),
-        ..default_settings()?
+        ..default_settings(temporary)?
     })
     .await
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -50,6 +50,7 @@
 
 | Environment Variable | Description                    | Default Value |
 |----------------------|--------------------------------|---------------|
+| `DB_PATH`       | Specifies a location for postgres data directory making it persistent after the test |           |
 | `EXTERNAL_TEST_DB`       | Run tests against external test database if set |           |
 | `EXTERNAL_TEST_DB_BOOTSTRAP`       | Run tests against external test database if set |           |
 | `MEM_LIMIT_MB`       | Set memory limit for tests that use TrustifyContext, shows the memory usage when the test reaches the limit  | `500 MiB`          |

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -9,7 +9,7 @@ use utoipa::{
 use utoipa_actix_web::AppExt;
 
 pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
-    let (db, postgresql) = db::embedded::create().await?;
+    let (db, postgresql) = db::embedded::create(true).await?;
     let (storage, _temp) = FileSystemBackend::for_test().await?;
 
     let (_, mut openapi) = App::new()

--- a/xtask/src/dataset.rs
+++ b/xtask/src/dataset.rs
@@ -83,8 +83,8 @@ impl GenerateDump {
 
     pub async fn run(self) -> anyhow::Result<()> {
         let (db, postgres) = match &self.working_dir {
-            Some(wd) => db::embedded::create_in(wd.join("db")).await?,
-            None => db::embedded::create().await?,
+            Some(wd) => db::embedded::create_in(wd.join("db"), true).await?,
+            None => db::embedded::create(true).await?,
         };
 
         let (storage, _tmp) = match &self.working_dir {


### PR DESCRIPTION
This commits adds a new env-var `DB_PATH` for us to specify the postgresql path.

`DB_PATH=/home/heliofrota/Desktop/testdb cargo test advisory::endpoints::test::upload_default_csaf_format_multiple`

With this we can take a look at the logs when the test finish

`cat testdb/data/start.log`