### PR TITLE
fix: enable filtering/sorting on qualified purl json fields

### DIFF
--- a/common/auth/src/authorizer/mod.rs
+++ b/common/auth/src/authorizer/mod.rs
@@ -32,7 +32,7 @@ impl Authorizer {
         permission: Permission,
     ) -> Result<(), AuthorizationError> {
         if self.config.is_none() {
-            log::warn!("Authorization disabled, all permissions granted");
+            log::debug!("Authorization disabled, all permissions granted");
             return Ok(());
         }
 

--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 
 use sea_orm::entity::ColumnDef;
@@ -13,7 +13,7 @@ use super::Error;
 pub struct Columns {
     columns: Vec<(ColumnRef, ColumnDef)>,
     translator: Option<Translator>,
-    json_keys: HashMap<&'static str, &'static str>,
+    json_keys: BTreeMap<&'static str, &'static str>,
 }
 
 impl Display for Columns {
@@ -77,7 +77,7 @@ impl Columns {
         Self {
             columns,
             translator: None,
-            json_keys: HashMap::new(),
+            json_keys: BTreeMap::new(),
         }
     }
 
@@ -365,7 +365,7 @@ mod tests {
         );
         assert_eq!(
             clause(q("foo"))?,
-            r#"("advisory"."location" ILIKE '%foo%') OR ("advisory"."title" ILIKE '%foo%') OR (("purl" ->> 'type') ILIKE '%foo%') OR (("purl" ->> 'version') ILIKE '%foo%') OR (("purl" ->> 'name') ILIKE '%foo%')"#
+            r#"("advisory"."location" ILIKE '%foo%') OR ("advisory"."title" ILIKE '%foo%') OR (("purl" ->> 'name') ILIKE '%foo%') OR (("purl" ->> 'type') ILIKE '%foo%') OR (("purl" ->> 'version') ILIKE '%foo%')"#
         );
         assert!(clause(q("missing=gone")).is_err());
         assert!(clause(q("").sort("name")).is_ok());

--- a/common/src/db/query/filter.rs
+++ b/common/src/db/query/filter.rs
@@ -42,11 +42,9 @@ impl TryFrom<(&str, Operator, &Vec<String>, &Columns)> for Filter {
                         |s| match columns.translate(field, &operator.to_string(), s) {
                             Some(x) => q(&x).filter_for(columns),
                             None => columns.for_field(field).and_then(|(expr, col_def)| {
-                                Arg::parse(s, col_def.get_column_type()).and_then(|v| {
-                                    Ok(Filter {
-                                        operands: Operand::Simple(expr.clone(), v),
-                                        operator,
-                                    })
+                                Arg::parse(s, col_def.get_column_type()).map(|v| Filter {
+                                    operands: Operand::Simple(expr.clone(), v),
+                                    operator,
                                 })
                             }),
                         },

--- a/common/src/db/query/filter.rs
+++ b/common/src/db/query/filter.rs
@@ -69,17 +69,9 @@ impl TryFrom<(&Vec<String>, &Columns)> for Filter {
                     .iter()
                     .flat_map(|s| {
                         // Create a LIKE filter for all the string-ish columns
-                        columns.iter().filter_map(move |(col_ref, col_def)| {
-                            match col_def.get_column_type() {
-                                ColumnType::String(_) | ColumnType::Text => Some(Filter {
-                                    operands: Operand::Simple(
-                                        Expr::col(col_ref.clone()),
-                                        Arg::Value(SeaValue::from(s)),
-                                    ),
-                                    operator: Operator::Like,
-                                }),
-                                _ => None,
-                            }
+                        columns.strings().map(move |expr| Filter {
+                            operands: Operand::Simple(expr, Arg::Value(SeaValue::from(s))),
+                            operator: Operator::Like,
                         })
                     })
                     .collect(),

--- a/modules/fundamental/src/ai/service/tools/package_info.rs
+++ b/modules/fundamental/src/ai/service/tools/package_info.rs
@@ -324,9 +324,9 @@ There are multiple that match:
 {
   "items": [
     {
-      "identifier": "pkg:maven/io.quarkus/quarkus-resteasy-reactive-jsonb-common@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+      "identifier": "pkg:maven/io.quarkus/quarkus-resteasy-reactive-jsonb-common-deployment@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "name": "quarkus-resteasy-reactive-jsonb-common",
+      "name": "quarkus-resteasy-reactive-jsonb-common-deployment",
       "version": "2.13.8.Final-redhat-00004"
     },
     {
@@ -336,9 +336,9 @@ There are multiple that match:
       "version": "2.13.8.Final-redhat-00004"
     },
     {
-      "identifier": "pkg:maven/io.quarkus/quarkus-resteasy-reactive-jsonb-common-deployment@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+      "identifier": "pkg:maven/io.quarkus/quarkus-resteasy-reactive-jsonb-common@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "name": "quarkus-resteasy-reactive-jsonb-common-deployment",
+      "name": "quarkus-resteasy-reactive-jsonb-common",
       "version": "2.13.8.Final-redhat-00004"
     },
     {

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -292,7 +292,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = format!("/api/v1/purl?q={}", encode("ty=maven"));
+    let uri = format!("/api/v1/purl?q={}", encode("type=maven"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(3, response.items.len());
@@ -304,7 +304,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
             &ctx.db,
         )
         .await?;
-    let uri = format!("/api/v1/purl?q={}", encode("ty=rpm&arch=i386"));
+    let uri = format!("/api/v1/purl?q={}", encode("type=rpm&arch=i386"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(1, response.items.len());

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -315,7 +315,11 @@ impl PurlService {
                 qualified_purl::Entity
                     .columns()
                     .json_keys("purl", &["ty", "namespace", "name", "version"])
-                    .json_keys("qualifiers", &["arch", "type", "repository_url"]),
+                    .json_keys("qualifiers", &["arch", "distro", "repository_url"])
+                    .translator(|f, op, v| match f {
+                        "type" => Some(format!("ty{op}{v}")),
+                        _ => None,
+                    }),
             )?
             .limiting(connection, paginated.offset, paginated.limit);
 

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -8,10 +8,10 @@ use crate::{
     Error,
 };
 use sea_orm::{
-    prelude::Uuid, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, IntoSimpleExpr,
-    QueryFilter, QueryOrder, QuerySelect, QueryTrait,
+    prelude::Uuid, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, QueryFilter,
+    QueryOrder, QuerySelect,
 };
-use sea_query::{Condition, Expr, Order, SimpleExpr};
+use sea_query::Order;
 use tracing::instrument;
 use trustify_common::{
     db::{

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 use trustify_common::{
     db::{
         limiter::LimiterTrait,
-        query::{Filtering, Query},
+        query::{Filtering, IntoColumns, Query},
     },
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
@@ -309,29 +309,14 @@ impl PurlService {
         paginated: Paginated,
         connection: &C,
     ) -> Result<PaginatedResults<PurlSummary>, Error> {
-        // TODO: this would be the condition used to select from jsonb name key
-        let _unused_condition = Expr::cust_with_exprs(
-            "$1->>'name' ~~* $2",
-            [
-                qualified_purl::Column::Purl.into_simple_expr(),
-                SimpleExpr::Value(format!("%{}%", query.q).into()),
-            ],
-        );
-
-        // TODO: we need to figure out how we bring in querying keys of jsonb column in query.rs
         let limiter = qualified_purl::Entity::find()
-            .left_join(versioned_purl::Entity)
-            .filter(
-                Condition::any().add(
-                    versioned_purl::Column::BasePurlId.in_subquery(
-                        base_purl::Entity::find()
-                            .filtering(query)?
-                            .select_only()
-                            .column(base_purl::Column::Id)
-                            .into_query(),
-                    ),
-                ),
-            )
+            .filtering_with(
+                query,
+                qualified_purl::Entity
+                    .columns()
+                    .json_keys("purl", &["ty", "namespace", "name", "version"])
+                    .json_keys("qualifiers", &["arch", "type", "repository_url"]),
+            )?
             .limiting(connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -626,9 +626,11 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let uuid = results.items[0].head.uuid;
 
-    let _results = service
+    let results = service
         .purl_by_uuid(&uuid, Default::default(), &ctx.db)
         .await?;
+
+    assert_eq!(uuid, results.unwrap().head.uuid);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #888
Fixes #951
Fixes #972

This introduces some potential naming conflicts, specifically that `type` is a valid PURL _qualifier_ as well as an attribute of the PURL itself, therefore we currently alias `ty` to `type`, which effectively prohibits using the `type` _qualifier_ in queries; only the type of the PURL itself may be used.

We need to decide which qualifiers we want to support. 
