### PR TITLE
feat: show relationships in response from /api/v1/purl/{key}

### DIFF
--- a/entity/src/relationship.rs
+++ b/entity/src/relationship.rs
@@ -5,6 +5,7 @@ use std::fmt;
     Debug,
     Copy,
     Clone,
+    Hash,
     PartialEq,
     Eq,
     EnumIter,

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -355,13 +355,14 @@ async fn purl_relationships(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         .await?;
 
     let src = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src";
-    let x86 = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64";
-    let uri = format!("/api/v1/purl/{}", urlencoding::encode(x86));
+    let bin = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64";
+
+    let uri = format!("/api/v2/purl/{}", urlencoding::encode(bin));
     let request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
     log::debug!("{response:#?}");
-    assert_eq!("generated_from", response["relationships"][0][0]);
-    assert_eq!(src, response["relationships"][0][1]);
+
+    assert_eq!(src, response["relationships"]["generated_from"][0]);
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3279,30 +3279,30 @@ components:
             items:
               $ref: '#/components/schemas/PurlLicenseSummary'
           relationships:
-            type: array
-            items:
+            type: object
+            additionalProperties:
               type: array
-              items: false
-              prefixItems:
-              - type: string
-                enum:
-                - contained_by
-                - dependency_of
-                - dev_dependency_of
-                - optional_dependency_of
-                - provided_dependency_of
-                - test_dependency_of
-                - runtime_dependency_of
-                - example_of
-                - generated_from
-                - ancestor_of
-                - variant_of
-                - build_tool_of
-                - dev_tool_of
-                - described_by
-                - package_of
-                - undefined
-              - type: string
+              items:
+                type: string
+            propertyNames:
+              type: string
+              enum:
+              - contained_by
+              - dependency_of
+              - dev_dependency_of
+              - optional_dependency_of
+              - provided_dependency_of
+              - test_dependency_of
+              - runtime_dependency_of
+              - example_of
+              - generated_from
+              - ancestor_of
+              - variant_of
+              - build_tool_of
+              - dev_tool_of
+              - described_by
+              - package_of
+              - undefined
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3266,6 +3266,7 @@ components:
         - base
         - advisories
         - licenses
+        - relationships
         properties:
           advisories:
             type: array
@@ -3277,6 +3278,31 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/PurlLicenseSummary'
+          relationships:
+            type: array
+            items:
+              type: array
+              items: false
+              prefixItems:
+              - type: string
+                enum:
+                - contained_by
+                - dependency_of
+                - dev_dependency_of
+                - optional_dependency_of
+                - provided_dependency_of
+                - test_dependency_of
+                - runtime_dependency_of
+                - example_of
+                - generated_from
+                - ancestor_of
+                - variant_of
+                - build_tool_of
+                - dev_tool_of
+                - described_by
+                - package_of
+                - undefined
+              - type: string
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:


### PR DESCRIPTION
Fixes #1131

This might take care of other camp/atlas issues, too, since any relationships associated with the purl (not just `generated_from`) will be included.