### PR TITLE
fix: optimize import of product related entities during csaf ingestion

### DIFF
--- a/modules/ingestor/src/graph/product/mod.rs
+++ b/modules/ingestor/src/graph/product/mod.rs
@@ -166,7 +166,8 @@ impl Graph {
                     cpe_key: organization_cpe_key,
                     website: None,
                 };
-                let org = self.ingest_organization(vendor, org, connection).await?;
+                let org: OrganizationContext<'_> =
+                    self.ingest_organization(vendor, org, connection).await?;
 
                 product::ActiveModel {
                     id: Default::default(),


### PR DESCRIPTION
This PR improves ingestion performance of CSAF documents, by doing batch insert for products and version ranges.

Performance improvements are significant for a large csaf documents

Before:
```
$ time csaf scoop http://localhost:8080/api/v1/advisory etc/datasets/ds3/csaf/2023/cve-2023-44487.json

________________________________________________________
Executed in  210.75 secs      fish           external
   usr time    4.01 millis    0.07 millis    3.94 millis
   sys time   24.75 millis    1.27 millis   23.49 millis
   ```

After:
```
$ time csaf scoop http://localhost:8080/api/v1/advisory etc/datasets/ds3/csaf/2023/cve-2023-44487.json

________________________________________________________
Executed in   53.29 secs      fish           external
   usr time    5.26 millis    0.09 millis    5.17 millis
   sys time   27.33 millis    1.45 millis   25.88 millis
```

There is another area where we could significantly improve ingestion time, captured by #1110. But that should be done by the separate PR.