### PR TITLE
chore: change API version to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ zipped archive of SBOMs and/or Advisories like so:
 ```shell
 cd etc/datasets
 make
-http POST localhost:8080/api/v1/dataset @ds1.zip
+http POST localhost:8080/api/v2/dataset @ds1.zip
 ```
 
 #### Upload
@@ -44,8 +44,8 @@ There is an "Upload" menu option in the GUI: http://localhost:8080/upload
 You can also interact with the API directly in a shell:
 
 ```shell
-cat some-sbom.json | http POST localhost:8080/api/v1/sbom
-cat some-advisory.json | http POST localhost:8080/api/v1/advisory
+cat some-sbom.json | http POST localhost:8080/api/v2/sbom
+cat some-advisory.json | http POST localhost:8080/api/v2/advisory
 ```
 
 #### Importers
@@ -140,7 +140,7 @@ If you haven't already, [get started!](https://www.rust-lang.org/learn/get-start
 
 #### If test failures on OSX
 
-Potentially our concurrent Postgres installations during testing can
+Potentially, our concurrent Postgres installations during testing can
 exhaust shared-memory.  Adjusting shared-memory on OSX is not
 straight-forward.  Use [this
 guide](https://unix.stackexchange.com/questions/689295/values-from-sysctl-a-dont-match-etc-sysctl-conf-even-after-restart).
@@ -149,7 +149,7 @@ guide](https://unix.stackexchange.com/questions/689295/values-from-sysctl-a-dont
 
 Unit tests and "PM mode" use an embedded instance of Postgres that is
 installed as required on the local filesystem. This is convenient for
-local development but you can also configure the app to use an
+local development, but you can also configure the app to use an
 external database.
 
 Starting a containerized Postgres instance:

--- a/modules/analysis/src/endpoints.rs
+++ b/modules/analysis/src/endpoints.rs
@@ -32,7 +32,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Analysis status.", body = AnalysisStatus),
     ),
 )]
-#[get("/v1/analysis/status")]
+#[get("/v2/analysis/status")]
 pub async fn analysis_status(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,
@@ -55,7 +55,7 @@ pub async fn analysis_status(
         (status = 200, description = "Search component(s) and return their root components.", body = AncestorSummary),
     ),
 )]
-#[get("/v1/analysis/root-component")]
+#[get("/v2/analysis/root-component")]
 pub async fn search_component_root_components(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,
@@ -80,7 +80,7 @@ pub async fn search_component_root_components(
         (status = 200, description = "Retrieve component(s) root components by name or pURL.", body = AncestorSummary),
     ),
 )]
-#[get("/v1/analysis/root-component/{key}")]
+#[get("/v2/analysis/root-component/{key}")]
 pub async fn get_component_root_components(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,
@@ -115,7 +115,7 @@ pub async fn get_component_root_components(
         (status = 200, description = "Search component(s) and return their deps.", body = DepSummary),
     ),
 )]
-#[get("/v1/analysis/dep")]
+#[get("/v2/analysis/dep")]
 pub async fn search_component_deps(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,
@@ -140,7 +140,7 @@ pub async fn search_component_deps(
         (status = 200, description = "Retrieve component(s) dep components by name or pURL.", body = DepSummary),
     ),
 )]
