### PR TITLE
TC-2174 OSV Python ecosystem management

### DIFF
--- a/etc/test-data/cyclonedx/pypi_aiohttp.json
+++ b/etc/test-data/cyclonedx/pypi_aiohttp.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "serialNumber": "urn:uuid:a5ddee00-4b86-498c-b7fd-b001b77479d1",
+  "metadata": {
+    "timestamp": "2025-01-28T18:14:15.675260000Z",
+    "component": {
+      "type": "application",
+      "name": "1 vulnerability",
+      "version": "0.1.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "aiohttp",
+      "version": "1.0.5",
+      "description": "1 vulnerability",
+      "purl": "pkg:pypi/aiohttp@1.0.5"
+    },
+    {
+      "type": "library",
+      "name": "opencrx-core-models",
+      "version": "4.3-alpha-10",
+      "description": "no vulnerabilities",
+      "purl": "pkg:maven/org.opencrx/opencrx-core-models@4.3-alpha-10"
+    }
+  ]
+}

--- a/etc/test-data/osv/GHSA-45c4-8wx5-qw6w.json
+++ b/etc/test-data/osv/GHSA-45c4-8wx5-qw6w.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-45c4-8wx5-qw6w",
+  "modified": "2024-09-03T21:33:36Z",
+  "published": "2023-07-20T14:52:00Z",
+  "aliases": [
+    "CVE-2023-37276"
+  ],
+  "summary": "aiohttp.web.Application vulnerable to HTTP request smuggling via llhttp HTTP request parser",
+  "details": "### Impact\n\naiohttp v3.8.4 and earlier are [bundled with llhttp v6.0.6](https://github.com/aio-libs/aiohttp/blob/v3.8.4/.gitmodules) which is vulnerable to CVE-2023-30589. The vulnerable code is used by aiohttp for its HTTP request parser when available which is the default case when installing from a wheel.\n\nThis vulnerability only affects users of aiohttp as an HTTP server (ie `aiohttp.Application`), you are not affected by this vulnerability if you are using aiohttp as an HTTP client library (ie `aiohttp.ClientSession`).\n\n### Reproducer\n\n```python\nfrom aiohttp import web\n\nasync def example(request: web.Request):\n    headers = dict(request.headers)\n    body = await request.content.read()\n    return web.Response(text=f\"headers: {headers} body: {body}\")\n\napp = web.Application()\napp.add_routes([web.post('/', example)])\nweb.run_app(app)\n```\n\nSending a crafted HTTP request will cause the server to misinterpret one of the HTTP header values leading to HTTP request smuggling.\n\n```console\n$ printf \"POST / HTTP/1.1\\r\\nHost: localhost:8080\\r\\nX-Abc: \\rxTransfer-Encoding: chunked\\r\\n\\r\\n1\\r\\nA\\r\\n0\\r\\n\\r\\n\" \\\n  | nc localhost 8080\n\nExpected output:\n  headers: {'Host': 'localhost:8080', 'X-Abc': '\\rxTransfer-Encoding: chunked'} body: b''\n\nActual output (note that 'Transfer-Encoding: chunked' is an HTTP header now and body is treated differently)\n  headers: {'Host': 'localhost:8080', 'X-Abc': '', 'Transfer-Encoding': 'chunked'} body: b'A'\n```\n\n### Patches\n\nUpgrade to the latest version of aiohttp to resolve this vulnerability. It has been fixed in v3.8.5: [`pip install aiohttp >= 3.8.5`](https://pypi.org/project/aiohttp/3.8.5/)\n\n### Workarounds\n\nIf you aren't able to upgrade you can reinstall aiohttp using `AIOHTTP_NO_EXTENSIONS=1` as an environment variable to disable the llhttp HTTP request parser implementation. The pure Python implementation isn't vulnerable to request smuggling:\n\n```console\n$ python -m pip uninstall --yes aiohttp\n$ AIOHTTP_NO_EXTENSIONS=1 python -m pip install --no-binary=aiohttp --no-cache aiohttp\n```\n\n### References\n\n* https://nvd.nist.gov/vuln/detail/CVE-2023-30589\n* https://hackerone.com/reports/2001873\n",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+    },
+    {
+      "type": "CVSS_V4",
+      "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "aiohttp"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.8.5"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 3.8.4"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/aio-libs/aiohttp/security/advisories/GHSA-45c4-8wx5-qw6w"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-37276"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/aio-libs/aiohttp/commit/9337fb3f2ab2b5f38d7e98a194bde6f7e3d16c40"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/aio-libs/aiohttp/commit/9c13a52c21c23dfdb49ed89418d28a5b116d0681"
+    },
+    {
+      "type": "WEB",
+      "url": "https://hackerone.com/reports/2001873"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/aio-libs/aiohttp"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/aio-libs/aiohttp/blob/v3.8.4/.gitmodules"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypa/advisory-database/tree/main/vulns/aiohttp/PYSEC-2023-120.yaml"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-444"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-07-20T14:52:00Z",
+    "nvd_published_at": "2023-07-19T20:15:10Z"
+  }
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -101,6 +101,7 @@ mod m0000810_fix_get_purl;
 mod m0000820_create_conversation;
 mod m0000830_perf_indexes;
 mod m0000840_add_relationship_14_15;
