### PR TITLE
fix: sbom license migration to update nulls

### DIFF
--- a/migration/src/m0000720_alter_sbom_fix_null_array.rs
+++ b/migration/src/m0000720_alter_sbom_fix_null_array.rs
@@ -6,47 +6,17 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.alter_table(Self::alter_table()).await?;
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0000720_alter_sbom_fix_null_array/migration_up.sql"
+            ))
+            .await?;
+
         Ok(())
     }
 
     async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         Ok(())
-    }
-}
-
-impl Migration {
-    fn alter_table() -> TableAlterStatement {
-        Table::alter()
-            .table(Sbom::Table)
-            .modify_column(
-                ColumnDef::new(Sbom::DataLicenses)
-                    .array(ColumnType::Text)
-                    .not_null()
-                    .default(SimpleExpr::Custom("ARRAY[]::text[]".to_string()))
-                    .to_owned(),
-            )
-            .to_owned()
-    }
-}
-
-#[derive(DeriveIden)]
-enum Sbom {
-    Table,
-    DataLicenses,
-}
-
-#[cfg(test)]
-mod test {
-    use crate::m0000720_alter_sbom_fix_null_array::Migration;
-    use crate::PostgresQueryBuilder;
-
-    #[test]
-    fn test() {
-        let sql = Migration::alter_table().build(PostgresQueryBuilder);
-        assert_eq!(
-            sql,
-            r#"ALTER TABLE "sbom" ALTER COLUMN "data_licenses" TYPE text[], ALTER COLUMN "data_licenses" SET NOT NULL, ALTER COLUMN "data_licenses" SET DEFAULT ARRAY[]::text[]"#
-        );
     }
 }

--- a/migration/src/m0000720_alter_sbom_fix_null_array/migration_up.sql
+++ b/migration/src/m0000720_alter_sbom_fix_null_array/migration_up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "sbom"
+ALTER COLUMN "data_licenses" TYPE text[] USING COALESCE("data_licenses", ARRAY[]::text[]),
+ALTER COLUMN "data_licenses" SET NOT NULL,
+ALTER COLUMN "data_licenses" SET DEFAULT ARRAY[]::text[]


### PR DESCRIPTION
This is a fix for https://github.com/trustification/trustify-load-test-runs/issues/5

The fix is to use `USING COALESCE` to update NULL values before set the constraint. As I couldn't find an easy way to do that in sea-orm, I converted the migration to raw sql