### PR TITLE
feat[ai]: Add conversation endpoints.

### DIFF
--- a/modules/fundamental/src/ai/endpoints/mod.rs
+++ b/modules/fundamental/src/ai/endpoints/mod.rs
@@ -2,15 +2,27 @@
 mod test;
 
 use crate::{
-    ai::model::{AiFlags, AiTool, ChatState},
-    ai::service::AiService,
+    ai::{
+        model::{AiFlags, AiTool, ChatState, Conversation, ConversationSummary},
+        service::AiService,
+    },
     Error,
 };
-use actix_http::header;
-use actix_web::{get, post, web, HttpResponse, Responder};
+use actix_web::{
+    delete, get,
+    http::header::{self, ETag, EntityTag, IfMatch},
+    post, put, web, HttpResponse, Responder,
+};
+
+use crate::ai::model::ChatMessage;
 use itertools::Itertools;
+use time::OffsetDateTime;
+use trustify_auth::authenticator::user::UserDetails;
 use trustify_auth::{authorizer::Require, Ai};
+use trustify_common::db::query::Query;
 use trustify_common::db::Database;
+use trustify_common::model::{Paginated, PaginatedResults};
+use uuid::Uuid;
 
 pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, db: Database) {
     let service = AiService::new(db.clone());
@@ -19,7 +31,12 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .service(completions)
         .service(flags)
         .service(tools)
-        .service(tool_call);
+        .service(tool_call)
+        .service(create_conversation)
+        .service(update_conversation)
+        .service(list_conversations)
+        .service(get_conversation)
+        .service(delete_conversation);
 }
 
 #[utoipa::path(
@@ -35,11 +52,10 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 #[post("/v2/ai/completions")]
 pub async fn completions(
     service: web::Data<AiService>,
-    db: web::Data<Database>,
     request: web::Json<ChatState>,
     _: Require<Ai>,
 ) -> actix_web::Result<impl Responder> {
-    let response = service.completions(&request, db.as_ref()).await?;
+    let response = service.completions(&request).await?;
     Ok(HttpResponse::Ok().json(response))
 }
 