-#[get("/v1/analysis/dep/{key}")]
+#[get("/v2/analysis/dep/{key}")]
 pub async fn get_component_deps(
     service: web::Data<AnalysisService>,
     db: web::Data<Database>,
@@ -183,7 +183,7 @@ mod test {
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
         //should match multiple components
-        let uri = "/api/v1/analysis/root-component?q=B";
+        let uri = "/api/v2/analysis/root-component?q=B";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
 
@@ -197,7 +197,7 @@ mod test {
         log::info!("{:?}", response);
 
         //should match a single component
-        let uri = "/api/v1/analysis/root-component?q=BB";
+        let uri = "/api/v2/analysis/root-component?q=BB";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(response["items"][0]["purl"], "pkg:rpm/redhat/BB@0.0.0");
@@ -218,7 +218,7 @@ mod test {
         let app = caller(ctx).await?;
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-        let uri = "/api/v1/analysis/root-component/B";
+        let uri = "/api/v2/analysis/root-component/B";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
 
@@ -241,7 +241,7 @@ mod test {
         let app = caller(ctx).await?;
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-        let uri = "/api/v1/analysis/root-component/pkg%3A%2F%2Frpm%2Fredhat%2FB%400.0.0";
+        let uri = "/api/v2/analysis/root-component/pkg%3A%2F%2Frpm%2Fredhat%2FB%400.0.0";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
 
@@ -268,7 +268,7 @@ mod test {
         ])
         .await?;
 
-        let uri = "/api/v1/analysis/root-component?q=spymemcached";
+        let uri = "/api/v2/analysis/root-component?q=spymemcached";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
 
@@ -300,11 +300,11 @@ mod test {
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
         //prime the graph hashmap
-        let uri = "/api/v1/analysis/root-component?q=BB";
+        let uri = "/api/v2/analysis/root-component?q=BB";
         let load1 = TestRequest::get().uri(uri).to_request();
         let _response: Value = app.call_and_read_body_json(load1).await;
 
-        let uri = "/api/v1/analysis/status";
+        let uri = "/api/v2/analysis/status";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
 
@@ -314,7 +314,7 @@ mod test {
         // ingest duplicate sbom which has different date
         ctx.ingest_documents(["spdx/simple-dup.json"]).await?;
 
-        let uri = "/api/v1/analysis/status";
+        let uri = "/api/v2/analysis/status";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
 
@@ -330,7 +330,7 @@ mod test {
         let app = caller(ctx).await?;
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-        let uri = "/api/v1/analysis/dep?q=A";
+        let uri = "/api/v2/analysis/dep?q=A";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
 
@@ -357,7 +357,7 @@ mod test {
         let app = caller(ctx).await?;
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-        let uri = "/api/v1/analysis/dep/A";
+        let uri = "/api/v2/analysis/dep/A";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
@@ -385,7 +385,7 @@ mod test {
         let app = caller(ctx).await?;
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-        let uri = "/api/v1/analysis/dep/pkg%3A%2F%2Frpm%2Fredhat%2FAA%400.0.0%3Farch%3Dsrc";
+        let uri = "/api/v2/analysis/dep/pkg%3A%2F%2Frpm%2Fredhat%2FAA%400.0.0%3Farch%3Dsrc";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
@@ -412,7 +412,7 @@ mod test {
         ])
         .await?;
 
-        let uri = "/api/v1/analysis/dep?q=spymemcached";
+        let uri = "/api/v2/analysis/dep?q=spymemcached";
 
         let request: Request = TestRequest::get().uri(uri).to_request();
 
@@ -435,21 +435,21 @@ mod test {
         ctx.ingest_documents(["spdx/simple.json"]).await?;
 
         // filter on node_id
-        let uri = "/api/v1/analysis/dep?q=node_id%3DSPDXRef-A";
+        let uri = "/api/v2/analysis/dep?q=node_id%3DSPDXRef-A";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(response["items"][0]["name"], "A");
         assert_eq!(&response["total"], 1);
 
         // filter on node_id
-        let uri = "/api/v1/analysis/root-component?q=node_id%3DSPDXRef-B";
+        let uri = "/api/v2/analysis/root-component?q=node_id%3DSPDXRef-B";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(response["items"][0]["name"], "B");
         assert_eq!(&response["total"], 1);
 
         // filter on node_id & name
-        let uri = "/api/v1/analysis/root-component?q=node_id%3DSPDXRef-B%26name%3DB";
+        let uri = "/api/v2/analysis/root-component?q=node_id%3DSPDXRef-B%26name%3DB";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(response["items"][0]["name"], "B");
@@ -457,19 +457,19 @@ mod test {
 
         // filter on sbom_id (which has urn:uuid: prefix)
         let sbom_id = response["items"][0]["sbom_id"].as_str().unwrap();
-        let uri = format!("/api/v1/analysis/root-component?q=sbom_id={}", sbom_id);
+        let uri = format!("/api/v2/analysis/root-component?q=sbom_id={}", sbom_id);
         let request: Request = TestRequest::get().uri(uri.clone().as_str()).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(&response["total"], 8);
 
         // negative test
-        let uri = "/api/v1/analysis/root-component?q=sbom_id=urn:uuid:99999999-9999-9999-9999-999999999999";
+        let uri = "/api/v2/analysis/root-component?q=sbom_id=urn:uuid:99999999-9999-9999-9999-999999999999";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         assert_eq!(&response["total"], 0);
 
         // negative test
-        let uri = "/api/v1/analysis/root-component?q=node_id%3DSPDXRef-B%26name%3DA";
+        let uri = "/api/v2/analysis/root-component?q=node_id%3DSPDXRef-B%26name%3DA";
         let request: Request = TestRequest::get().uri(uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
 
@@ -486,7 +486,7 @@ mod test {
 
         // Find all deps of src rpm
         let src = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src";
-        let uri = format!("/api/v1/analysis/dep/{}", urlencoding::encode(src));
+        let uri = format!("/api/v2/analysis/dep/{}", urlencoding::encode(src));
         let request: Request = TestRequest::get().uri(&uri).to_request();
         let response: Value = app.call_and_read_body_json(request).await;
         log::debug!("{response:#?}");
@@ -495,7 +495,7 @@ mod test {
         // Ensure binary rpm GeneratedFrom src rpm
         let x86 = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64";
         let uri = format!(
-            "/api/v1/analysis/root-component/{}",
+            "/api/v2/analysis/root-component/{}",
             urlencoding::encode(x86)
         );
         let request: Request = TestRequest::get().uri(&uri).to_request();

--- a/modules/fundamental/README.md
+++ b/modules/fundamental/README.md
@@ -6,11 +6,11 @@
 By PURL:
 
 ```bash
-http localhost:8080/api/v1/sbom/by-purl purl==pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1
+http localhost:8080/api/v2/sbom/by-purl purl==pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1
 ```
 
 By package ID (as returned by other APIs):
 
 ```bash
-http localhost:8080/api/v1/sbom/by-purl id==6cfff15d-ee06-4cb7-be37-a835aed2af82
+http localhost:8080/api/v2/sbom/by-purl id==6cfff15d-ee06-4cb7-be37-a835aed2af82
 ```

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -18,7 +18,7 @@ use trustify_entity::labels::Labels;
         (status = 404, description = "The advisory could not be found"),
     ),
 )]
-#[put("/v1/advisory/{id}/label")]
+#[put("/v2/advisory/{id}/label")]
 pub async fn set(
     advisory: web::Data<AdvisoryService>,
     db: web::Data<Database>,
@@ -50,7 +50,7 @@ pub async fn set(
         (status = 404, description = "The advisory could not be found"),
     ),
 )]
-#[patch("/v1/advisory/{id}/label")]
+#[patch("/v2/advisory/{id}/label")]
 pub async fn update(
     advisory: web::Data<AdvisoryService>,
     id: web::Path<Id>,

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -64,7 +64,7 @@ pub fn configure(
         (status = 200, description = "Matching vulnerabilities", body = PaginatedResults<AdvisorySummary>),
     ),
 )]
-#[get("/v1/advisory")]
+#[get("/v2/advisory")]
 /// List advisories
 pub async fn all(
     state: web::Data<AdvisoryService>,
@@ -92,7 +92,7 @@ pub async fn all(
         (status = 404, description = "Matching advisory not found"),
     ),
 )]
-#[get("/v1/advisory/{key}")]
+#[get("/v2/advisory/{key}")]
 /// Get an advisory
 pub async fn get(
     state: web::Data<AdvisoryService>,
@@ -121,7 +121,7 @@ pub async fn get(
         (status = 404, description = "Matching advisory not found"),
     ),
 )]
-#[delete("/v1/advisory/{key}")]
+#[delete("/v2/advisory/{key}")]
 /// Delete an advisory
 pub async fn delete(
     state: web::Data<AdvisoryService>,
@@ -175,7 +175,7 @@ struct UploadParams {
         (status = 400, description = "The file could not be parsed as an advisory"),
     )
 )]
-#[post("/v1/advisory")]
+#[post("/v2/advisory")]
 /// Upload a new advisory
 pub async fn upload(
     service: web::Data<IngestorService>,
@@ -204,7 +204,7 @@ pub async fn upload(
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/v1/advisory/{key}/download")]
+#[get("/v2/advisory/{key}/download")]
 /// Download an advisory document
 pub async fn download(
     db: web::Data<Database>,

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -83,7 +83,7 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -171,7 +171,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = format!("/api/v1/advisory/urn:uuid:{}", advisory2.advisory.id);
+    let uri = format!("/api/v2/advisory/urn:uuid:{}", advisory2.advisory.id);
 
     let request = TestRequest::get().uri(&uri).to_request();
 
@@ -193,7 +193,7 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         json!(["CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N"])
     );
 
-    let uri = format!("/api/v1/advisory/urn:uuid:{}", advisory1.advisory.id);
+    let uri = format!("/api/v2/advisory/urn:uuid:{}", advisory1.advisory.id);
 
     let request = TestRequest::get().uri(&uri).to_request();
 
@@ -270,7 +270,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         )
         .await?;
 
-    let uri = format!("/api/v1/advisory/{}", uuid.urn());
+    let uri = format!("/api/v2/advisory/{}", uuid.urn());
 
     let request = TestRequest::get().uri(&uri).to_request();
 
@@ -302,7 +302,7 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 async fn search_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     async fn query(app: &impl CallService, q: &str) -> PaginatedResults<AdvisorySummary> {
         let uri = format!(
-            "/api/v1/advisory?q={}&sort={}",
+            "/api/v2/advisory?q={}&sort={}",
             urlencoding::encode(q),
             urlencoding::encode("ingested:desc")
         );
@@ -348,7 +348,7 @@ async fn upload_default_csaf_format(ctx: &TrustifyContext) -> Result<(), anyhow:
 
     let payload = document_bytes("csaf/cve-2023-33201.json").await?;
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -386,7 +386,7 @@ async fn upload_default_csaf_format_multiple(ctx: &TrustifyContext) -> Result<()
         "csaf/rhsa-2024-2705.json",
     ];
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
 
     for file in files {
         let payload = document_bytes(file).await?;
@@ -410,7 +410,7 @@ async fn upload_osv_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let payload = document_bytes("osv/RUSTSEC-2021-0079.json").await?;
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -429,7 +429,7 @@ async fn upload_cve_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let payload = document_bytes("mitre/CVE-2024-27088.json").await?;
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -447,7 +447,7 @@ async fn upload_cve_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn upload_unknown_format(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/advisory";
+    let uri = "/api/v2/advisory";
     let request = TestRequest::post().uri(uri).to_request();
 
     let response = app.call_service(request).await;
@@ -468,7 +468,7 @@ async fn upload_with_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     let app = caller(ctx).await?;
     let payload = document_bytes("csaf/cve-2023-33201.json").await?;
 
-    let uri = "/api/v1/advisory?labels.foo=bar&labels.bar=baz";
+    let uri = "/api/v2/advisory?labels.foo=bar&labels.bar=baz";
     let request = TestRequest::post()
         .uri(uri)
         .set_payload(payload)
@@ -485,7 +485,7 @@ async fn upload_with_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     // now check the labels
 
     let request = TestRequest::get()
-        .uri(&format!("/api/v1/advisory/{}", result.id))
+        .uri(&format!("/api/v2/advisory/{}", result.id))
         .to_request();
     let result: AdvisoryDetails = app.call_and_read_body_json(request).await;
 
@@ -511,7 +511,7 @@ async fn download_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let digest: String = Sha256::digest(document_bytes(DOC).await?).encode_hex();
     let app = caller(ctx).await?;
     ctx.ingest_document(DOC).await?;
-    let uri = format!("/api/v1/advisory/sha256:{digest}/download");
+    let uri = format!("/api/v2/advisory/sha256:{digest}/download");
     let request = TestRequest::get().uri(&uri).to_request();
     let doc: Value = app.call_and_read_body_json(request).await;
     assert_eq!(doc["document"]["tracking"]["id"], "CVE-2023-33201");
@@ -525,7 +525,7 @@ async fn download_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn download_advisory_by_id(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let result = ctx.ingest_document(DOC).await?;
-    let uri = format!("/api/v1/advisory/{}/download", result.id);
+    let uri = format!("/api/v2/advisory/{}/download", result.id);
     let request = TestRequest::get().uri(&uri).to_request();
     let doc: Value = app.call_and_read_body_json(request).await;
     assert_eq!(doc["document"]["tracking"]["id"], "CVE-2023-33201");
@@ -540,7 +540,7 @@ async fn set_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
     let result = ctx.ingest_document(DOC).await?;
     let request = TestRequest::patch()
-        .uri(&format!("/api/v1/advisory/{}/label", result.id))
+        .uri(&format!("/api/v2/advisory/{}/label", result.id))
         .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
         .to_request();
     let response = app.call_service(request).await;
@@ -558,7 +558,7 @@ async fn set_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     ctx.ingest_document(DOC).await?;
     let request = TestRequest::patch()
         .uri(&format!(
-            "/api/v1/advisory/{}/label",
+            "/api/v2/advisory/{}/label",
             Id::Uuid(Uuid::now_v7())
         ))
         .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
@@ -578,7 +578,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let doc = ctx.ingest_document(DOC).await?;
 
     let advisory_list: PaginatedResults<AdvisorySummary> = app
-        .call_and_read_body_json(TestRequest::get().uri("/api/v1/advisory").to_request())
+        .call_and_read_body_json(TestRequest::get().uri("/api/v2/advisory").to_request())
         .await;
     assert_eq!(advisory_list.total, 1);
 
@@ -586,7 +586,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v1/advisory/{}", doc.id))
+                .uri(&format!("/api/v2/advisory/{}", doc.id))
                 .to_request(),
         )
         .await;
@@ -596,7 +596,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // check that the document is gone
     let advisory_list: PaginatedResults<AdvisorySummary> = app
-        .call_and_read_body_json(TestRequest::get().uri("/api/v1/advisory").to_request())
+        .call_and_read_body_json(TestRequest::get().uri("/api/v2/advisory").to_request())
         .await;
     assert_eq!(advisory_list.total, 0);
 
@@ -604,7 +604,7 @@ async fn delete_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response = app
         .call_service(
             TestRequest::delete()
-                .uri(&format!("/api/v1/advisory/{}", doc.id))
+                .uri(&format!("/api/v2/advisory/{}", doc.id))
                 .to_request(),
         )
         .await;

--- a/modules/fundamental/src/ai/endpoints/mod.rs
+++ b/modules/fundamental/src/ai/endpoints/mod.rs
@@ -32,7 +32,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 404, description = "The AI service is not enabled")
     )
 )]
-#[post("/v1/ai/completions")]
+#[post("/v2/ai/completions")]
 pub async fn completions(
     service: web::Data<AiService>,
     db: web::Data<Database>,
@@ -51,7 +51,7 @@ pub async fn completions(
         (status = 404, description = "The AI service is not enabled")
     )
 )]
-#[get("/v1/ai/flags")]
+#[get("/v2/ai/flags")]
 // Gets the flags for the AI service
 pub async fn flags(
     service: web::Data<AiService>,
@@ -70,7 +70,7 @@ pub async fn flags(
         (status = 404, description = "The AI service is not enabled")
     )
 )]
-#[get("/v1/ai/tools")]
+#[get("/v2/ai/tools")]
 // Gets the list of tools that are available to assist AI services.
 pub async fn tools(
     service: web::Data<AiService>,
@@ -101,7 +101,7 @@ pub async fn tools(
         (status = 404, description = "The tool was not found")
     )
 )]
-#[post("/v1/ai/tools/{name}")]
+#[post("/v2/ai/tools/{name}")]
 pub async fn tool_call(
     service: web::Data<AiService>,
     name: web::Path<String>,

--- a/modules/fundamental/src/ai/endpoints/test.rs
+++ b/modules/fundamental/src/ai/endpoints/test.rs
@@ -26,7 +26,7 @@ async fn configure(ctx: &TrustifyContext) -> anyhow::Result<()> {
     req.add_human_message("Give me information about the SBOMs available for quarkus reporting its name, SHA and URL.".into());
 
     let request = TestRequest::post()
-        .uri("/api/v1/ai/completions")
+        .uri("/api/v2/ai/completions")
         .set_json(req)
         .to_request();
 
@@ -50,7 +50,7 @@ async fn configure(ctx: &TrustifyContext) -> anyhow::Result<()> {
 #[test(actix_web::test)]
 async fn flags(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let app = caller(ctx).await?;
-    let request = TestRequest::get().uri("/api/v1/ai/flags").to_request();
+    let request = TestRequest::get().uri("/api/v2/ai/flags").to_request();
 
     let response = app.call_service(request).await;
     log::debug!("Code: {}", response.status());
@@ -76,7 +76,7 @@ async fn flags(ctx: &TrustifyContext) -> anyhow::Result<()> {
 #[test(actix_web::test)]
 async fn tools(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let app = caller(ctx).await?;
-    let request = TestRequest::get().uri("/api/v1/ai/tools").to_request();
+    let request = TestRequest::get().uri("/api/v2/ai/tools").to_request();
 
     let response = app.call_service(request).await;
     log::debug!("Code: {}", response.status());
@@ -107,7 +107,7 @@ async fn tools_call(ctx: &TrustifyContext) -> anyhow::Result<()> {
     let app = caller(ctx).await?;
 
     let request = TestRequest::post()
-        .uri("/api/v1/ai/tools/unknown")
+        .uri("/api/v2/ai/tools/unknown")
         .set_json(json!({"input":"quarkus"}))
         .to_request();
 
@@ -115,7 +115,7 @@ async fn tools_call(ctx: &TrustifyContext) -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     let request = TestRequest::post()
-        .uri("/api/v1/ai/tools/sbom-info")
+        .uri("/api/v2/ai/tools/sbom-info")
         .set_json(json!({"input":"quarkus"}))
         .to_request();
 

--- a/modules/fundamental/src/license/endpoints/mod.rs
+++ b/modules/fundamental/src/license/endpoints/mod.rs
@@ -40,7 +40,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Matching licenses", body = PaginatedResults<LicenseSummary>),
     ),
 )]
-#[get("/v1/license")]
+#[get("/v2/license")]
 /// List licenses
 pub async fn list_licenses(
     state: web::Data<LicenseService>,
@@ -57,7 +57,7 @@ pub async fn list_licenses(
         (status = 200, description = "The license", body = LicenseSummary),
     ),
 )]
-#[get("/v1/license/{uuid}")]
+#[get("/v2/license/{uuid}")]
 /// Retrieve license details
 pub async fn get_license(
     state: web::Data<LicenseService>,
@@ -77,7 +77,7 @@ pub async fn get_license(
         (status = 200, description = "The versioned pURLs allowing the license", body = LicenseSummary),
     ),
 )]
-#[get("/v1/license/{uuid}/purl")]
+#[get("/v2/license/{uuid}/purl")]
 /// Retrieve pURLs covered by a license
 pub async fn get_license_purls(
     state: web::Data<LicenseService>,

--- a/modules/fundamental/src/license/endpoints/spdx.rs
+++ b/modules/fundamental/src/license/endpoints/spdx.rs
@@ -18,7 +18,7 @@ use trustify_common::{
         (status = 200, description = "Matching licenses", body = PaginatedResults<SpdxLicenseSummary>),
     ),
 )]
-#[get("/v1/license/spdx/license")]
+#[get("/v2/license/spdx/license")]
 /// List SPDX licenses
 pub async fn list_spdx_licenses(
     state: web::Data<LicenseService>,
@@ -37,7 +37,7 @@ pub async fn list_spdx_licenses(
         (status = 200, description = "SPDX license details", body = SpdxLicenseDetails),
     ),
 )]
-#[get("/v1/license/spdx/license/{id}")]
+#[get("/v2/license/spdx/license/{id}")]
 /// Get SPDX license details
 pub async fn get_spdx_license(
     state: web::Data<LicenseService>,

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -13,7 +13,7 @@ use trustify_test_context::{call::CallService, TrustifyContext};
 async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/license/spdx/license";
+    let uri = "/api/v2/license/spdx/license";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -29,12 +29,12 @@ async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/license/spdx/license/GLWTPL";
+    let uri = "/api/v2/license/spdx/license/GLWTPL";
     let request = TestRequest::get().uri(uri).to_request();
     let response: SpdxLicenseDetails = app.call_and_read_body_json(request).await;
     assert_eq!(response.summary.id, "GLWTPL");
 
-    let uri = "/api/v1/license/spdx/license/GlwtPL";
+    let uri = "/api/v2/license/spdx/license/GlwtPL";
     let request = TestRequest::get().uri(uri).to_request();
     let response: SpdxLicenseDetails = app.call_and_read_body_json(request).await;
     assert_eq!(response.summary.id, "GLWTPL");
@@ -47,7 +47,7 @@ async fn get_spdx_license(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 async fn list_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/license?q=LGPL";
+    let uri = "/api/v2/license?q=LGPL";
 
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseSummary> = app.call_and_read_body_json(request).await;
@@ -69,7 +69,7 @@ async fn list_license_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     ctx.ingest_document("ubi9-9.2-755.1697625012.json").await?;
 
-    let uri = "/api/v1/license?q=LGPL&limit=0";
+    let uri = "/api/v2/license?q=LGPL&limit=0";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<LicenseSummary> = app.call_and_read_body_json(request).await;
 
@@ -79,7 +79,7 @@ async fn list_license_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     let lgpl = lgpl.unwrap();
 
-    let uri = format!("/api/v1/license/{}/purl", lgpl.id.urn());
+    let uri = format!("/api/v2/license/{}/purl", lgpl.id.urn());
 
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<LicenseDetailsPurlSummary> =
@@ -87,7 +87,7 @@ async fn list_license_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     assert_eq!(29, response.total);
 
-    let uri = format!("/api/v1/license/{}/purl?offset=25", lgpl.id.urn());
+    let uri = format!("/api/v2/license/{}/purl?offset=25", lgpl.id.urn());
 
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<LicenseDetailsPurlSummary> =

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -33,7 +33,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Matching organizations", body = OrganizationSummary),
     ),
 )]
