### PR TITLE
docs: RELEASE.md add note about branches for trustify-ui

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -141,4 +141,18 @@ To test, you can push a release tag to your personal fork of the repository. By 
 workflow in your personal repository, and create a release there. If that's ok for your fork, you can push and force
 push tags as you like, to fix and test the release process.
 
+## Branches and Cargo.toml
 
+When branching off a "release branch" change the `Cargo.toml` files as follows:
+
+Replace:
+
+```cargo
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/main" }
+```
+
+by:
+
+```cargo
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "release/x.y.z" }
+```


### PR DESCRIPTION
Based on https://github.com/trustification/trustify/pull/1249

Aligned the RELEASE.md from release/0.2.z in the main branch.