### PR TITLE
chore: add index for DELETE operation

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -108,6 +108,7 @@ mod m0000880_org_name_index;
 mod m0000890_create_sbom_external_node;
 mod m0000900_perf_indexes;
 mod m0000910_insert_packagist_version_scheme;
+mod m0000920_perf_indexes;
 
 #[cfg(feature = "ai")]
 pub mod ai;
@@ -225,6 +226,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000890_create_sbom_external_node::Migration),
             Box::new(m0000900_perf_indexes::Migration),
             Box::new(m0000910_insert_packagist_version_scheme::Migration),
+            Box::new(m0000920_perf_indexes::Migration),
         ]
     }
 }

--- a/migration/src/m0000920_perf_indexes.rs
+++ b/migration/src/m0000920_perf_indexes.rs
@@ -1,0 +1,47 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(VulnerabilityDescription::Table)
+                    .name(Indexes::AdvisoryIdIndex.to_string())
+                    .col(VulnerabilityDescription::AdvisoryId)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(VulnerabilityDescription::Table)
+                    .name(Indexes::AdvisoryIdIndex.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+enum Indexes {
+    AdvisoryIdIndex,
+}
+
+#[derive(DeriveIden)]
+enum VulnerabilityDescription {
+    Table,
+    AdvisoryId,
+}


### PR DESCRIPTION
During ingestion, do we do clean up descriptions using:

```sql
DELETE FROM "vulnerability_description" WHERE "vulnerability_description"."advisory_id" = $1
```

That shows up in the AWS RDS console as top SQL statement. I think an index might help. But I am guessing.