### PR TITLE
fix: use predictable ids for product related entities and additionally speed up csaf ingestion

### DIFF
--- a/entity/src/version_scheme.rs
+++ b/entity/src/version_scheme.rs
@@ -1,6 +1,19 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Eq, Hash, Debug, PartialEq, EnumIter, DeriveActiveEnum, strum::Display)]
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    Hash,
+    Debug,
+    PartialEq,
+    EnumIter,
+    DeriveActiveEnum,
+    strum::Display,
+    Serialize,
+    Deserialize,
+)]
 #[sea_orm(
     rs_type = "String",
     db_type = "String(StringLen::None)",

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -4,6 +4,7 @@ use sea_orm::{
     Set,
 };
 use sea_query::{Condition, Expr, IntoCondition};
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, purl::Purl};
 use trustify_cvss::cvss3::Cvss3Base;
@@ -12,19 +13,19 @@ use trustify_entity::{
     version_scheme::VersionScheme, vulnerability,
 };
 
-#[derive(Clone, Eq, Hash, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VersionInfo {
     pub scheme: VersionScheme,
     pub spec: VersionSpec,
 }
 
-#[derive(Clone, Eq, Hash, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq, Serialize, Deserialize)]
 pub enum VersionSpec {
     Exact(String),
     Range(Version, Version),
 }
 
-#[derive(Clone, Eq, Hash, Debug, PartialEq)]
+#[derive(Clone, Eq, Hash, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Version {
     Inclusive(String),
     Exclusive(String),


### PR DESCRIPTION
This PR handles two things. 

First it removes select in loop that checks for preexisting purl statuses. Instead I added a bit of logic to return early from ingesting already ingested csaf document, which I believe is the case this was protecting from.

Additionally, now product related entities use predictable ids that was missing in yesterdays batch insert PR. There are still some workarounds in this area that will be tackled next, when the sam work is done for ingesting SBOMs.

This all result in further speedup of csaf ingestion, where `cve-2023-44487` goes locally from 50 to 20 sec.

The whole dataset 3 now ingests for 30 sec

```
time http POST localhost:8080/api/v1/dataset @etc/datasets/ds3.zip
________________________________________________________
Executed in   35.23 secs      fish           external
   usr time  152.97 millis    0.09 millis  152.89 millis
   sys time   66.68 millis    1.29 millis   65.40 millis   
```  

I'm still testing the importer, but it looks like 2024 RH CSAF should be imported in 1.5h, by the current pace.