### PR TITLE
Cache the Theseus postgresql install to avoid rate limit errors on CI PR jobs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,13 @@ jobs:
         run: cargo check
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
+
+      - name: Cache Theseus Postgresql Installation
+        uses: actions/cache@v4
+        with:
+          path: ~/.theseus/postgresql
+          key: ${{ runner.os }}-theseus-postgresql-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Test
         run: cargo test -- --nocapture
         env:


### PR DESCRIPTION
An example of a job that failed can be found at:

https://github.com/trustification/trustify/actions/runs/12791739126/job/35660536423