### PR TITLE
refactor: dry up redundant test app creation logic

### DIFF
--- a/modules/analysis/src/endpoints.rs
+++ b/modules/analysis/src/endpoints.rs
@@ -166,13 +166,13 @@ pub async fn get_component_deps(
 
 #[cfg(test)]
 mod test {
-    use crate::test::{caller, CallService};
+    use crate::test::caller;
     use actix_http::Request;
     use actix_web::test::TestRequest;
     use serde_json::Value;
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::TrustifyContext;
+    use trustify_test_context::{call::CallService, TrustifyContext};
 
     #[test_context(TrustifyContext)]
     #[test(actix_web::test)]

--- a/modules/analysis/src/test.rs
+++ b/modules/analysis/src/test.rs
@@ -1,50 +1,9 @@
 use crate::endpoints::configure;
-use actix_http::Request;
-use actix_web::{
-    dev::{Service, ServiceResponse},
-    web, App, Error,
+use trustify_test_context::{
+    call::{self, CallService},
+    TrustifyContext,
 };
-use bytes::Bytes;
-use sea_orm::prelude::async_trait::async_trait;
-use serde::de::DeserializeOwned;
-use trustify_auth::authorizer::Authorizer;
-use trustify_test_context::TrustifyContext;
-use utoipa_actix_web::AppExt;
 
-/// A trait wrapping an `impl Service` in a way that we can pass it as a reference.
-#[async_trait(?Send)]
-pub trait CallService {
-    async fn call_service(&self, s: Request) -> ServiceResponse;
-    async fn call_and_read_body(&self, r: Request) -> Bytes;
-    async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T;
-}
-
-#[async_trait(?Send)]
-impl<S> CallService for S
-where
-    S: Service<Request, Response = ServiceResponse, Error = Error>,
-{
-    async fn call_service(&self, r: Request) -> ServiceResponse {
-        actix_web::test::call_service(self, r).await
-    }
-    async fn call_and_read_body(&self, r: Request) -> Bytes {
-        actix_web::test::call_and_read_body(self, r).await
-    }
-    async fn call_and_read_body_json<T: DeserializeOwned>(&self, r: Request) -> T {
-        actix_web::test::call_and_read_body_json(self, r).await
-    }
-}
-
-pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService> {
-    Ok(actix_web::test::init_service(
-        App::new()
-            .into_utoipa_app()
-            .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
-            .app_data(web::Data::new(Authorizer::new(None)))
-            .service(
-                utoipa_actix_web::scope("/api").configure(|svc| configure(svc, ctx.db.clone())),
-            )
-            .into_app(),
-    )
-    .await)
+pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
+    call::caller(|svc| configure(svc, ctx.db.clone())).await
 }

--- a/modules/ingestor/tests/common.rs
+++ b/modules/ingestor/tests/common.rs
@@ -1,28 +1,12 @@
-use actix_web::{web, App};
-use trustify_auth::authorizer::Authorizer;
 use trustify_module_ingestor::endpoints::{configure, Config};
-use trustify_test_context::{call::CallService, TrustifyContext};
-use utoipa_actix_web::AppExt;
-
-#[allow(unused)]
-pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService> {
-    caller_with(ctx, Config::default()).await
-}
+use trustify_test_context::{
+    call::{self, CallService},
+    TrustifyContext,
+};
 
 pub async fn caller_with(
     ctx: &TrustifyContext,
     config: Config,
-) -> anyhow::Result<impl CallService> {
-    Ok(actix_web::test::init_service(
-        App::new()
-            .into_utoipa_app()
-            .app_data(web::PayloadConfig::default().limit(5 * 1024 * 1024))
-            .app_data(web::Data::new(Authorizer::new(None)))
-            .service(
-                utoipa_actix_web::scope("/api")
-                    .configure(|svc| configure(svc, config, ctx.db.clone(), ctx.storage.clone())),
-            )
-            .into_app(),
-    )
-    .await)
+) -> anyhow::Result<impl CallService + '_> {
+    call::caller(|svc| configure(svc, config, ctx.db.clone(), ctx.storage.clone())).await
 }


### PR DESCRIPTION
We have 3 places that are essentially doing the same thing. That thing is more correctly done in a single place and test context seemed the most appropriate.