### PR TITLE
fix: infinite loop when invalid file passed to Format::from_bytes

### DIFF
--- a/etc/test-data/indigestable.json
+++ b/etc/test-data/indigestable.json
@@ -1,0 +1,32 @@
+{
+  "SPDXVersion": "SPDX-2.2",
+  "DataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "DocumentName": "Example-SPDX-Document-using-AncestorOf",
+  "DocumentNamespace": "http://spdx.org/spdxdocs/example-spdx-document-123456",
+  "Creator": "Person: Jim Fuller-RedHat",
+  "Created": "2025-01-21T17:41:32Z",
+  "packages": [
+    {
+      "PackageName": "PackageUpstreamA",
+      "SPDXID": "SPDXRef-PackageUpstreamA",
+      "PackageVersion": "1.0",
+      "PackageDownloadLocation": "NOASSERTION",
+      "FilesAnalyzed": false
+    },
+    {
+      "PackageName": "PackageB",
+      "SPDXID": "SPDXRef-PackageB",
+      "PackageVersion": "2.0",
+      "PackageDownloadLocation": "NOASSERTION",
+      "FilesAnalyzed": false
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-PackageUpstreamA",
+      "relationshipType": "ANCESTOR_OF",
+      "relatedSpdxElement": "SPDXRef-PackageB"
+    }
+  ]
+}

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -300,7 +300,7 @@ mod test {
         assert!(matches!(Format::from_bytes(&spdx), Ok(Format::SPDX)));
 
         let indigestable = document_bytes("indigestable.json").await?;
-        assert!(matches!(Format::from_bytes(&indigestable), Err(_)));
+        assert!(Format::from_bytes(&indigestable).is_err());
 
         let cwe = document_read("cwec_latest.xml.zip")?;
         let mut cwe = ZipArchive::new(cwe)?;


### PR DESCRIPTION
At present, only our test fixtures call `Format::from_bytes` and we obviously don't currently pass invalid docs to our tests. But if we expose this behavior to users, we'll want to prevent infinite loops attempting to ingest invalid docs of an unknown format.