-#[get("/v1/organization")]
+#[get("/v2/organization")]
 /// List organizations
 pub async fn all(
     state: web::Data<OrganizationService>,
@@ -60,7 +60,7 @@ pub async fn all(
         (status = 404, description = "Matching organization not found"),
     ),
 )]
-#[get("/v1/organization/{id}")]
+#[get("/v2/organization/{id}")]
 /// Retrieve organization details
 pub async fn get(
     state: web::Data<OrganizationService>,

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -52,7 +52,7 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v1/organization?sort=name";
+    let uri = "/api/v2/organization?sort=name";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -110,7 +110,7 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_org = &orgs.items[0];
     let org_id = first_org.head.id;
 
-    let uri = format!("/api/v1/organization/{}", org_id);
+    let uri = format!("/api/v2/organization/{}", org_id);
 
     let request = TestRequest::get().uri(&uri).to_request();
 

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -38,7 +38,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Matching products", body = PaginatedResults<ProductSummary>),
     ),
 )]
-#[get("/v1/product")]
+#[get("/v2/product")]
 pub async fn all(
     state: web::Data<ProductService>,
     db: web::Data<Database>,
@@ -60,7 +60,7 @@ pub async fn all(
         (status = 404, description = "Matching product not found"),
     ),
 )]
-#[get("/v1/product/{id}")]
+#[get("/v2/product/{id}")]
 pub async fn get(
     state: web::Data<ProductService>,
     db: web::Data<Database>,
@@ -86,7 +86,7 @@ pub async fn get(
         (status = 404, description = "Matching product not found"),
     ),
 )]
