### PR TITLE
fix: Point to a UI that uses /v2/ prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8818,7 +8818,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#59b9f149ea75db974b39b5729e8479ba0ff285ff"
+source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#b8c3b1f186b0bd14495425847bc772013b37b24e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",


### PR DESCRIPTION
This PR points to the latest version available of the UI, the one that contains the /v2/ changes done after https://github.com/trustification/trustify/pull/1133