### PR TITLE
[release/0.2.z] task: align trustify-ui dependency branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#4ab79f543b00077fb8e0e33b595e1f6472dfb982"
+source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Frelease%2F0.2.z#cd7827e5b8d2fe437298df7ae6174b614b465ac5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ trustify-module-fundamental = { path = "modules/fundamental" }
 trustify-module-importer = { path = "modules/importer" }
 trustify-module-ui = { path = "modules/ui", default-features = false }
 trustify-server = { path = "server", default-features = false }
-trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/main" }
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/release/0.2.z" }
 trustify-module-ingestor = { path = "modules/ingestor" }
 trustify-module-storage = { path = "modules/storage" }
 trustify-module-graphql = { path = "modules/graphql" }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -142,3 +142,18 @@ workflow in your personal repository, and create a release there. If that's ok f
 push tags as you like, to fix and test the release process.
 
 
+## Branches and Cargo.toml
+
+When branching off a "release branch" change the `Cargo.toml` files as follows: 
+
+Replace:
+
+```cargo
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/main" }
+```
+
+by:
+
+```cargo
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "release/x.y.z" }
+```


### PR DESCRIPTION
The branch release/0.2.z should point to the ui dependency also using the release/0.2.z branches