+mod m0000850_python_version;
 
 pub struct Migrator;
 
@@ -209,6 +210,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000820_create_conversation::Migration),
             Box::new(m0000830_perf_indexes::Migration),
             Box::new(m0000840_add_relationship_14_15::Migration),
+            Box::new(m0000850_python_version::Migration),
         ]
     }
 }

--- a/migration/src/m0000850_python_version.rs
+++ b/migration/src/m0000850_python_version.rs
@@ -1,0 +1,138 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            &Query::update()
+                .table(VersionScheme::Table)
+                .value(VersionScheme::Id, "python")
+                .and_where(Expr::col(VersionScheme::Id).eq("pypi"))
+                .to_owned()
+                .to_string(PostgresQueryBuilder),
+        )
+        .await?;
+
+        db.execute_unprepared(include_str!("m0000850_python_version/pythonver_cmp.sql"))
+            .await
+            .map(|_| ())?;
+
+        db.execute_unprepared(include_str!(
+            "m0000850_python_version/python_version_matches.sql"
+        ))
+        .await
+        .map(|_| ())?;
+
+        db.execute_unprepared(include_str!("m0000850_python_version/version_matches.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(include_str!("m0000670_version_cmp/version_matches.sql"))
+            .await
+            .map(|_| ())?;
+
+        db.execute_unprepared("drop function python_version_matches")
+            .await?;
+
+        db.execute_unprepared("drop function pythonver_cmp").await?;
+
+        insert(
+            db,
+            "pypi",
+            "Python",
+            Some("https://www.python.org/dev/peps/pep-0440/"),
+        )
+        .await?;
+        update(db, "python", "pypi").await?;
+        delete(db, "python").await?;
+
+        Ok(())
+    }
+}
+
+async fn insert(
+    db: &SchemaManagerConnection<'_>,
+    id: &str,
+    name: &str,
+    description: Option<&str>,
+) -> Result<(), DbErr> {
+    db.execute(
+        db.get_database_backend().build(
+            Query::insert()
+                .into_table(VersionScheme::Table)
+                .columns([
+                    VersionScheme::Id,
+                    VersionScheme::Name,
+                    VersionScheme::Description,
+                ])
+                .values([
+                    SimpleExpr::Value(Value::String(Some(Box::new(id.to_string())))),
+                    SimpleExpr::Value(Value::String(Some(Box::new(name.to_string())))),
+                    SimpleExpr::Value(Value::String(description.map(|e| Box::new(e.to_string())))),
+                ])
+                .map_err(|e| DbErr::Custom(e.to_string()))?,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn update(
+    db: &SchemaManagerConnection<'_>,
+    current_version_scheme: &str,
+    update_to_version_scheme: &str,
+) -> Result<(), DbErr> {
+    db.execute(
+        db.get_database_backend().build(
+            Query::update()
+                .table(VersionRange::Table)
+                .value(
+                    VersionRange::VersionSchemeId,
+                    update_to_version_scheme.to_string(),
+                )
+                .and_where(
+                    Expr::col(VersionRange::VersionSchemeId).eq(current_version_scheme.to_string()),
+                ),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn delete(db: &SchemaManagerConnection<'_>, version_scheme: &str) -> Result<(), DbErr> {
+    db.execute(
+        db.get_database_backend().build(
+            Query::delete()
+                .from_table(VersionScheme::Table)
+                .and_where(Expr::col(VersionScheme::Id).eq(version_scheme.to_string())),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+#[derive(DeriveIden)]
+pub enum VersionScheme {
+    Table,
+    Id,
+    Name,
+    Description,
+}
+
+#[derive(DeriveIden)]
+enum VersionRange {
+    Table,
+    VersionSchemeId,
+}

--- a/migration/src/m0000850_python_version/python_version_matches.sql
+++ b/migration/src/m0000850_python_version/python_version_matches.sql
@@ -1,0 +1,52 @@
+create or replace function python_version_matches(version_p text, range_p version_range)
+    returns bool
+as
+$$
+declare
+    low_end integer;
+    high_end integer;
+begin
+    if range_p.low_version is not null then
+        low_end := pythonver_cmp(version_p, range_p.low_version);
+    end if;
+
+    if low_end is not null then
+        if range_p.low_inclusive then
+            if low_end < 0 then
+                return false;
+            end if;
+        else
+            if low_end <= 0 then
+                return false;
+            end if;
+        end if;
+
+    end if;
+
+
+    if range_p.high_version is not null then
+        high_end := pythonver_cmp(version_p, range_p.high_version);
+    end if;
+
+    if high_end is not null then
+        if range_p.high_inclusive then
+            if high_end > 0 then
+                return false;
+            end if;
+        else
+            if high_end >= 0 then
+                return false;
+            end if;
+        end if;
+    end if;
+
+    if low_end is null and high_end is null then
+        return false;
+    end if;
+
+    return true;
+
+end
+$$
+    language plpgsql immutable;
+

--- a/migration/src/m0000850_python_version/pythonver_cmp.sql
+++ b/migration/src/m0000850_python_version/pythonver_cmp.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE FUNCTION pythonver_cmp(left_p TEXT, right_p TEXT)
+RETURNS INTEGER
+AS
+$$
+DECLARE
+left_parts text[];
+    right_parts text[];
+
+    left_major BIGINT;
+    left_minor BIGINT;
+    left_patch BIGINT;
+
+    right_major BIGINT;
+    right_minor BIGINT;
+    right_patch BIGINT;
+
+    -- Pre-release, Post-release, Dev-release
+    left_pre TEXT := NULL;
+    right_pre TEXT := NULL;
+
+    left_pre_num BIGINT := NULL;
+    right_pre_num BIGINT := NULL;
+
+    left_post BIGINT := NULL;
+    right_post BIGINT := NULL;
+
+    left_dev BIGINT := NULL;
+    right_dev BIGINT := NULL;
+BEGIN
+
+    left_parts = regexp_split_to_array(substring(left_p, E'^[^[:alpha:]]+'), E'\\.');
+    left_major = left_parts[1]::bigint;
+    left_minor = coalesce(left_parts[2]::bigint, 0);
+    left_patch = coalesce(left_parts[3]::bigint, 0);
+
+    right_parts = regexp_split_to_array(substring(right_p, E'^[^[:alpha:]]+'), E'\\.');
+    right_major = right_parts[1]::bigint;
+    right_minor = coalesce(right_parts[2]::bigint, 0);
+    right_patch = coalesce(right_parts[3]::bigint, 0);
+
+IF left_major > right_major THEN RETURN +1;
+    ELSIF left_major < right_major THEN RETURN -1;
+END IF;
+
+    IF left_minor > right_minor THEN RETURN +1;
+    ELSIF left_minor < right_minor THEN RETURN -1;
+END IF;
+
+    IF left_patch > right_patch THEN RETURN +1;
+    ELSIF left_patch < right_patch THEN RETURN -1;
+END IF;
+
+    -- Extract pre-release versions (allow `a1`, `b2`, `rc3` without hyphen)
+    left_pre := (regexp_match(left_p, '(a|b|rc)(\d*)'))[1];
+    left_pre_num := NULLIF((regexp_match(left_p, '(a|b|rc)(\d*)'))[2], '')::BIGINT;
+
+    right_pre := (regexp_match(right_p, '(a|b|rc)(\d*)'))[1];
+    right_pre_num := NULLIF((regexp_match(right_p, '(a|b|rc)(\d*)'))[2], '')::BIGINT;
+
+    IF left_pre IS NOT NULL AND right_pre IS NULL THEN RETURN -1; END IF;
+    IF right_pre IS NOT NULL AND left_pre IS NULL THEN RETURN +1; END IF;
+
+    -- Compare pre-release versions (alpha < beta < rc)
+    IF left_pre IS NOT NULL AND right_pre IS NOT NULL THEN
+        IF left_pre < right_pre THEN RETURN -1;
+        ELSIF left_pre > right_pre THEN RETURN +1;
+        ELSIF left_pre_num < right_pre_num THEN RETURN -1;
+        ELSIF left_pre_num > right_pre_num THEN RETURN +1;
+END IF;
+END IF;
+
+    -- Extract post-release versions (postN)
+    left_post := NULLIF((regexp_match(left_p, 'post(\d+)'))[1], '')::BIGINT;
+    right_post := NULLIF((regexp_match(right_p, 'post(\d+)'))[1], '')::BIGINT;
+
+    IF left_post IS NOT NULL AND right_post IS NULL THEN RETURN +1; END IF;
+    IF right_post IS NOT NULL AND left_post IS NULL THEN RETURN -1; END IF;
+    IF left_post IS NOT NULL AND right_post IS NOT NULL THEN
+        IF left_post > right_post THEN RETURN +1;
+        ELSIF left_post < right_post THEN RETURN -1;
+END IF;
+END IF;
+
+    -- Extract dev-release versions (devN)
+    left_dev := NULLIF((regexp_match(left_p, 'dev(\d+)'))[1], '')::BIGINT;
+    right_dev := NULLIF((regexp_match(right_p, 'dev(\d+)'))[1], '')::BIGINT;
+
+    IF left_dev IS NOT NULL AND right_dev IS NULL THEN RETURN -1; END IF;
+    IF right_dev IS NOT NULL AND left_dev IS NULL THEN RETURN +1; END IF;
+    IF left_dev IS NOT NULL AND right_dev IS NOT NULL THEN
+        IF left_dev > right_dev THEN RETURN +1;
+        ELSIF left_dev < right_dev THEN RETURN -1;
+END IF;
+END IF;
+
+    -- If everything is equal, return 0
+RETURN 0;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END
+$$
+LANGUAGE plpgsql IMMUTABLE;

--- a/migration/src/m0000850_python_version/version_matches.sql
+++ b/migration/src/m0000850_python_version/version_matches.sql
@@ -1,0 +1,45 @@
+create or replace function version_matches(version_p text, range_p version_range)
+    returns bool
+as
+$$
+declare
+begin
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            -- Git is git, and hard.
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            -- Semver is semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            -- RubyGems claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            -- NPM claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            -- Golang claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            -- NuGet claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            -- Just check if it is equal
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            -- Look at me! I'm an RPM! I'm special!
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            -- Look at me! I'm a Maven! I'm kinda special!
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            -- Python versioning
+            then python_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$
+    language plpgsql immutable;

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -1,0 +1,46 @@
+use test_context::test_context;
+use test_log::test;
+use tracing::instrument;
+use trustify_cvss::cvss3::severity::Severity;
+use trustify_module_fundamental::sbom::service::SbomService;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[instrument]
+#[test(tokio::test)]
+async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let sbom = SbomService::new(ctx.db.clone());
+
+    // ingest the SBOM
+    let result1 = ctx.ingest_document("cyclonedx/pypi_aiohttp.json").await?;
+
+    assert_eq!(
+        result1.document_id,
+        Some("urn:uuid:a5ddee00-4b86-498c-b7fd-b001b77479d1".to_string())
+    );
+
+    // ingest the advisory
+    let result2 = ctx.ingest_document("osv/GHSA-45c4-8wx5-qw6w.json").await?;
+
+    assert_eq!(result2.document_id, Some("GHSA-45c4-8wx5-qw6w".to_string()));
+
+    let sbom1 = sbom
+        .fetch_sbom_details(result1.id, vec![], &ctx.db)
+        .await?
+        .expect("SBOM details must be found");
+    log::info!("SBOM1: {sbom1:?}");
+
+    assert_eq!(1, sbom1.advisories.len());
+    assert_eq!("GHSA-45c4-8wx5-qw6w", sbom1.advisories[0].head.document_id);
+    assert_eq!(1, sbom1.advisories[0].status.len());
+    assert_eq!(
+        "CVE-2023-37276",
+        sbom1.advisories[0].status[0].vulnerability.identifier
+    );
+    assert_eq!(
+        Severity::Medium,
+        sbom1.advisories[0].status[0].average_severity
+    );
+    assert_eq!("affected", sbom1.advisories[0].status[0].status);
+    Ok(())
+}

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::expect_used)]
 
 mod cyclonedx;
+mod details;
 mod graph;
 mod reingest;
 mod spdx;

--- a/modules/ingestor/src/service/advisory/osv/translate.rs
+++ b/modules/ingestor/src/service/advisory/osv/translate.rs
@@ -38,6 +38,7 @@ fn translate<'a>(ecosystem: &Ecosystem, name: &'a str) -> Option<PackageUrl<'a>>
                 None
             }
         }
+        Ecosystem::PyPI => PackageUrl::new("pypi", name).ok(),
         _ => None,
     }
 }
@@ -59,6 +60,7 @@ mod test {
         "groupid:artifactid",
         Some("pkg:maven/groupid/artifactid?repository_url=http://other/repo")
     )]
