### PR TITLE
chore: add db conn env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8345,6 +8345,7 @@ dependencies = [
  "deepsize",
  "hex",
  "human-date-parser",
+ "humantime",
  "itertools 0.13.0",
  "lenient_semver",
  "log",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -49,6 +49,7 @@ tracing = { workspace = true }
 utoipa = { workspace = true, features = ["url"] }
 uuid = { workspace = true, features = ["v5", "serde"] }
 walker-common = { workspace = true, features = ["bzip2", "liblzma"]}
+humantime = "2.1.0"
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -16,6 +16,7 @@ use sea_orm::{
 };
 use sqlx::error::ErrorKind;
 use std::ops::{Deref, DerefMut};
+use std::time::Duration;
 use tracing::instrument;
 
 #[derive(Clone, Debug)]
@@ -36,6 +37,11 @@ impl Database {
         opt.max_connections(database.max_conn);
         opt.min_connections(database.min_conn);
         opt.sqlx_logging_level(log::LevelFilter::Trace);
+
+        opt.connect_timeout(Duration::from_secs(database.connect_timeout));
+        opt.acquire_timeout(Duration::from_secs(database.acquire_timeout));
+        opt.max_lifetime(Duration::from_secs(database.max_lifetime));
+        opt.idle_timeout(Duration::from_secs(database.idle_timeout));
 
         let db = sea_orm::Database::connect(opt).await?;
         let name = database.name.clone();

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -31,6 +31,10 @@
 | `TRUSTD_DB_HOST`                         | Database address                                                                    | `localhost`                             |
 | `TRUSTD_DB_MAX_CONN`                     | Database max connections                                                            | `75`                                    |
 | `TRUSTD_DB_MIN_CONN`                     | Database min connections                                                            | `25`                                    |
+| `TRUSTD_DB_CONNECT_TIMEOUT`              | Database connect timeout (humantime)                                                | `8s`                                    |
+| `TRUSTD_DB_ACQUIRE_TIMEOUT`              | Database acquire timeout (humantime)                                                | `8s`                                    |
+| `TRUSTD_DB_MAX_LIFETIME`                 | Database max lifetime (humantime)                                                   | `7200s`                                 |
+| `TRUSTD_DB_IDLE_TIMEOUT`                 | Database idle timeout (humantime)                                                   | `600s`                                  |
 | `TRUSTD_DB_NAME`                         | Database name                                                                       | `trustify`                              |
 | `TRUSTD_DB_PASSWORD`                     | Database password                                                                   | `trustify`                              |
 | `TRUSTD_DB_PORT`                         | Database port                                                                       | `5432`                                  |


### PR DESCRIPTION
exposing some of sea_orm database conn configurations (as per https://docs.rs/sea-orm/latest/sea_orm/struct.ConnectOptions.html)

```rust
    pub connect_timeout: u64,
    #[arg(id="db-acquire-timeout", long, env = ENV_DB_ACQUIRE_TIMEOUT, default_value_t=DB_ACQUIRE_TIMEOUT.into(), conflicts_with = "db-url")]
    pub acquire_timeout: u64,
    #[arg(id="db-max-lifetime", long, env = ENV_DB_MAX_LIFETIME, default_value_t=DB_MAX_LIFETIME.into(), conflicts_with = "db-url")]
    pub max_lifetime: u64,
    #[arg(id="db-idle-timeout", long, env = ENV_DB_IDLE_TIMEOUT, default_value_t=DB_IDLE_TIMEOUT.into(), conflicts_with = "db-url")]
    pub idle_timeout: u64,
```

doing this will presumably set db conn keepalive settings to avoid having to stand up a tls conn with every db request.


which use [humantime](https://crates.io/crates/humantime) to set value in seconds, hours, days:

```bash
export TRUSTD_DB_CONNECT_TIMEOUT=8                                
export TRUSTD_DB_ACQUIRE_TIMEOUT=8
export TRUSTD_DB_MAX_LIFETIME=7200                                 
export TRUSTD_DB_IDLE_TIMEOUT=600                                 
```