### PR TITLE
fix: improve product version range migration

### DIFF
--- a/etc/deploy/compose/compose.yaml
+++ b/etc/deploy/compose/compose.yaml
@@ -7,3 +7,4 @@ services:
       POSTGRES_PASSWORD: "trustify"
       POSTGRES_DB: "trustify"
     restart: always
+    shm_size: '1g'

--- a/migration/src/m0000800_alter_product_version_range_scheme.rs
+++ b/migration/src/m0000800_alter_product_version_range_scheme.rs
@@ -9,7 +9,9 @@ impl MigrationTrait for Migration {
         // use rpm version range scheme as it covers more usecases
         manager
             .get_connection()
-            .execute_unprepared(r#"UPDATE version_range SET version_scheme_id = 'rpm' WHERE id IN (SELECT version_range_id FROM product_version_range)"#)
+            .execute_unprepared(include_str!(
+                "m0000800_alter_product_version_range_scheme/migration_up.sql"
+            ))
             .await?;
 
         Ok(())
@@ -19,7 +21,9 @@ impl MigrationTrait for Migration {
         // return to semver version range scheme
         manager
             .get_connection()
-            .execute_unprepared(r#"UPDATE version_range SET version_scheme_id = 'semver' WHERE id IN (SELECT version_range_id FROM product_version_range)"#)
+            .execute_unprepared(include_str!(
+                "m0000800_alter_product_version_range_scheme/migration_down.sql"
+            ))
             .await?;
 
         Ok(())

--- a/migration/src/m0000800_alter_product_version_range_scheme/migration_down.sql
+++ b/migration/src/m0000800_alter_product_version_range_scheme/migration_down.sql
@@ -1,0 +1,9 @@
+WITH ranges_to_update AS (
+    SELECT version_range.* FROM
+    version_range
+    JOIN product_version_range ON version_range.id = product_version_range.version_range_id
+)
+UPDATE version_range
+SET version_scheme_id = 'semver'
+FROM ranges_to_update
+WHERE version_range.id = ranges_to_update.id

--- a/migration/src/m0000800_alter_product_version_range_scheme/migration_up.sql
+++ b/migration/src/m0000800_alter_product_version_range_scheme/migration_up.sql
@@ -1,0 +1,9 @@
+WITH ranges_to_update AS (
+    SELECT version_range.* FROM
+    version_range
+    JOIN product_version_range ON version_range.id = product_version_range.version_range_id
+)
+UPDATE version_range
+SET version_scheme_id = 'rpm'
+FROM ranges_to_update
+WHERE version_range.id = ranges_to_update.id


### PR DESCRIPTION
This PR contains improved migration query mentioned in #1142 

Query by itself runs for about ~30 min on load test database dump, but I didn't get to test the migration because of https://github.com/trustification/trustify-load-test-runs/issues/5 