@@ -122,4 +138,247 @@ pub async fn tool_call(
     Ok(HttpResponse::Ok()
         .insert_header((header::CONTENT_TYPE, "text/plain"))
         .body(result))
+}
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "createConversation",
+    responses(
+        (status = 200, description = "The resulting conversation", body = Conversation),
+        (status = 400, description = "The request was invalid"),
+        (status = 404, description = "The AI service is not enabled")
+    )
+)]
+#[post("/v1/ai/conversations")]
+pub async fn create_conversation(_: Require<Ai>) -> actix_web::Result<impl Responder, Error> {
+    // generate an assistant response
+    let uuid = Uuid::now_v7();
+    let response = Conversation {
+        id: uuid,
+        messages: Default::default(),
+        updated_at: to_offset_date_time(uuid)?,
+        seq: 0,
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+fn to_offset_date_time(uuid: Uuid) -> Result<OffsetDateTime, Error> {
+    match uuid.get_timestamp() {
+        Some(ts) => match OffsetDateTime::from_unix_timestamp(ts.to_unix().0 as i64) {
+            Ok(ts) => Ok(ts),
+            Err(e) => Err(Error::Internal(e.to_string())),
+        },
+        None => Err(Error::Internal("uuid generation failure".into())),
+    }
+}
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "updateConversation",
+    params(
+        ("id", Path, description = "Opaque ID of the conversation"),
+        ("if-match"=Option<String>, Header, description = "The revision to update")
+    ),
+    request_body = Vec<ChatMessage>,
+    responses(
+        (status = 200, description = "The resulting conversation", body = Conversation),
+        (status = 400, description = "The request was invalid"),
+        (status = 404, description = "The AI service is not enabled or the conversation was not found")
+    )
+)]
+#[put("/v1/ai/conversations/{id}")]
+pub async fn update_conversation(
+    service: web::Data<AiService>,
+    db: web::Data<Database>,
+    id: web::Path<Uuid>,
+    web::Header(if_match): web::Header<IfMatch>,
+    user: UserDetails,
+    request: web::Json<Vec<ChatMessage>>,
+    _: Require<Ai>,
+) -> actix_web::Result<impl Responder> {
+    let user_id = user.id;
+    let seq = match &if_match {
+        IfMatch::Any => None,
+        IfMatch::Items(items) => items
+            .first()
+            .and_then(|etag| etag.tag().parse::<i32>().ok()),
+    };
+    let conversation_id = id.into_inner();
+
+    let (conversation, messages) = service
+        .upsert_conversation(conversation_id, user_id, &request, seq, db.as_ref())
+        .await?;
+
+    let conversation = Conversation {
+        id: conversation.id,
+        updated_at: conversation.updated_at,
+        messages,
+        seq: conversation.seq,
+    };
+
+    Ok(HttpResponse::Ok().json(conversation))
+}
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "listConversations",
+    params(
+        Query,
+        Paginated,
+    ),
+    responses(
+        (status = 200, description = "The resulting list of conversation summaries", body = PaginatedResults<ConversationSummary>),
+        (status = 404, description = "The AI service is not enabled")
+    )
+)]
+#[get("/v1/ai/conversations")]
+// Gets the list of the user's previous conversations
+pub async fn list_conversations(
+    service: web::Data<AiService>,
+    web::Query(search): web::Query<Query>,
+    web::Query(paginated): web::Query<Paginated>,
+    db: web::Data<Database>,
+    user: UserDetails,
+    _: Require<Ai>,
+) -> actix_web::Result<impl Responder> {
+    let user_id = user.id;
+
+    let result = service
+        .fetch_conversations(user_id, search, paginated, db.as_ref())
+        .await?;
+
+    let result = PaginatedResults {
+        items: result
+            .items
+            .into_iter()
+            .map(|c| ConversationSummary {
+                id: c.id,
+                summary: c.summary,
+                updated_at: c.updated_at,
+            })
+            .collect(),
+        total: result.total,
+    };
+
+    Ok(HttpResponse::Ok().json(result))
+}
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "getConversation",
+    params(
+        ("id", Path, description = "Opaque ID of the conversation")
+    ),
+    responses(
+        (status = 200, description = "The resulting conversation", body = Conversation, headers(
+            ("etag" = String, description = "Sequence ID")
+        )),
+        (status = 400, description = "The request was invalid"),
+        (status = 404, description = "The AI service is not enabled")
+    )
+)]
+#[get("/v1/ai/conversations/{id}")]
+pub async fn get_conversation(
+    service: web::Data<AiService>,
+    db: web::Data<Database>,
+    id: web::Path<Uuid>,
+    user: UserDetails,
+    _: Require<Ai>,
+) -> actix_web::Result<impl Responder> {
+    let user_id = user.id;
+
+    let uuid = id.into_inner();
+    let conversation = service.fetch_conversation(uuid, db.as_ref()).await?;
+
+    match conversation {
+        // return an empty conversation i
+        None => Ok(HttpResponse::Ok()
+            .append_header((header::ETAG, ETag(EntityTag::new_strong("0".to_string()))))
+            .json(Conversation {
+                id: uuid,
+                messages: Default::default(),
+                updated_at: to_offset_date_time(uuid)?,
+                seq: 0,
+            })),
+
+        // Found the conversation
+        Some((conversation, internal_state)) => {
+            // verify that the conversation belongs to the user
+            if conversation.user_id != user_id {
+                // make this error look like a not found error to avoid leaking
+                // existence of the conversation
+                Err(Error::NotFound("conversation not found".to_string()))?;
+            }
+
+            Ok(HttpResponse::Ok()
+                .append_header((
+                    header::ETAG,
+                    ETag(EntityTag::new_strong(format!("{}", conversation.seq))),
+                ))
+                .json(Conversation {
+                    id: conversation.id,
+                    updated_at: conversation.updated_at,
+                    messages: internal_state.chat_messages(),
+                    seq: conversation.seq,
+                }))
+        }
+    }
+}
+
+#[utoipa::path(
+    tag = "ai",
+    operation_id = "deleteConversation",
+    params(
+        ("id", Path, description = "Opaque ID of the conversation")
+    ),
+    responses(
+        (status = 200, description = "The resulting conversation", body = Conversation),
+        (status = 400, description = "The request was invalid"),
+        (status = 404, description = "The AI service is not enabled or the conversation was not found")
+    )
+)]
+#[delete("/v1/ai/conversations/{id}")]
+pub async fn delete_conversation(
+    service: web::Data<AiService>,
+    db: web::Data<Database>,
+    id: web::Path<Uuid>,
+    user: UserDetails,
+    _: Require<Ai>,
+) -> actix_web::Result<impl Responder> {
+    let user_id = user.id;
+    let conversation_id = id.into_inner();
+
+    let conversation = service
+        .fetch_conversation(conversation_id, db.as_ref())
+        .await?;
+
+    match conversation {
+        // the conversation_id might be invalid
+        None => Err(Error::NotFound("conversation not found".to_string()))?,
+
+        // Found the conversation
+        Some((conversation, internal_state)) => {
+            // verify that the conversation belongs to the user
+            if conversation.user_id != user_id {
+                // make this error look like a not found error to avoid leaking
+                // existence of the conversation
+                Err(Error::NotFound("conversation not found".to_string()))?;
+            }
+
+            let rows_affected = service
+                .delete_conversation(conversation_id, db.as_ref())
+                .await?;
+            match rows_affected {
+                0 => Ok(HttpResponse::NotFound().finish()),
+                1 => Ok(HttpResponse::Ok().json(Conversation {
+                    id: conversation.id,
+                    updated_at: conversation.updated_at,
+                    messages: internal_state.chat_messages(),
+                    seq: conversation.seq,
+                })),
+                _ => Err(Error::Internal("Unexpected number of rows affected".into()))?,
+            }
+        }
+    }
 }

