### PR TITLE
fix: improve sbom to vunerabilities correlation

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -96,6 +96,7 @@ mod m0000750_alter_advisory_add_document_id;
 mod m0000760_product_status_index;
 mod m0000780_alter_source_document_time;
 mod m0000790_alter_sbom_alter_document_id;
+mod m0000800_alter_product_version_range_scheme;
 
 pub struct Migrator;
 
@@ -199,6 +200,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000760_product_status_index::Migration),
             Box::new(m0000780_alter_source_document_time::Migration),
             Box::new(m0000790_alter_sbom_alter_document_id::Migration),
+            Box::new(m0000800_alter_product_version_range_scheme::Migration),
         ]
     }
 }

--- a/migration/src/m0000800_alter_product_version_range_scheme.rs
+++ b/migration/src/m0000800_alter_product_version_range_scheme.rs
@@ -1,0 +1,27 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // use rpm version range scheme as it covers more usecases
+        manager
+            .get_connection()
+            .execute_unprepared(r#"UPDATE version_range SET version_scheme_id = 'rpm' WHERE id IN (SELECT version_range_id FROM product_version_range)"#)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // return to semver version range scheme
+        manager
+            .get_connection()
+            .execute_unprepared(r#"UPDATE version_range SET version_scheme_id = 'semver' WHERE id IN (SELECT version_range_id FROM product_version_range)"#)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -235,10 +235,9 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(!quarkus_sbom.advisories.is_empty());
     let quarkus_adv = &quarkus_sbom.advisories[0].status[0];
 
-    assert_eq!(quarkus_adv.status, "fixed");
+    assert_eq!(quarkus_adv.status, "affected");
     assert_eq!(quarkus_adv.vulnerability.identifier, "CVE-2023-0044");
 
-    let quarkus_adv = &quarkus_sbom.advisories[0].status[1];
     assert_eq!(quarkus_adv.packages.len(), 1);
     assert_eq!(quarkus_adv.packages[0].purl.len(), 1);
     assert_eq!(quarkus_adv.packages[0].purl[0].head.purl, Purl::from_str("pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar").unwrap());

--- a/modules/ingestor/src/service/advisory/csaf/product_status.rs
+++ b/modules/ingestor/src/service/advisory/csaf/product_status.rs
@@ -70,12 +70,14 @@ impl ProductStatus {
                                     // let upper = semver.clone().set_major(semver.major + 1).build();
                                     let mut upper = semver.clone();
                                     upper.major += 1;
+                                    upper.minor = 0;
+                                    upper.patch = 0;
                                     VersionInfo {
                                         spec: VersionSpec::Range(
                                             Version::Inclusive(semver.to_string()),
                                             Version::Exclusive(upper.to_string()),
                                         ),
-                                        scheme: VersionScheme::Semver,
+                                        scheme: VersionScheme::Rpm,
                                     }
                                 }
                                 Err(_) => VersionInfo {


### PR DESCRIPTION
This PR contains rework of sbom to vulnerability use case. The performance should be now much better and it should fix some issues with the results in the process as well. I tested it manually with some larger sboms on top of DS1, like rhel-7 and everything works much smoother now.
There's still room for other performance improvements, but let's do that in follow-up PRs