-#[delete("/v1/product/{id}")]
+#[delete("/v2/product/{id}")]
 pub async fn delete(
     state: web::Data<ProductService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -37,7 +37,7 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v1/product?sort=name";
+    let uri = "/api/v2/product?sort=name";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -77,7 +77,7 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
 
-    let uri = format!("/api/v1/product/{}", product_id);
+    let uri = format!("/api/v2/product/{}", product_id);
 
     let request = TestRequest::get().uri(&uri).to_request();
 
@@ -117,7 +117,7 @@ async fn delete_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let first_product = &products.items[0];
     let product_id = first_product.head.id;
 
-    let uri = format!("/api/v1/product/{}", product_id);
+    let uri = format!("/api/v2/product/{}", product_id);
 
     let request = TestRequest::delete().uri(&uri).to_request();
 

--- a/modules/fundamental/src/purl/endpoints/base.rs
+++ b/modules/fundamental/src/purl/endpoints/base.rs
@@ -26,7 +26,7 @@ use trustify_common::{
         (status = 200, description = "Details for the versionless base PURL", body = BasePurlDetails),
     ),
 )]
-#[get("/v1/purl/base/{key}")]
+#[get("/v2/purl/base/{key}")]
 /// Retrieve details about a base versionless pURL
 pub async fn get_base_purl(
     service: web::Data<PurlService>,
@@ -54,7 +54,7 @@ pub async fn get_base_purl(
         (status = 200, description = "All relevant matching versionless base PURL", body = PaginatedResults<BasePurlSummary>),
     ),
 )]
-#[get("/v1/purl/base")]
+#[get("/v2/purl/base")]
 /// List base versionless pURLs
 pub async fn all_base_purls(
     service: web::Data<PurlService>,

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -47,7 +47,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Details for the qualified PURL", body = PurlDetails),
     ),
 )]
-#[get("/v1/purl/{key}")]
+#[get("/v2/purl/{key}")]
 /// Retrieve details of a fully-qualified pURL
 pub async fn get(
     service: web::Data<PurlService>,
@@ -76,7 +76,7 @@ pub async fn get(
         (status = 200, description = "All relevant matching qualified PURLs", body = PaginatedResults<PurlSummary>),
     ),
 )]
-#[get("/v1/purl")]
+#[get("/v2/purl")]
 /// List fully-qualified pURLs
 pub async fn all(
     service: web::Data<PurlService>,

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -76,7 +76,7 @@ async fn types(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type";
+    let uri = "/api/v2/purl/type";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -104,7 +104,7 @@ async fn r#type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven";
+    let uri = "/api/v2/purl/type/maven";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -115,7 +115,7 @@ async fn r#type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let log4j = &response.items[0];
     assert_eq!("pkg:maven/org.apache/log4j", log4j.head.purl.to_string());
 
-    let uri = "/api/v1/purl/type/rpm";
+    let uri = "/api/v2/purl/type/rpm";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -135,7 +135,7 @@ async fn type_package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven/org.apache/log4j";
+    let uri = "/api/v2/purl/type/maven/org.apache/log4j";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -166,7 +166,7 @@ async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
+    let uri = "/api/v2/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
     let response: VersionedPurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(2, response.purls.len());
@@ -179,7 +179,7 @@ async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         .iter()
         .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17"));
 
-    let uri = "/api/v1/purl/type/rpm/sendmail@4.4.4";
+    let uri = "/api/v2/purl/type/rpm/sendmail@4.4.4";
     let request = TestRequest::get().uri(uri).to_request();
     let response: VersionedPurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(0, response.purls.len());
@@ -193,7 +193,7 @@ async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
+    let uri = "/api/v2/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
     let response: VersionedPurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(2, response.purls.len());
@@ -206,7 +206,7 @@ async fn package(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert!(jdk17.is_some());
     let jdk17 = jdk17.unwrap();
 
-    let uri = format!("/api/v1/purl/{}", jdk17.uuid);
+    let uri = format!("/api/v2/purl/{}", jdk17.uuid);
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PurlDetails = app.call_and_read_body_json(request).await;
 
@@ -223,12 +223,12 @@ async fn version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven/org.apache/log4j@1.2.3";
+    let uri = "/api/v2/purl/type/maven/org.apache/log4j@1.2.3";
     let request = TestRequest::get().uri(uri).to_request();
     let log4j_123: VersionedPurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(2, log4j_123.purls.len());
 
-    let uri = format!("/api/v1/purl/version/{}", log4j_123.head.uuid);
+    let uri = format!("/api/v2/purl/version/{}", log4j_123.head.uuid);
     let request = TestRequest::get().uri(&uri).to_request();
     let response: VersionedPurlDetails = app.call_and_read_body_json(request).await;
 
@@ -243,12 +243,12 @@ async fn base(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/type/maven/org.apache/log4j";
+    let uri = "/api/v2/purl/type/maven/org.apache/log4j";
     let request = TestRequest::get().uri(uri).to_request();
     let log4j: BasePurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(2, log4j.versions.len());
 
-    let uri = format!("/api/v1/purl/base/{}", log4j.head.uuid);
+    let uri = format!("/api/v2/purl/base/{}", log4j.head.uuid);
     let request = TestRequest::get().uri(&uri).to_request();
     let response: BasePurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(log4j.head.uuid, response.head.uuid);
@@ -262,7 +262,7 @@ async fn base_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl/base?q=log4j";
+    let uri = "/api/v2/purl/base?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<BasePurlSummary> = app.call_and_read_body_json(request).await;
 
@@ -277,7 +277,7 @@ async fn qualified_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl?q=log4j";
+    let uri = "/api/v2/purl?q=log4j";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
 
@@ -292,7 +292,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
     setup(&ctx.db, &ctx.graph).await?;
     let app = caller(ctx).await?;
 
-    let uri = format!("/api/v1/purl?q={}", encode("type=maven"));
+    let uri = format!("/api/v2/purl?q={}", encode("type=maven"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(3, response.items.len());
@@ -304,7 +304,7 @@ async fn qualified_packages_filtering(ctx: &TrustifyContext) -> Result<(), anyho
             &ctx.db,
         )
         .await?;
-    let uri = format!("/api/v1/purl?q={}", encode("type=rpm&arch=i386"));
+    let uri = format!("/api/v2/purl?q={}", encode("type=rpm&arch=i386"));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
     assert_eq!(1, response.items.len());
@@ -325,7 +325,7 @@ async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/purl?q=hyper";
+    let uri = "/api/v2/purl?q=hyper";
     let request = TestRequest::get().uri(uri).to_request();
     let response: PaginatedResults<PurlSummary> = app.call_and_read_body_json(request).await;
 
@@ -333,7 +333,7 @@ async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     let uuid = response.items[0].head.uuid;
 
-    let uri = format!("/api/v1/purl/{uuid}");
+    let uri = format!("/api/v2/purl/{uuid}");
 
     let request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;

--- a/modules/fundamental/src/purl/endpoints/type.rs
+++ b/modules/fundamental/src/purl/endpoints/type.rs
@@ -21,7 +21,7 @@ use trustify_common::{
         (status = 200, description = "List of all known PURL types", body = Vec<TypeSummary>),
     ),
 )]
-#[get("/v1/purl/type")]
+#[get("/v2/purl/type")]
 /// List known pURL types
 pub async fn all_purl_types(
     service: web::Data<PurlService>,
@@ -43,7 +43,7 @@ pub async fn all_purl_types(
         (status = 200, description = "Information regarding PURLs within an type", body = PaginatedResults<BasePurlSummary>),
     ),
 )]
-#[get("/v1/purl/type/{type}")]
+#[get("/v2/purl/type/{type}")]
 /// Retrieve details about a pURL type
 pub async fn get_purl_type(
     service: web::Data<PurlService>,
@@ -72,7 +72,7 @@ pub async fn get_purl_type(
         (status = 200, description = "Matching vulnerabilities", body = BasePurlDetails),
     ),
 )]
-#[get("/v1/purl/type/{type}/{namespace_and_name:[^@]+}")]
+#[get("/v2/purl/type/{type}/{namespace_and_name:[^@]+}")]
 /// Retrieve base pURL details of a type
 pub async fn get_base_purl_of_type(
     service: web::Data<PurlService>,
@@ -107,7 +107,7 @@ pub async fn get_base_purl_of_type(
         (status = 200, description = "Matching vulnerabilities", body = VersionedPurlDetails),
     ),
 )]
