### PR TITLE
fix: report CPE parsing as "bad request"

### DIFF
--- a/modules/analysis/src/error.rs
+++ b/modules/analysis/src/error.rs
@@ -47,6 +47,9 @@ impl From<DbErr> for Error {
 impl ResponseError for Error {
     fn error_response(&self) -> HttpResponse<BoxBody> {
         match self {
+            Self::Cpe(err) => {
+                HttpResponse::BadRequest().json(ErrorInformation::new("InvalidCpeSyntax", err))
+            }
             Self::Purl(err) => {
                 HttpResponse::BadRequest().json(ErrorInformation::new("InvalidPurlSyntax", err))
             }


### PR DESCRIPTION
Right now, it is being reported as an internal server error.