### PR TITLE
chore: update rust to 1.84.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
* https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html#whats-in-1841