-#[get("/v1/purl/type/{type}/{namespace_and_name:[^@]+}@{version}")]
+#[get("/v2/purl/type/{type}/{namespace_and_name:[^@]+}@{version}")]
 /// Retrieve versioned pURL details of a type
 pub async fn get_versioned_purl_of_type(
     service: web::Data<PurlService>,

--- a/modules/fundamental/src/purl/endpoints/version.rs
+++ b/modules/fundamental/src/purl/endpoints/version.rs
@@ -18,7 +18,7 @@ use trustify_common::{db::Database, id::IdError, purl::Purl};
         (status = 200, description = "Details for the version of a PURL", body = VersionedPurlDetails),
     ),
 )]
-#[get("/v1/purl/version/{key}")]
+#[get("/v2/purl/version/{key}")]
 /// Retrieve details of a versioned, non-qualified pURL
 pub async fn get_versioned_purl(
     service: web::Data<PurlService>,

--- a/modules/fundamental/src/sbom/endpoints/label.rs
+++ b/modules/fundamental/src/sbom/endpoints/label.rs
@@ -18,7 +18,7 @@ use trustify_entity::labels::Labels;
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[patch("/v1/sbom/{id}/label")]
+#[patch("/v2/sbom/{id}/label")]
 pub async fn update(
     sbom: web::Data<SbomService>,
     id: web::Path<Id>,
@@ -49,7 +49,7 @@ pub async fn update(
         (status = 404, description = "The SBOM could not be found"),
     ),
 )]
-#[put("/v1/sbom/{id}/label")]
+#[put("/v2/sbom/{id}/label")]
 pub async fn set(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -83,7 +83,7 @@ pub fn configure(
         (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary>),
     ),
 )]
-#[get("/v1/sbom")]
+#[get("/v2/sbom")]
 pub async fn all(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -167,7 +167,7 @@ impl TryFrom<AllRelatedQuery> for Uuid {
         (status = 200, description = "Matching SBOMs", body = PaginatedResults<SbomSummary>),
     ),
 )]
-#[get("/v1/sbom/by-package")]
+#[get("/v2/sbom/by-package")]
 pub async fn all_related(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -202,7 +202,7 @@ pub async fn all_related(
         (status = 200, description = "Number of matching SBOMs per package", body = Vec<i64>),
     ),
 )]
-#[get("/v1/sbom/count-by-package")]
+#[get("/v2/sbom/count-by-package")]
 pub async fn count_related(
     sbom: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -230,7 +230,7 @@ pub async fn count_related(
         (status = 404, description = "Matching SBOM not found"),
     ),
 )]
-#[get("/v1/sbom/{id}")]
+#[get("/v2/sbom/{id}")]
 pub async fn get(
     fetcher: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -255,7 +255,7 @@ pub async fn get(
         (status = 404, description = "Matching SBOM not found"),
     ),
 )]
-#[get("/v1/sbom/{id}/advisory")]
+#[get("/v2/sbom/{id}/advisory")]
 pub async fn get_sbom_advisories(
     fetcher: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -282,7 +282,7 @@ all!(GetSbomAdvisories -> ReadSbom, ReadAdvisory);
         (status = 404, description = "Matching SBOM not found"),
     ),
 )]
-#[delete("/v1/sbom/{id}")]
+#[delete("/v2/sbom/{id}")]
 pub async fn delete(
     service: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -323,7 +323,7 @@ pub async fn delete(
         (status = 200, description = "Packages", body = PaginatedResults<SbomPackage>),
     ),
 )]
-#[get("/v1/sbom/{id}/packages")]
+#[get("/v2/sbom/{id}/packages")]
 pub async fn packages(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -366,7 +366,7 @@ struct RelatedQuery {
         (status = 200, description = "Packages", body = PaginatedResults<SbomPackageRelation>),
     ),
 )]
-#[get("/v1/sbom/{id}/related")]
+#[get("/v2/sbom/{id}/related")]
 pub async fn related(
     fetch: web::Data<SbomService>,
     db: web::Data<Database>,
@@ -418,7 +418,7 @@ struct UploadQuery {
         (status = 400, description = "The file could not be parsed as an advisory"),
     )
 )]
-#[post("/v1/sbom")]
+#[post("/v2/sbom")]
 /// Upload a new SBOM
 pub async fn upload(
     service: web::Data<IngestorService>,
@@ -445,7 +445,7 @@ pub async fn upload(
         (status = 404, description = "The document could not be found"),
     )
 )]
-#[get("/v1/sbom/{key}/download")]
+#[get("/v2/sbom/{key}/download")]
 pub async fn download(
     ingestor: web::Data<IngestorService>,
     db: web::Data<Database>,

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -39,7 +39,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Matching vulnerabilities", body = PaginatedResults<VulnerabilitySummary>),
     ),
 )]
-#[get("/v1/vulnerability")]
+#[get("/v2/vulnerability")]
 /// List vulnerabilities
 pub async fn all(
     state: web::Data<VulnerabilityService>,
@@ -67,7 +67,7 @@ pub async fn all(
         (status = 404, description = "Specified vulnerability not found"),
     ),
 )]
-#[get("/v1/vulnerability/{id}")]
+#[get("/v2/vulnerability/{id}")]
 /// Retrieve vulnerability details
 pub async fn get(
     state: web::Data<VulnerabilityService>,
@@ -97,7 +97,7 @@ pub async fn get(
         (status = 404, description = "Specified vulnerability not found"),
     ),
 )]
-#[delete("/v1/vulnerability/{id}")]
+#[delete("/v2/vulnerability/{id}")]
 /// Delete vulnerability
 pub async fn delete(
     state: web::Data<VulnerabilityService>,

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -90,7 +90,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         .ingest_vulnerability("CVE-345", (), &ctx.db)
         .await?;
 
-    let uri = "/api/v1/vulnerability";
+    let uri = "/api/v2/vulnerability";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -187,7 +187,7 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let uri = "/api/v1/vulnerability/CVE-123";
+    let uri = "/api/v2/vulnerability/CVE-123";
     let request = TestRequest::get().uri(uri).to_request();
     let vuln: Value = app.call_and_read_body_json(request).await;
     log::debug!("{:#?}", vuln);
@@ -282,7 +282,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         )
         .await?;
 
-    let uri = "/api/v1/vulnerability/CVE-123";
+    let uri = "/api/v2/vulnerability/CVE-123";
     let response = app
         .call_service(TestRequest::get().uri(uri).to_request())
         .await;
@@ -323,7 +323,7 @@ async fn get_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let vuln: Value = app
         .call_and_read_body_json(
             TestRequest::get()
-                .uri("/api/v1/vulnerability/CVE-2024-26308")
+                .uri("/api/v2/vulnerability/CVE-2024-26308")
                 .to_request(),
         )
         .await;

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -26,7 +26,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         (status = 200, description = "Matching weaknesses", body = PaginatedResults<LicenseSummary>),
     ),
 )]
-#[get("/v1/weakness")]
+#[get("/v2/weakness")]
 /// List weaknesses
 pub async fn list_weaknesses(
     state: web::Data<WeaknessService>,
@@ -44,7 +44,7 @@ pub async fn list_weaknesses(
         (status = 200, description = "The weakness", body = LicenseSummary),
     ),
 )]
