### PR TITLE
Don’t benchmark on every PR.  

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
-    branches:
-      - "main"
+#  pull_request:
+#    branches:
+#      - "main"
 
 concurrency: benchmark
 


### PR DESCRIPTION
This seems to fail PR ci checks consistently.