--- a/modules/fundamental/src/ai/endpoints/test.rs
+++ b/modules/fundamental/src/ai/endpoints/test.rs
@@ -1,13 +1,15 @@
-use crate::ai::model::ChatState;
+use crate::ai::model::{ChatMessage, ChatState, Conversation, ConversationSummary};
 use crate::ai::service::test::{ingest_fixtures, sanitize_uuid_field, sanitize_uuid_urn};
 use crate::ai::service::AiService;
 use crate::test::caller;
 use actix_http::StatusCode;
 use actix_web::dev::ServiceResponse;
-use actix_web::test::TestRequest;
+use actix_web::test::{read_body_json, TestRequest};
 use serde_json::json;
 use test_context::test_context;
 use test_log::test;
+use trustify_common::model::PaginatedResults;
+use trustify_test_context::auth::TestAuthentication;
 use trustify_test_context::call::CallService;
 use trustify_test_context::TrustifyContext;
 
@@ -22,8 +24,8 @@ async fn configure(ctx: &TrustifyContext) -> anyhow::Result<()> {
     ingest_fixtures(ctx).await?;
 
     let app = caller(ctx).await?;
-    let mut req = ChatState::new();
-    req.add_human_message("Give me information about the SBOMs available for quarkus reporting its name, SHA and URL.".into());
+    let mut req = ChatState::default();
+    req.messages.push(ChatMessage::human("Give me information about the SBOMs available for quarkus reporting its name, SHA and URL.".into()));
 
     let request = TestRequest::post()
         .uri("/api/v2/ai/completions")
@@ -153,6 +155,156 @@ async fn tools_call(ctx: &TrustifyContext) -> anyhow::Result<()> {
 "#
             .trim()
     );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn conversation_crud(ctx: &TrustifyContext) -> anyhow::Result<()> {
+    if !AiService::new(ctx.db.clone()).completions_enabled() {
+        return Ok(()); // skip test
+    }
+
+    ctx.ingest_document("quarkus/v1/quarkus-bom-2.13.8.Final-redhat-00004.json")
+        .await?;
+
+    let app = caller(ctx).await?;
+
+    // Verify that there are no conversations
+    let request = TestRequest::get()
+        .uri("/api/v1/ai/conversations")
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: PaginatedResults<ConversationSummary> = read_body_json(response).await;
+    assert_eq!(result.total, 0);
+    assert_eq!(result.items.len(), 0);
+
+    // Create a conversation
+    let request = TestRequest::post()
+        .uri("/api/v1/ai/conversations")
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let conversation_v1: Conversation = read_body_json(response).await;
+    assert_eq!(conversation_v1.seq, 0);
+    assert_eq!(
+        conversation_v1.messages.len(),
+        0,
+        "empty conversation should have no messages"
+    );
+
+    // Add first message to the conversation
+    let mut update1 = conversation_v1.messages.clone();
+    update1.push(ChatMessage::human(
+        "What is the latest version of Quarks?".into(),
+    ));
+
+    let request = TestRequest::put()
+        .uri(format!("/api/v1/ai/conversations/{}", conversation_v1.id).as_str())
+        .set_json(update1.clone())
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let conversation_v2: Conversation = read_body_json(response).await;
+    assert_eq!(conversation_v2.seq, 1);
+    assert!(
+        conversation_v2.messages.len() > update1.len(),
+        "assistant should add more messages"
+    );
+
+    // Verify that the conversation can be listed
+    let request = TestRequest::get()
+        .uri("/api/v1/ai/conversations")
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: PaginatedResults<ConversationSummary> = read_body_json(response).await;
+    assert_eq!(result.total, 1);
+    assert_eq!(result.items.len(), 1);
+    assert_eq!(result.items[0].id, conversation_v1.id);
+
+    // Verify that we can retrieve the conversation by ID
+    let request = TestRequest::get()
+        .uri(format!("/api/v1/ai/conversations/{}", conversation_v1.id).as_str())
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: Conversation = read_body_json(response).await;
+    assert_eq!(result, conversation_v2);
+
+    // Verify that we can update the conversation
+    let mut update2 = conversation_v2.messages.clone();
+    update2.push(ChatMessage::human(
+        "Are there any related CVEs affecting it?".into(),
+    ));
+
+    let request = TestRequest::put()
+        .uri(format!("/api/v1/ai/conversations/{}", conversation_v1.id).as_str())
+        .append_header(("if-match", format!("\"{}\"", conversation_v2.seq).as_str()))
+        .set_json(update2.clone())
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let conversation_v3: Conversation = read_body_json(response).await;
+    assert_eq!(conversation_v3.seq, conversation_v2.seq + 1);
+    assert!(
+        conversation_v3.messages.len() > update2.len(),
+        "assistant should add more messages"
+    );
+
+    // Verify that we can retrieve the updated conversation by ID
+    let request = TestRequest::get()
+        .uri(format!("/api/v1/ai/conversations/{}", conversation_v1.id).as_str())
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: Conversation = read_body_json(response).await;
+    assert_eq!(result, conversation_v3);
+
+    // Verify that we can delete the conversation
+    let request = TestRequest::delete()
+        .uri(format!("/api/v1/ai/conversations/{}", conversation_v1.id).as_str())
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify that the conversation is deleted
+    let request = TestRequest::get()
+        .uri("/api/v1/ai/conversations")
+        .to_request()
+        .test_auth("user-a");
+
+    let response = app.call_service(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: PaginatedResults<ConversationSummary> = read_body_json(response).await;
+    assert_eq!(result.total, 0);
+    assert_eq!(result.items.len(), 0);
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,159 @@ paths:
                     type: object
                   version:
                     type: string
+  /api/v1/ai/conversations:
+    get:
+      tags:
+      - ai
+      operationId: listConversations
+      parameters:
+      - name: q
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: no limit
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      responses:
+        '200':
+          description: The resulting list of conversation summaries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_ConversationSummary'
+        '404':
+          description: The AI service is not enabled
+    post:
+      tags:
+      - ai
+      operationId: createConversation
+      responses:
+        '200':
+          description: The resulting conversation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400':
+          description: The request was invalid
+        '404':
+          description: The AI service is not enabled
+  /api/v1/ai/conversations/{id}:
+    get:
+      tags:
+      - ai
+      operationId: getConversation
+      parameters:
+      - name: id
+        in: path
+        description: Opaque ID of the conversation
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The resulting conversation
+          headers:
+            etag:
+              schema:
+                type: string
+              description: Sequence ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400':
+          description: The request was invalid
+        '404':
+          description: The AI service is not enabled
+    put:
+      tags:
+      - ai
+      operationId: updateConversation
+      parameters:
+      - name: id
+        in: path
+        description: Opaque ID of the conversation
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: if-match
+        in: header
+        description: The revision to update
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatMessage'
+        required: true
+      responses:
+        '200':
+          description: The resulting conversation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400':
+          description: The request was invalid
+        '404':
+          description: The AI service is not enabled or the conversation was not found
+    delete:
+      tags:
+      - ai
+      operationId: deleteConversation
+      parameters:
+      - name: id
+        in: path
+        description: Opaque ID of the conversation
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The resulting conversation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400':
+          description: The request was invalid
+        '404':
+          description: The AI service is not enabled or the conversation was not found
   /api/v2/advisory:
     get:
       tags:
@@ -2334,20 +2487,24 @@ components:
       required:
       - message_type
       - content
+      - timestamp
       properties:
         content:
           type: string
-        internal_state:
-          type:
-          - string
-          - 'null'
         message_type:
           $ref: '#/components/schemas/MessageType'
+        timestamp:
+          type: string
+          format: date-time
     ChatState:
       type: object
       required:
       - messages
       properties:
+        internal_state:
+          type:
+          - string
+          - 'null'
         messages:
           type: array
           items:
@@ -2409,6 +2566,42 @@ components:
         period:
           type: string
           description: The period the importer should be run.
+    Conversation:
+      type: object
+      required:
+      - id
+      - messages
+      - updated_at
+      - seq
+      properties:
+        id:
+          type: string
+          format: uuid
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessage'
+        seq:
+          type: integer
+          format: int32
+        updated_at:
+          type: string
+          format: date-time
+    ConversationSummary:
+      type: object
+      required:
+      - id
+      - updated_at
+      - summary
+      properties:
+        id:
+          type: string
+          format: uuid
+        summary:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
     CsafImporter:
       allOf:
       - $ref: '#/components/schemas/CommonImporter'
@@ -2838,6 +3031,33 @@ components:
           items:
             allOf:
             - $ref: '#/components/schemas/BasePurlHead'
+        total:
+          type: integer
+          format: int64
+          minimum: 0
+    PaginatedResults_ConversationSummary:
+      type: object
+      required:
+      - items
+      - total
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            required:
+            - id
+            - updated_at
+            - summary
+            properties:
+              id:
+                type: string
+                format: uuid
+              summary:
+                type: string
+              updated_at:
+                type: string
+                format: date-time
         total:
           type: integer
           format: int64

--- a/xtask/src/ai.rs
+++ b/xtask/src/ai.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use nu_ansi_term::Color::Blue;
 use reedline::FileBackedHistory;
 use reedline::{DefaultPrompt, DefaultPromptSegment, Reedline, Signal};
-use trustify_module_fundamental::ai::model::{ChatState, MessageType};
+use trustify_module_fundamental::ai::model::{ChatMessage, ChatState, MessageType};
 
 #[derive(Debug, Parser, Default)]
 pub struct Ai {
@@ -41,7 +41,7 @@ Enter your question or type:
 
     println!("Using Trustify endpoint: {}", url);
 
-    let mut chat_state = ChatState::new();
+    let mut chat_state = ChatState::default();
     loop {
         match line_editor.read_line(&prompt) {
             Ok(Signal::Success(buffer)) => {
@@ -51,14 +51,14 @@ Enter your question or type:
                         return Ok(());
                     }
                     "clear" => {
-                        chat_state = ChatState::new();
+                        chat_state = ChatState::default();
                         println!("{}", Blue.paint("\nChat history cleared..."));
                         continue;
                     }
                     _ => {}
                 }
 
-                chat_state.add_human_message(buffer.clone());
+                chat_state.messages.push(ChatMessage::human(buffer.clone()));
                 let pos = chat_state.messages.len();
 
                 let client = reqwest::Client::new();


### PR DESCRIPTION
LLM internal state messages is simplified to be a single field either on ChatState or in the Conversation table. We now keep timestamps for individual ChatMessages.

Also drop the db connection arg from the completions method as the DB is Not needed for those calls.

You can test out the completions API using the UI at: https://github.com/chirino/ai-assistant-vite

just `npm i && npm run dev` and use the browser link outputted.