+    #[case(Ecosystem::PyPI, "aiohttp", Some("pkg:pypi/aiohttp"))]
     fn test_translate(
         #[case] ecosystem: Ecosystem,
         #[case] name: &str,

--- a/modules/ingestor/tests/version/mod.rs
+++ b/modules/ingestor/tests/version/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 mod mavenver;
+mod pythonver;
 mod rpmver;
 mod semver;
 

--- a/modules/ingestor/tests/version/pythonver.rs
+++ b/modules/ingestor/tests/version/pythonver.rs
@@ -1,0 +1,137 @@
+use crate::version::common::{version_matches, Version, VersionRange};
+use sea_orm::{ConnectionTrait, Statement};
+use test_context::test_context;
+use test_log::test;
+use trustify_common::db::Database;
+use trustify_test_context::TrustifyContext;
+
+#[path = "common.rs"]
+mod common;
+
+async fn pythonver_cmp(
+    db: &Database,
+    left: &str,
+    right: &str,
+) -> Result<Option<i32>, anyhow::Error> {
+    let result = db
+        .query_one(Statement::from_string(
+            db.get_database_backend(),
+            format!(
+                r#"
+        SELECT * FROM pythonver_cmp( '{left}', '{right}' )
+        "#,
+            ),
+        ))
+        .await?;
+
+    if let Some(result) = result {
+        Ok(result.try_get_by_index(0)?)
+    } else {
+        Ok(None)
+    }
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn test_pythonver_cmp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    assert_eq!(Some(-1), pythonver_cmp(&ctx.db, "1.8.3", "2.9.0").await?);
+    assert_eq!(Some(0), pythonver_cmp(&ctx.db, "1.8.3", "1.8.3").await?);
+    assert_eq!(Some(1), pythonver_cmp(&ctx.db, "1.8.3", "1.8.2").await?);
+
+    assert_eq!(Some(1), pythonver_cmp(&ctx.db, "1.8.3", "1.8").await?);
+    assert_eq!(Some(-1), pythonver_cmp(&ctx.db, "1.8", "1.8.3").await?);
+    assert_eq!(Some(0), pythonver_cmp(&ctx.db, "1.8", "1.8.0").await?);
+
+    assert_eq!(Some(-1), pythonver_cmp(&ctx.db, "1.2.3a1", "1.2.3").await?);
+    assert_eq!(
+        Some(-1),
+        pythonver_cmp(&ctx.db, "1.2.3a1", "1.2.3.b1").await?
+    );
+    assert_eq!(
+        Some(-1),
+        pythonver_cmp(&ctx.db, "1.2.3b1", "1.2.3.rc1").await?
+    );
+    assert_eq!(Some(-1), pythonver_cmp(&ctx.db, "1.2.3rc1", "1.2.3").await?);
+    assert_eq!(
+        Some(1),
+        pythonver_cmp(&ctx.db, "1.2.3.post1", "1.2.3").await?
+    );
+    assert_eq!(
+        Some(1),
+        pythonver_cmp(&ctx.db, "1.2.3.post2", "1.2.3.post1").await?
+    );
+    assert_eq!(
+        Some(-1),
+        pythonver_cmp(&ctx.db, "1.2.3.dev1", "1.2.3").await?
+    );
+    Ok(())
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn test_version_matches(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+
+    assert!(version_matches(&db, "1.0.2", VersionRange::Exact("1.0.2"), "python").await?);
+    assert!(!version_matches(&db, "1.0.2", VersionRange::Exact("1.0.0"), "python").await?);
+
+    assert!(
+        version_matches(
+            &db,
+            "1.0.2",
+            VersionRange::Range(Version::Unbounded, Version::Inclusive("1.0.2")),
+            "python"
+        )
+        .await?
+    );
+
+    assert!(
+        !version_matches(
+            &db,
+            "1.0.2",
+            VersionRange::Range(Version::Unbounded, Version::Exclusive("1.0.2")),
+            "python"
+        )
+        .await?
+    );
+
+    assert!(
+        version_matches(
+            &db,
+            "1.0.2b2",
+            VersionRange::Range(Version::Unbounded, Version::Exclusive("1.0.2")),
+            "python"
+        )
+        .await?
+    );
+
+    assert!(
+        version_matches(
+            &db,
+            "1.0.2",
+            VersionRange::Range(Version::Inclusive("1.0.2"), Version::Exclusive("1.0.5")),
+            "python"
+        )
+        .await?
+    );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext, skip_teardown)]
+#[test(tokio::test)]
+async fn test_version_matches_commons_compress(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = ctx.db;
+
+    assert!(
+        !version_matches(
+            &db,
+            "1.26",
+            VersionRange::Range(Version::Inclusive("1.21"), Version::Exclusive("1.26")),
+            "python"
+        )
+        .await?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2174

- Added PLSQL function for Python versions (ref. https://packaging.python.org/en/latest/specifications/version-specifiers/ and https://peps.python.org/pep-0440/) with related SeaORM migration and test in `modules/ingestor/tests/version/pythonver.rs`.
- Managed `Python` and `PyPI` ecosystems in OSV loader (with test)
- Enhanced the `translate` function (with test)
- Furthermore added test `modules/fundamental/tests/sbom/details.rs` for the SBOM details to ensure a GHSA OSV vulnerability for the `PyPI` ecosystem (e.g. [GHSA-45c4-8wx5-qw6w](https://github.com/github/advisory-database/blob/ce72d06562c2b0f4e3af52889f6d9080319324a9/advisories/github-reviewed/2023/07/GHSA-45c4-8wx5-qw6w/GHSA-45c4-8wx5-qw6w.json)) properly correlates with an SBOM 