-#[get("/v1/weakness/{id}")]
+#[get("/v2/weakness/{id}")]
 /// Retrieve weakness details
 pub async fn get_weakness(
     state: web::Data<WeaknessService>,

--- a/modules/fundamental/src/weakness/endpoints/test.rs
+++ b/modules/fundamental/src/weakness/endpoints/test.rs
@@ -20,7 +20,7 @@ async fn list_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/weakness";
+    let uri = "/api/v2/weakness";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -44,7 +44,7 @@ async fn query_weaknesses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/weakness?q=struts";
+    let uri = "/api/v2/weakness?q=struts";
 
     let request = TestRequest::get().uri(uri).to_request();
 
@@ -68,7 +68,7 @@ async fn get_weakness(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let app = caller(ctx).await?;
 
-    let uri = "/api/v1/weakness/CWE-1004";
+    let uri = "/api/v2/weakness/CWE-1004";
 
     let request = TestRequest::get().uri(uri).to_request();
 

--- a/modules/fundamental/tests/limit.rs
+++ b/modules/fundamental/tests/limit.rs
@@ -20,7 +20,7 @@ async fn upload_bomb_sbom(ctx: &TrustifyContext) -> anyhow::Result<()> {
     .await?;
 
     let request = TestRequest::post()
-        .uri("/api/v1/sbom")
+        .uri("/api/v2/sbom")
         .set_payload(document_bytes_raw("bomb.bz2").await?)
         .to_request();
 
@@ -43,7 +43,7 @@ async fn upload_bomb_advisory(ctx: &TrustifyContext) -> anyhow::Result<()> {
     .await?;
 
     let request = TestRequest::post()
-        .uri("/api/v1/advisory")
+        .uri("/api/v2/advisory")
         .set_payload(document_bytes_raw("bomb.bz2").await?)
         .to_request();
 

--- a/modules/importer/README.md
+++ b/modules/importer/README.md
@@ -3,13 +3,13 @@
 ## Create a new CSAF importer
 
 ```shell
-http POST localhost:8080/api/v1/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[onlyPatterns][]="^cve-2023-" csaf[period]=30s csaf[v3Signatures]:=true
+http POST localhost:8080/api/v2/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[onlyPatterns][]="^cve-2023-" csaf[period]=30s csaf[v3Signatures]:=true
 ```
 
 ## Create a new OSV importer
 
 ```shell
-http POST localhost:8080/api/v1/importer/osv-r osv[source]=https://github.com/RConsortium/r-advisory-database osv[path]=vulns osv[disabled]:=false osv[period]=30s
+http POST localhost:8080/api/v2/importer/osv-r osv[source]=https://github.com/RConsortium/r-advisory-database osv[path]=vulns osv[disabled]:=false osv[period]=30s
 ```
 
 ## Create a new SBOM importer
@@ -17,70 +17,70 @@ http POST localhost:8080/api/v1/importer/osv-r osv[source]=https://github.com/RC
 Quarkus & RHEL 9 data:
 
 ```shell
-http POST localhost:8080/api/v1/importer/redhat-sbom sbom[source]=https://access.redhat.com/security/data/sbom/beta/ sbom[keys][]=https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
+http POST localhost:8080/api/v2/importer/redhat-sbom sbom[source]=https://access.redhat.com/security/data/sbom/beta/ sbom[keys][]=https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4 sbom[disabled]:=false sbom[onlyPatterns][]=quarkus sbom[onlyPatterns][]=rhel-9 sbom[period]=30s sbom[v3Signatures]:=true
 ```
 
 ## Get all importers
 
 ```shell
-http GET localhost:8080/api/v1/importer
+http GET localhost:8080/api/v2/importer
 ```
 
 ## Get a specific importer
 
 ```shell
-http GET localhost:8080/api/v1/importer/redhat-csaf
-http GET localhost:8080/api/v1/importer/redhat-sbom
+http GET localhost:8080/api/v2/importer/redhat-csaf
+http GET localhost:8080/api/v2/importer/redhat-sbom
 ```
 
 ## Get reports
 
 ```shell
-http GET localhost:8080/api/v1/importer/redhat-csaf/report
-http GET localhost:8080/api/v1/importer/redhat-sbom/report
+http GET localhost:8080/api/v2/importer/redhat-csaf/report
+http GET localhost:8080/api/v2/importer/redhat-sbom/report
 ```
 
 ## Update an importer configuration
 
 ```shell
-http PUT localhost:8080/api/v1/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[period]=30s csaf[v3Signatures]:=true csaf[fetchRetries]:=50
+http PUT localhost:8080/api/v2/importer/redhat-csaf csaf[source]=https://redhat.com/.well-known/csaf/provider-metadata.json csaf[disabled]:=false csaf[period]=30s csaf[v3Signatures]:=true csaf[fetchRetries]:=50
 ```
 
 Or, updating the existing configuration (requires `jq`). To preview the changes:
 
 ```shell
-http GET localhost:8080/api/v1/importer/redhat-csaf/report | jq .configuration | jq .csaf.fetchRetries=50
+http GET localhost:8080/api/v2/importer/redhat-csaf/report | jq .configuration | jq .csaf.fetchRetries=50
 ```
 
 To execute:
 
 ```shell
-http GET localhost:8080/api/v1/importer/redhat-csaf | jq .configuration | jq .csaf.fetchRetries=50 | http PUT localhost:8080/api/v1/importer/redhat-csaf
+http GET localhost:8080/api/v2/importer/redhat-csaf | jq .configuration | jq .csaf.fetchRetries=50 | http PUT localhost:8080/api/v2/importer/redhat-csaf
 ```
 
 ## Patch an importer configuration
 
 ```shell
-http PATCH localhost:8080/api/v1/importer/redhat-csaf "Content-Type:application/merge-patch+json" csaf[fetchRetries]:=50
+http PATCH localhost:8080/api/v2/importer/redhat-csaf "Content-Type:application/merge-patch+json" csaf[fetchRetries]:=50
 ```
 
 ## Delete an importer
 
 ```shell
-http DELETE localhost:8080/api/v1/importer/redhat-csaf
-http DELETE localhost:8080/api/v1/importer/redhat-sbom
+http DELETE localhost:8080/api/v2/importer/redhat-csaf
+http DELETE localhost:8080/api/v2/importer/redhat-sbom
 ```
 
 ## Set the enabled state of an importer
 
 ```shell
-echo true | http PUT localhost:8080/api/v1/importer/redhat-sbom/enabled
+echo true | http PUT localhost:8080/api/v2/importer/redhat-sbom/enabled
 ```
 
 ## Force an importer run
 
 ```shell
-http PUT localhost:8080/api/v1/importer/redhat-sbom/force
+http PUT localhost:8080/api/v2/importer/redhat-sbom/force
 ```
 
 

--- a/modules/importer/src/endpoints.rs
+++ b/modules/importer/src/endpoints.rs
@@ -35,7 +35,7 @@ pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: 
         (status = 200, description = "List importer configurations", body = [Importer])
     )
 )]
-#[get("/v1/importer")]
+#[get("/v2/importer")]
 /// List importer configurations
 async fn list(
     service: web::Data<ImporterService>,
@@ -56,7 +56,7 @@ async fn list(
         (status = 409, description = "An importer with that name already exists")
     )
 )]
-#[post("/v1/importer/{name}")]
+#[post("/v2/importer/{name}")]
 /// Create a new importer configuration
 async fn create(
     service: web::Data<ImporterService>,
@@ -84,7 +84,7 @@ async fn create(
         (status = 404, description = "An importer with that name could not be found")
     )
 )]
