### PR TITLE
feat: Gathering metrics at development time

### DIFF
--- a/common/infrastructure/Cargo.toml
+++ b/common/infrastructure/Cargo.toml
@@ -11,7 +11,7 @@ actix-tls = { workspace = true, features = ["openssl"] }
 actix-web = { workspace = true, features = ["openssl"] }
 actix-web-extras = { workspace = true }
 actix-web-httpauth = { workspace = true }
-actix-web-opentelemetry = { workspace = true }
+actix-web-opentelemetry = { workspace = true, features = ["metrics"] }
 actix-web-prom = { workspace = true }
 anyhow = { workspace = true }
 bytesize = { workspace = true }

--- a/common/infrastructure/src/app/mod.rs
+++ b/common/infrastructure/src/app/mod.rs
@@ -9,7 +9,7 @@ use actix_web::{
 };
 use actix_web_extras::middleware::Condition;
 use actix_web_httpauth::{extractors::bearer::BearerAuth, middleware::HttpAuthentication};
-use actix_web_opentelemetry::RequestTracing;
+use actix_web_opentelemetry::{RequestMetrics, RequestTracing};
 use actix_web_prom::PrometheusMetrics;
 use futures::{future::LocalBoxFuture, FutureExt};
 use std::sync::Arc;
@@ -23,6 +23,7 @@ pub struct AppOptions {
     pub authorizer: Authorizer,
     pub logger: Option<Logger>,
     pub tracing_logger: Option<RequestTracing>,
+    pub otel_metrics: Option<RequestMetrics>,
 }
 
 /// create a new authenticator
