### PR TITLE
feat: remove the --devmode runtime option

### DIFF
--- a/common/auth/src/auth.rs
+++ b/common/auth/src/auth.rs
@@ -53,17 +53,14 @@ pub fn is_default<D: Default + PartialEq>(d: &D) -> bool {
 impl AuthConfigArguments {
     pub fn split(
         self,
-        devmode: bool,
+        defaults: bool,
     ) -> Result<Option<(AuthenticatorConfig, AuthorizerConfig)>, anyhow::Error> {
-        // disabled overrides devmode
         if self.disabled {
             return Ok(None);
         }
-
-        // check for devmode
-        if devmode {
-            log::warn!("Running in developer mode");
-            return Ok(Some((AuthenticatorConfig::devmode(), Default::default())));
+        if defaults {
+            log::warn!("Running with default auth config");
+            return Ok(Some(Default::default()));
         }
 
         Ok(Some(match self.config {
@@ -96,7 +93,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn auth_disabled_devmode_false() {
+    fn auth_disabled_no_defaults() {
         let args = AuthConfigArguments {
             disabled: true,
             config: None,
@@ -108,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn auth_enabled_devmode_true() {
+    fn auth_enabled_with_defaults() {
         let args = AuthConfigArguments {
             disabled: false,
             config: None,

--- a/common/auth/src/authenticator/config.rs
+++ b/common/auth/src/authenticator/config.rs
@@ -1,4 +1,4 @@
-use crate::{authenticator::default_scope_mappings, devmode};
+use crate::{authenticator::default_scope_mappings, default};
 use clap::ArgAction;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -31,15 +31,14 @@ pub struct AuthenticatorConfig {
     pub clients: Vec<AuthenticatorClientConfig>,
 }
 
-impl AuthenticatorConfig {
-    /// Create settings when using `--devmode`.
-    pub fn devmode() -> Self {
+impl Default for AuthenticatorConfig {
+    fn default() -> Self {
         Self {
-            clients: devmode::CLIENT_IDS
+            clients: default::CLIENT_IDS
                 .iter()
                 .map(|client_id| AuthenticatorClientConfig {
                     client_id: client_id.to_string(),
-                    issuer_url: devmode::issuer_url(),
+                    issuer_url: default::issuer_url(),
                     scope_mappings: default_scope_mappings(),
                     additional_permissions: Default::default(),
                     required_audience: None,

--- a/common/auth/src/default.rs
+++ b/common/auth/src/default.rs
@@ -1,16 +1,16 @@
-/// The default issuer when using `--devmode`.
+/// The default issuer url
 pub const ISSUER_URL: &str = "http://localhost:8090/realms/trustify";
 
 /// The default client id for the frontend
 pub const FRONTEND_CLIENT_ID: &str = "frontend";
 
-/// The default "service" client ID for devmode
+/// The default "service" client ID
 pub const SERVICE_CLIENT_ID: &str = "testing-manager";
 
 pub const PUBLIC_CLIENT_IDS: &[&str] = &[FRONTEND_CLIENT_ID];
 pub const CONFIDENTIAL_CLIENT_IDS: &[&str] = &["walker", "testing-user", SERVICE_CLIENT_ID];
 
-/// The clients which will be accepted by services when running with `--devmode`.
+/// The clients which will be accepted by services
 ///
 /// This also includes the "testing" clients, as this allows running the testsuite against an
 /// already spun-up set of services.
@@ -28,10 +28,10 @@ pub const SWAGGER_UI_CLIENT_ID: &str = FRONTEND_CLIENT_ID;
 /// This is not a secret. Don't use this in production.
 pub const SSO_CLIENT_SECRET: &str = "R8A6KFeyxJsMDBhjfHbpZTIF0GWt43HP";
 
-/// Get the issuer URL for `--devmode`.
+/// Get the issuer URL
 ///
-/// This can be either the value of [`ISSUER_URL`], or it can be overridden using the environment
-/// variable `ISSUER_URL`.
+/// This can be either the value of [`ISSUER_URL`], or it can be
+/// overridden using the environment variable `TRUSTD_ISSUER_URL`.
 pub fn issuer_url() -> String {
     std::env::var("TRUSTD_ISSUER_URL").unwrap_or_else(|_| ISSUER_URL.to_string())
 }

--- a/common/auth/src/lib.rs
+++ b/common/auth/src/lib.rs
@@ -5,7 +5,7 @@ pub mod auth;
 pub mod authenticator;
 pub mod authorizer;
 pub mod client;
-pub mod devmode;
+pub mod default;
 
 #[cfg(feature = "swagger")]
 pub mod swagger_ui;

--- a/common/auth/src/swagger_ui.rs
+++ b/common/auth/src/swagger_ui.rs
@@ -1,4 +1,4 @@
-use crate::devmode::{self, SWAGGER_UI_CLIENT_ID};
+use crate::default::{self, SWAGGER_UI_CLIENT_ID};
 use actix_web::dev::HttpServiceFactory;
 use openid::{Client, Discovered, Provider, StandardClaims};
 use std::sync::Arc;
@@ -11,7 +11,7 @@ use utoipa::openapi::{
 };
 use utoipa_swagger_ui::{oauth, Config, SwaggerUi};
 
-#[derive(Clone, Debug, Default, clap::Args)]
+#[derive(Clone, Debug, clap::Args)]
 #[command(
     rename_all_env = "SCREAMING_SNAKE_CASE",
     next_help_heading = "Swagger UI OIDC"
@@ -44,12 +44,12 @@ pub struct SwaggerUiOidcConfig {
     pub swagger_ui_oidc_client_id: String,
 }
 
-impl SwaggerUiOidcConfig {
-    pub fn devmode() -> Self {
+impl Default for SwaggerUiOidcConfig {
+    fn default() -> Self {
         Self {
             tls_insecure: false,
             ca_certificates: vec![],
-            swagger_ui_oidc_issuer_url: Some(devmode::issuer_url()),
+            swagger_ui_oidc_issuer_url: Some(default::issuer_url()),
             swagger_ui_oidc_client_id: SWAGGER_UI_CLIENT_ID.to_string(),
         }
     }
@@ -96,18 +96,6 @@ impl SwaggerUiOidc {
             auth_url: client.provider.auth_uri().to_string(),
             client_id: client.client_id,
         }))
-    }
-
-    pub async fn from_devmode_or_config(
-        devmode: bool,
-        config: SwaggerUiOidcConfig,
-    ) -> anyhow::Result<Option<Self>> {
-        let config = match devmode {
-            true => SwaggerUiOidcConfig::devmode(),
-            false => config,
-        };
-
-        Self::new(config).await
     }
 
     pub fn apply_to_schema(&self, openapi: &mut OpenApi) {

--- a/server/src/embedded_oidc.rs
+++ b/server/src/embedded_oidc.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use trustify_auth::devmode::{
+use trustify_auth::default::{
     CONFIDENTIAL_CLIENT_IDS, ISSUER_URL, PUBLIC_CLIENT_IDS, SSO_CLIENT_SECRET,
 };
 use trustify_infrastructure::health::Check;
@@ -61,8 +61,6 @@ fn create(enabled: bool) -> anyhow::Result<Option<Server>> {
             default_scope: SCOPE.to_string(),
         });
     }
-
-    // take the devmode url and extract all information for building the server
 
     let url = Url::parse(ISSUER_URL)?;
     let port = url.port().unwrap_or(8090);

--- a/server/src/profile/importer.rs
+++ b/server/src/profile/importer.rs
@@ -18,7 +18,7 @@ use trustify_auth::{
     auth::AuthConfigArguments,
     authenticator::Authenticator,
     authorizer::Authorizer,
-    devmode::{FRONTEND_CLIENT_ID, ISSUER_URL, PUBLIC_CLIENT_IDS},
+    default::{FRONTEND_CLIENT_ID, ISSUER_URL, PUBLIC_CLIENT_IDS},
     swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc, SwaggerUiOidcConfig},
 };
 use trustify_common::{config::Database, db, model::BinaryByteSize};


### PR DESCRIPTION
Fixes #1126 

From what I can gather from the code, --devmode essentially did 2 things: 1) ran the db migrations, if any, and b) fired up an embedded OIDC server.

The concept of --devmode is a holdover from version 1, but since version 2 introduced the concept of "PM mode", having both modes is a source of confusion, and we have too many runtime parameters, anyway.

I also removed some public fn's that didn't seem to be used. It's difficult enough to understand our OIDC config code without it being conflated with a "dev mode". I assumed from the code that our dev mode defaults were reasonable defaults whether dev mode was a thing or not.