-#[get("/v1/importer/{name}")]
+#[get("/v2/importer/{name}")]
 /// Get an importer configuration
 async fn read(
     service: web::Data<ImporterService>,
@@ -115,7 +115,7 @@ async fn read(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[put("/v1/importer/{name}")]
+#[put("/v2/importer/{name}")]
 /// Update an existing importer configuration
 async fn update(
     service: web::Data<ImporterService>,
@@ -153,7 +153,7 @@ async fn update(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[patch("/v1/importer/{name}", guard = "guards::json_merge")]
+#[patch("/v2/importer/{name}", guard = "guards::json_merge")]
 /// Update an existing importer configuration
 async fn patch_json_merge(
     service: web::Data<ImporterService>,
@@ -192,7 +192,7 @@ async fn patch_json_merge(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[put("/v1/importer/{name}/enabled")]
+#[put("/v2/importer/{name}/enabled")]
 /// Update an existing importer configuration
 async fn set_enabled(
     service: web::Data<ImporterService>,
@@ -230,7 +230,7 @@ async fn set_enabled(
         (status = 412, description = "The provided if-match header did not match the stored revision"),
     )
 )]
-#[post("/v1/importer/{name}/force")]
+#[post("/v2/importer/{name}/force")]
 /// Force an importer to run as soon as possible
 async fn force(
     service: web::Data<ImporterService>,
@@ -259,7 +259,7 @@ async fn force(
         (status = 201, description = "Delete the importer configuration"),
     )
 )]
-#[delete("/v1/importer/{name}")]
+#[delete("/v2/importer/{name}")]
 /// Delete an importer configuration
 async fn delete(
     service: web::Data<ImporterService>,
@@ -285,7 +285,7 @@ async fn delete(
         (status = 200, description = "Retrieved importer reports", body = PaginatedResults<ImporterReport>),
     )
 )]
-#[get("/v1/importer/{name}/report")]
+#[get("/v2/importer/{name}/report")]
 /// Get reports for an importer
 async fn get_reports(
     service: web::Data<ImporterService>,

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -69,7 +69,7 @@ async fn default(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -79,7 +79,7 @@ async fn default(ctx: TrustifyContext) {
     // now list all
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer")
+        .uri("/api/v2/importer")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -106,7 +106,7 @@ async fn default(ctx: TrustifyContext) {
     // update it
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("baz"))
         .to_request();
 
@@ -116,7 +116,7 @@ async fn default(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -128,7 +128,7 @@ async fn default(ctx: TrustifyContext) {
     // delete it
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -137,7 +137,7 @@ async fn default(ctx: TrustifyContext) {
     // get none
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -163,7 +163,7 @@ async fn oplock(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -173,7 +173,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (no lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("baz"))
         .to_request();
 
@@ -183,7 +183,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -199,7 +199,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("buz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -210,7 +210,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -222,7 +222,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with broken lock)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("boz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -233,7 +233,7 @@ async fn oplock(ctx: TrustifyContext) {
     // update it (with wrong name)
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/importer/foo2")
+        .uri("/api/v2/importer/foo2")
         .set_json(mock_configuration("boz"))
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
@@ -244,7 +244,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it (must not change)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -262,7 +262,7 @@ async fn oplock(ctx: TrustifyContext) {
     // delete it (wrong lock)
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .append_header((header::IF_MATCH, old_etag.clone()))
         .to_request();
 
@@ -272,7 +272,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get it (must still be there)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -284,7 +284,7 @@ async fn oplock(ctx: TrustifyContext) {
     // delete it (correct lock)
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .append_header((header::IF_MATCH, etag.clone()))
         .to_request();
 
@@ -294,7 +294,7 @@ async fn oplock(ctx: TrustifyContext) {
     // get none
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -320,7 +320,7 @@ async fn patch(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::post()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(mock_configuration("bar"))
         .to_request();
 
@@ -330,7 +330,7 @@ async fn patch(ctx: TrustifyContext) {
     // get it
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -342,7 +342,7 @@ async fn patch(ctx: TrustifyContext) {
     // patch it
 
     let req = actix::TestRequest::patch()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(json!({
             "sbom": {
                 "source": "baz",
@@ -357,7 +357,7 @@ async fn patch(ctx: TrustifyContext) {
     // get it (again)
 
     let req = actix::TestRequest::get()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -369,7 +369,7 @@ async fn patch(ctx: TrustifyContext) {
     // delete it
 
     let req = actix::TestRequest::delete()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .to_request();
 
     let resp = actix::call_service(&app, req).await;
@@ -378,7 +378,7 @@ async fn patch(ctx: TrustifyContext) {
     // try again
 
     let req = actix::TestRequest::patch()
-        .uri("/api/v1/importer/foo")
+        .uri("/api/v2/importer/foo")
         .set_json(json!({
             "sbom": {
                 "source": "bar",

--- a/modules/ingestor/README.md
+++ b/modules/ingestor/README.md
@@ -3,11 +3,11 @@
 ## Upload an SBOM
 
 ```shell
-cat file.sbom | http POST localhost:8080/api/v1/sbom location==cli
+cat file.sbom | http POST localhost:8080/api/v2/sbom location==cli
 ```
 
 ## Upload a dataset
 
 ```shell
-http POST localhost:8080/api/v1/dataset @file-to-upload
+http POST localhost:8080/api/v2/dataset @file-to-upload
 ```

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -50,7 +50,7 @@ struct UploadParams {
         (status = 400, description = "The file could not be parsed as an dataset"),
     )
 )]
-#[post("/v1/dataset")]
+#[post("/v2/dataset")]
 /// Upload a new dataset
 pub async fn upload_dataset(
     service: web::Data<IngestorService>,

--- a/modules/ingestor/tests/limit.rs
+++ b/modules/ingestor/tests/limit.rs
@@ -30,7 +30,7 @@ async fn upload_bomb_dataset(ctx: &TrustifyContext) -> anyhow::Result<()> {
     dataset.finish()?;
 
     let request = TestRequest::post()
-        .uri("/api/v1/dataset")
+        .uri("/api/v2/dataset")
         .set_payload(data)
         .to_request();
 

--- a/modules/user/src/endpoints.rs
+++ b/modules/user/src/endpoints.rs
@@ -33,7 +33,7 @@ pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: 
         (status = 404, description = "Unknown user preference key"),
     )
 )]
-#[get("/v1/userPreference/{key}")]
+#[get("/v2/userPreference/{key}")]
 /// Get user preferences
 async fn get(
     service: web::Data<UserPreferenceService>,
@@ -67,7 +67,7 @@ async fn get(
         (status = 412, description = "The provided If-Match revision did not match the actual revision")
     )
 )]
-#[put("/v1/userPreference/{key}")]
+#[put("/v2/userPreference/{key}")]
 /// Set user preferences
 async fn set(
     service: web::Data<UserPreferenceService>,
@@ -106,7 +106,7 @@ async fn set(
         (status = 412, description = "The provided If-Match revision did not match the actual revision")
     )
 )]
-#[delete("/v1/userPreference/{key}")]
+#[delete("/v2/userPreference/{key}")]
 /// Delete user preferences
 async fn delete(
     service: web::Data<UserPreferenceService>,

--- a/modules/user/src/test.rs
+++ b/modules/user/src/test.rs
@@ -147,7 +147,7 @@ async fn wrong_rev(ctx: TrustifyContext) {
     // create one
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/userPreference/foo")
+        .uri("/api/v2/userPreference/foo")
         .set_json(json!({"a": 1}))
         .to_request()
         .test_auth("user-a");
@@ -158,7 +158,7 @@ async fn wrong_rev(ctx: TrustifyContext) {
     // try to update the wrong one
 
     let req = actix::TestRequest::put()
-        .uri("/api/v1/userPreference/foo")
+        .uri("/api/v2/userPreference/foo")
         .append_header((header::IF_MATCH, r#""a""#))
         .set_json(json!({"a": 2}))
         .to_request()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,7 +24,7 @@ paths:
                     type: object
                   version:
                     type: string
-  /api/v1/advisory:
+  /api/v2/advisory:
     get:
       tags:
       - advisory
@@ -113,7 +113,7 @@ paths:
           description: Upload a file
         '400':
           description: The file could not be parsed as an advisory
-  /api/v1/advisory/{id}/label:
+  /api/v2/advisory/{id}/label:
     put:
       tags:
       - advisory
@@ -160,7 +160,7 @@ paths:
           description: Modified the labels of the advisory
         '404':
           description: The advisory could not be found
-  /api/v1/advisory/{key}:
+  /api/v2/advisory/{key}:
     get:
       tags:
       - advisory
@@ -203,7 +203,7 @@ paths:
                 $ref: '#/components/schemas/AdvisoryDetails'
         '404':
           description: Matching advisory not found
-  /api/v1/advisory/{key}/download:
+  /api/v2/advisory/{key}/download:
     get:
       tags:
       - advisory
@@ -226,7 +226,7 @@ paths:
                 format: binary
         '404':
           description: The document could not be found
-  /api/v1/ai/completions:
+  /api/v2/ai/completions:
     post:
       tags:
       - ai
@@ -248,7 +248,7 @@ paths:
           description: The request was invalid
         '404':
           description: The AI service is not enabled
-  /api/v1/ai/flags:
+  /api/v2/ai/flags:
     get:
       tags:
       - ai
@@ -262,7 +262,7 @@ paths:
                 $ref: '#/components/schemas/AiFlags'
         '404':
           description: The AI service is not enabled
-  /api/v1/ai/tools:
+  /api/v2/ai/tools:
     get:
       tags:
       - ai
@@ -278,7 +278,7 @@ paths:
                   $ref: '#/components/schemas/AiTool'
         '404':
           description: The AI service is not enabled
-  /api/v1/ai/tools/{name}:
+  /api/v2/ai/tools/{name}:
     post:
       tags:
       - ai
@@ -306,7 +306,7 @@ paths:
           description: The tool request was invalid
         '404':
           description: The tool was not found
-  /api/v1/analysis/dep:
+  /api/v2/analysis/dep:
     get:
       tags:
       - analysis
@@ -351,7 +351,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DepSummary'
-  /api/v1/analysis/dep/{key}:
+  /api/v2/analysis/dep/{key}:
     get:
       tags:
       - analysis
@@ -370,7 +370,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DepSummary'
-  /api/v1/analysis/root-component:
+  /api/v2/analysis/root-component:
     get:
       tags:
       - analysis
@@ -415,7 +415,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AncestorSummary'
-  /api/v1/analysis/root-component/{key}:
+  /api/v2/analysis/root-component/{key}:
     get:
       tags:
       - analysis
@@ -434,7 +434,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AncestorSummary'
-  /api/v1/analysis/status:
+  /api/v2/analysis/status:
     get:
       tags:
       - analysis
@@ -446,7 +446,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnalysisStatus'
-  /api/v1/dataset:
+  /api/v2/dataset:
     post:
       tags:
       - dataset
@@ -474,7 +474,7 @@ paths:
           description: Uploaded the dataset
         '400':
           description: The file could not be parsed as an dataset
-  /api/v1/importer:
+  /api/v2/importer:
     get:
       tags:
       - importer
@@ -489,7 +489,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Importer'
-  /api/v1/importer/{name}:
+  /api/v2/importer/{name}:
     get:
       tags:
       - importer
@@ -627,7 +627,7 @@ paths:
           description: An importer with that name does not exist
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v1/importer/{name}/enabled:
+  /api/v2/importer/{name}/enabled:
     put:
       tags:
       - importer
@@ -661,7 +661,7 @@ paths:
           description: An importer with that name does not exist
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v1/importer/{name}/force:
+  /api/v2/importer/{name}/force:
     post:
       tags:
       - importer
@@ -695,7 +695,7 @@ paths:
           description: An importer with that name does not exist
         '412':
           description: The provided if-match header did not match the stored revision
-  /api/v1/importer/{name}/report:
+  /api/v2/importer/{name}/report:
     get:
       tags:
       - importer
@@ -714,7 +714,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ImporterReport'
-  /api/v1/license:
+  /api/v2/license:
     get:
       tags:
       - license
@@ -760,7 +760,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_LicenseSummary'
-  /api/v1/license/spdx/license:
+  /api/v2/license/spdx/license:
     get:
       tags:
       - spdx license
@@ -806,7 +806,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SpdxLicenseSummary'
-  /api/v1/license/spdx/license/{id}:
+  /api/v2/license/spdx/license/{id}:
     get:
       tags:
       - spdx license
@@ -825,7 +825,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpdxLicenseDetails'
-  /api/v1/license/{uuid}:
+  /api/v2/license/{uuid}:
     get:
       tags:
       - license
@@ -845,7 +845,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LicenseSummary'
-  /api/v1/license/{uuid}/purl:
+  /api/v2/license/{uuid}/purl:
     get:
       tags:
       - license
@@ -896,7 +896,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LicenseSummary'
-  /api/v1/organization:
+  /api/v2/organization:
     get:
       tags:
       - organization
@@ -942,7 +942,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationSummary'
-  /api/v1/organization/{id}:
+  /api/v2/organization/{id}:
     get:
       tags:
       - organization
@@ -965,7 +965,7 @@ paths:
                 $ref: '#/components/schemas/OrganizationDetails'
         '404':
           description: Matching organization not found
-  /api/v1/product:
+  /api/v2/product:
     get:
       tags:
       - product
@@ -1010,7 +1010,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ProductSummary'
-  /api/v1/product/{id}:
+  /api/v2/product/{id}:
     get:
       tags:
       - product
@@ -1053,7 +1053,7 @@ paths:
                 $ref: '#/components/schemas/ProductDetails'
         '404':
           description: Matching product not found
-  /api/v1/purl:
+  /api/v2/purl:
     get:
       tags:
       - purl
@@ -1099,7 +1099,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_PurlSummary'
-  /api/v1/purl/base:
+  /api/v2/purl/base:
     get:
       tags:
       - base purl
@@ -1145,7 +1145,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_BasePurlSummary'
-  /api/v1/purl/base/{key}:
+  /api/v2/purl/base/{key}:
     get:
       tags:
       - base purl
@@ -1165,7 +1165,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasePurlDetails'
-  /api/v1/purl/type:
+  /api/v2/purl/type:
     get:
       tags:
       - purl type
@@ -1180,7 +1180,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TypeSummary'
-  /api/v1/purl/type/{type}:
+  /api/v2/purl/type/{type}:
     get:
       tags:
       - purl type
@@ -1232,7 +1232,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_BasePurlSummary'
-  /api/v1/purl/type/{type}/{namespace_and_name}:
+  /api/v2/purl/type/{type}/{namespace_and_name}:
     get:
       tags:
       - purl type
@@ -1258,7 +1258,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasePurlDetails'
-  /api/v1/purl/type/{type}/{namespace_and_name}@{version}:
+  /api/v2/purl/type/{type}/{namespace_and_name}@{version}:
     get:
       tags:
       - purl
@@ -1290,7 +1290,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionedPurlDetails'
-  /api/v1/purl/version/{key}:
+  /api/v2/purl/version/{key}:
     get:
       tags:
       - versioned purl
@@ -1310,7 +1310,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionedPurlDetails'
-  /api/v1/purl/{key}:
+  /api/v2/purl/{key}:
     get:
       tags:
       - purl
@@ -1338,7 +1338,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PurlDetails'
-  /api/v1/sbom:
+  /api/v2/sbom:
     get:
       tags:
       - sbom
@@ -1423,7 +1423,7 @@ paths:
                 $ref: '#/components/schemas/IngestResult'
         '400':
           description: The file could not be parsed as an advisory
-  /api/v1/sbom/by-package:
+  /api/v2/sbom/by-package:
     get:
       tags:
       - sbom
@@ -1489,7 +1489,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomSummary'
-  /api/v1/sbom/count-by-package:
+  /api/v2/sbom/count-by-package:
     get:
       tags:
       - sbom
@@ -1534,7 +1534,7 @@ paths:
                 items:
                   type: integer
                   format: int64
-  /api/v1/sbom/{id}:
+  /api/v2/sbom/{id}:
     get:
       tags:
       - sbom
@@ -1575,7 +1575,7 @@ paths:
                 $ref: '#/components/schemas/SbomSummary'
         '404':
           description: Matching SBOM not found
-  /api/v1/sbom/{id}/advisory:
+  /api/v2/sbom/{id}/advisory:
     get:
       tags:
       - sbom
@@ -1598,7 +1598,7 @@ paths:
                   $ref: '#/components/schemas/SbomAdvisory'
         '404':
           description: Matching SBOM not found
-  /api/v1/sbom/{id}/label:
+  /api/v2/sbom/{id}/label:
     put:
       tags:
       - sbom
@@ -1645,7 +1645,7 @@ paths:
           description: Modified the labels of the SBOM
         '404':
           description: The SBOM could not be found
-  /api/v1/sbom/{id}/packages:
+  /api/v2/sbom/{id}/packages:
     get:
       tags:
       - sbom
@@ -1698,7 +1698,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackage'
-  /api/v1/sbom/{id}/related:
+  /api/v2/sbom/{id}/related:
     get:
       tags:
       - sbom
@@ -1776,7 +1776,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackageRelation'
-  /api/v1/sbom/{key}/download:
+  /api/v2/sbom/{key}/download:
     get:
       tags:
       - sbom
@@ -1798,7 +1798,7 @@ paths:
                 format: binary
         '404':
           description: The document could not be found
-  /api/v1/userPreference/{key}:
+  /api/v2/userPreference/{key}:
     get:
       tags:
       - userPreferences
@@ -1889,7 +1889,7 @@ paths:
           description: User preferences are deleted
         '412':
           description: The provided If-Match revision did not match the actual revision
-  /api/v1/vulnerability:
+  /api/v2/vulnerability:
     get:
       tags:
       - vulnerability
@@ -1935,7 +1935,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_VulnerabilitySummary'
-  /api/v1/vulnerability/{id}:
+  /api/v2/vulnerability/{id}:
     get:
       tags:
       - vulnerability
@@ -1978,7 +1978,7 @@ paths:
                 $ref: '#/components/schemas/VulnerabilityDetails'
         '404':
           description: Specified vulnerability not found
-  /api/v1/weakness:
+  /api/v2/weakness:
     get:
       tags:
       - weakness
@@ -2024,7 +2024,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_LicenseSummary'
-  /api/v1/weakness/{id}:
+  /api/v2/weakness/{id}:
     get:
       tags:
       - weakness

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -561,7 +561,7 @@ mod test {
         let resp = call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-        let req = TestRequest::get().uri("/api/v1/advisory").to_request();
+        let req = TestRequest::get().uri("/api/v2/advisory").to_request();
         let body = call_and_read_body(&app, req).await;
         let text = std::str::from_utf8(&body)?;
         assert!(text.contains("items"));

--- a/xtask/src/ai.rs
+++ b/xtask/src/ai.rs
@@ -63,7 +63,7 @@ Enter your question or type:
 
                 let client = reqwest::Client::new();
                 let res = client
-                    .post(format!("{}/api/v1/ai/completions", url))
+                    .post(format!("{}/api/v2/ai/completions", url))
                     .json(&chat_state)
                     .send()
                     .await?;


### PR DESCRIPTION
BREAKING-CHANGE: This changes the prefix of the API from /api/v1 to /api/v2 as this is the successor API of trustification (v1).

Closes: https://github.com/trustification/trustify/issues/1112