@@ -78,6 +79,8 @@ pub fn new_app(
         .wrap(Condition::from_option(options.cors))
         // Next, record metrics for the request (should never fail)
         .wrap(Condition::from_option(options.metrics))
+        // Next, record otel metrics for the request (should never fail)
+        .wrap(Condition::from_option(options.otel_metrics))
         // Compress everything
         .wrap(Compress::default())
         // First log the request, so that we know what happens (can't fail)

--- a/common/infrastructure/src/lib.rs
+++ b/common/infrastructure/src/lib.rs
@@ -3,7 +3,7 @@ mod infra;
 pub mod app;
 pub mod endpoint;
 pub mod health;
-pub mod tracing;
+pub mod otel;
 
 pub use infra::*;
 

--- a/docs/design/log_tracing.md
+++ b/docs/design/log_tracing.md
@@ -136,25 +136,4 @@ mean it will panic. For example, the `Option::unwrap_or` function:
 
 ![Screenshot of rustdoc for Option::unwrap_or](drawings/log_tracing_2.png)
 
-## Sending traces to OpenTelemetry Collector (devmode)
-
-Jaeger and OTEL Collector:
-
-```shell
-podman compose -f etc/dev-traces/compose.yaml up
-```
-
-Database:
-
-```shell
-podman compose -f etc/deploy/compose/compose.yaml up
-```
-
-Trustify with traces:
-
-```shell
-OTEL_TRACES_SAMPLER_ARG=1 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" cargo run --bin trustd api --db-password trustify --auth-disabled --tracing enabled
-```
-
-Access Trustify at [localhost:8080](http://localhost:8080) and analyze the traces using the [Jaeger UI](http://localhost:16686/)
 

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,45 @@
+# OpenTelemetry
+
+## Sending traces to OpenTelemetry Collector at development time
+
+Jaeger and OTEL Collector:
+
+```shell
+podman compose -f etc/telemetry/compose.yaml up
+```
+
+Database:
+
+```shell
+podman compose -f etc/deploy/compose/compose.yaml up
+```
+
+Trustify with traces:
+
+```shell
+OTEL_TRACES_SAMPLER_ARG=1 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" cargo run --bin trustd api --db-password trustify --auth-disabled --tracing enabled
+```
+
+Access Trustify at [localhost:8080](http://localhost:8080) and analyze the traces using the [Jaeger UI](http://localhost:16686/)
+
+## Gathering metrics at development time
+
+Prometheus and OTEL Collector:
+
+```shell
+podman compose -f etc/telemetry/compose.yaml up
+```
+
+Database:
+
+```shell
+podman compose -f etc/deploy/compose/compose.yaml up
+```
+
+Trustify with metrics:
+
+```shell
+cargo run --bin trustd api --db-password trustify --auth-disabled --metrics enabled
+```
+
+Access Trustify at [localhost:8080](http://localhost:8080) and analyze the metrics using the [Prometheus UI](http://localhost:9090/)

--- a/etc/telemetry/compose.yaml
+++ b/etc/telemetry/compose.yaml
@@ -1,4 +1,12 @@
 services:
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml:z
+    ports:
+      - "9090:9090"
+      - "9464:9464"
   jaeger-all-in-one:
     hostname: jaeger-all-in-one
     image: jaegertracing/all-in-one:1.53.0 # Using this version to align with trustify-helm-charts

--- a/etc/telemetry/config.yaml
+++ b/etc/telemetry/config.yaml
@@ -11,12 +11,17 @@ exporters:
       insecure: true
   debug:
     verbosity: detailed
+  prometheus:
+    endpoint: "0.0.0.0:9464"
 
 processors:
   batch: {}
 
 service:
   pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug, prometheus]
     traces:
       receivers: [otlp]
       processors: [batch]

--- a/etc/telemetry/prometheus.yaml
+++ b/etc/telemetry/prometheus.yaml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: 'collector'
+    static_configs:
+      - targets: ['collector:9464']
+

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -31,7 +31,7 @@ use trustify_infrastructure::{
     },
     endpoint::Trustify,
     health::checks::{Local, Probe},
-    tracing::Tracing,
+    otel::{Metrics as OtelMetrics, Tracing},
     Infrastructure, InfrastructureConfig, InitContext, Metrics,
 };
 use trustify_module_analysis::service::AnalysisService;
@@ -162,6 +162,7 @@ struct InitData {
     storage: DispatchBackend,
     http: HttpServerConfig<Trustify>,
     tracing: Tracing,
+    metrics: OtelMetrics,
     swagger_oidc: Option<Arc<SwaggerUiOidc>>,
     #[cfg(feature = "garage-door")]
     embedded_oidc: Option<embedded_oidc::EmbeddedOidc>,
@@ -294,6 +295,7 @@ impl InitData {
             config,
             http: run.http,
             tracing: run.infra.tracing,
+            metrics: run.infra.metrics,
             swagger_oidc,
             storage,
             #[cfg(feature = "garage-door")]
@@ -311,6 +313,7 @@ impl InitData {
         let http = {
             HttpServerBuilder::try_from(self.http)?
                 .tracing(self.tracing)
+                .metrics_otel(self.metrics)
                 .metrics(metrics.registry().clone(), SERVICE_ID)
                 .authorizer(self.authorizer)
                 .swagger_ui_oidc(self.swagger_oidc.clone())

--- a/server/src/profile/importer.rs
+++ b/server/src/profile/importer.rs
@@ -29,7 +29,7 @@ use trustify_infrastructure::{
     },
     endpoint::Trustify,
     health::checks::{Local, Probe},
-    tracing::Tracing,
+    otel::Tracing,
     Infrastructure, InfrastructureConfig, InitContext, Metrics,
 };
 use trustify_module_graphql::RootQuery;

--- a/trustd/src/db.rs
+++ b/trustd/src/db.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 use trustify_common::config::Database;
 use trustify_common::db;
-use trustify_infrastructure::tracing::{init_tracing, Tracing};
+use trustify_infrastructure::otel::{init_tracing, Tracing};
 
 #[derive(clap::Args, Debug)]
 pub struct Run {


### PR DESCRIPTION
* Adds prometheus to existing compose file
* Avoids conflicts with current custom metrics configs
* Moved otel dev docs to docs/otel.md
* Renamed tracing.rs to otel.rs as now it contains metrics [signal](https://opentelemetry.io/docs/concepts/signals/)

![2025-01-29_08-44](https://github.com/user-attachments/assets/4474c64a-9fab-41cf-be98-d132b4057887)
