### PR TITLE
TC-2240 OSV GHSA - Ecosystem RubyGems

### DIFF
--- a/entity/src/version_scheme.rs
+++ b/entity/src/version_scheme.rs
@@ -31,4 +31,5 @@ pub enum VersionScheme {
     Npm,
     Packagist,
     NuGet,
+    Gem,
 }

--- a/etc/test-data/cyclonedx/ghsa_test.json
+++ b/etc/test-data/cyclonedx/ghsa_test.json
@@ -60,6 +60,13 @@
       "version": "3.1.11",
       "description": "1 vulnerability",
       "purl": "pkg:nuget/Microsoft.NETCore.App.Runtime.win-x86@3.1.11"
+    },
+    {
+      "type": "library",
+      "name": "activerecord-session_store",
+      "version": "0.1.1",
+      "description": "1 vulnerability",
+      "purl": "pkg:gem/activerecord-session_store@0.1.1"
     }
   ]
 }

--- a/etc/test-data/osv/GHSA-cvw2-xj8r-mjf7.json
+++ b/etc/test-data/osv/GHSA-cvw2-xj8r-mjf7.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-cvw2-xj8r-mjf7",
+  "modified": "2023-09-05T22:00:39Z",
+  "published": "2021-03-09T00:45:31Z",
+  "aliases": [
+    "CVE-2019-25025"
+  ],
+  "summary": "Activerecord-session_store Vulnerable to Timing Attack",
+  "details": "The `activerecord-session_store` (aka Active Record Session Store) component through 1.1.3 for Ruby on Rails does not use a constant-time approach when delivering information about whether a guessed session ID is valid. Consequently, remote attackers can leverage timing discrepancies to achieve a correct guess in a relatively short amount of time. This is a related issue to CVE-2019-16782. \n\n## Recommendation\n\nThis has been fixed in version 2.0.0.  All users are advised to update to this version or later.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "RubyGems",
+        "name": "activerecord-session_store"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "2.0.0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "last_known_affected_version_range": "<= 1.1.3"
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-25025"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/activerecord-session_store/pull/151"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/activerecord-session_store/commit/9d4dd113d3010b82daaadf0b0ee6b9fb2afb2160"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/rails/activerecord-session_store"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rails/activerecord-session_store/releases/tag/v2.0.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/activerecord-session_store/CVE-2019-25025.yml"
+    },
+    {
+      "type": "WEB",
+      "url": "https://rubygems.org/gems/activerecord-session_store"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-208"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2021-03-09T00:45:19Z",
+    "nvd_published_at": "2021-03-05T06:15:00Z"
+  }
+}

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -47,13 +47,19 @@ async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow:
     let nuget = ctx.ingest_document("osv/GHSA-rh58-r7jh-xhx3.json").await?;
     assert_eq!(nuget.document_id, Some("GHSA-rh58-r7jh-xhx3".to_string()));
 
+    let rubygems = ctx.ingest_document("osv/GHSA-cvw2-xj8r-mjf7.json").await?;
+    assert_eq!(
+        rubygems.document_id,
+        Some("GHSA-cvw2-xj8r-mjf7".to_string())
+    );
+
     let sbom1 = sbom
         .fetch_sbom_details(result1.id, vec![], &ctx.db)
         .await?
         .expect("SBOM details must be found");
     log::info!("SBOM1: {sbom1:?}");
 
-    assert_eq!(6, sbom1.advisories.len());
+    assert_eq!(7, sbom1.advisories.len());
     check_advisory(
         &sbom1,
         "GHSA-45c4-8wx5-qw6w",
@@ -88,6 +94,12 @@ async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow:
         &sbom1,
         "GHSA-rh58-r7jh-xhx3",
         "CVE-2021-26423",
+        Severity::High,
+    );
+    check_advisory(
+        &sbom1,
+        "GHSA-cvw2-xj8r-mjf7",
+        "CVE-2019-25025",
         Severity::High,
     );
     Ok(())

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -223,6 +223,16 @@ impl<'g> OsvLoader<'g> {
                                 )
                                 .await?;
                             }
+                            (RangeType::Ecosystem, Ecosystem::RubyGems) => {
+                                create_package_status(
+                                    &advisory_vuln,
+                                    &purl,
+                                    range,
+                                    &VersionScheme::Gem,
+                                    &tx,
+                                )
+                                .await?;
+                            }
                             (_, _) => {
                                 create_package_status_versions(
                                     &advisory_vuln,

--- a/modules/ingestor/src/service/advisory/osv/translate.rs
+++ b/modules/ingestor/src/service/advisory/osv/translate.rs
@@ -42,6 +42,7 @@ fn translate<'a>(ecosystem: &Ecosystem, name: &'a str) -> Option<PackageUrl<'a>>
         Ecosystem::Go => split_name(name, "golang", "/"),
         Ecosystem::Packagist => split_name(name, "composer", "/"),
         Ecosystem::NuGet => PackageUrl::new("nuget", name).ok(),
+        Ecosystem::RubyGems => PackageUrl::new("gem", name).ok(),
         _ => None,
     }
 }
@@ -109,6 +110,12 @@ mod test {
         Some("pkg:nuget/Microsoft.NETCore.App.Runtime.win-x86")
     )]
     #[case(Ecosystem::NuGet, "PowerShell", Some("pkg:nuget/PowerShell"))]
+    #[case(Ecosystem::RubyGems, "pwpush", Some("pkg:gem/pwpush"))]
+    #[case(
+        Ecosystem::RubyGems,
+        "activerecord-session_store",
+        Some("pkg:gem/activerecord-session_store")
+    )]
     fn test_translate(
         #[case] ecosystem: Ecosystem,
         #[case] name: &str,


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2240

During local tests execution (and confirmed from GH CI job), it turned out the [test thread reached its limit](https://github.com/trustification/trustify/actions/runs/13258299168/job/37009027768?pr=1281#step:9:351), i.e. 2 MB, so ~`RUST_MIN_STACK` has been set to 3 MB, referencing it also in the project's README ([preview](https://github.com/mrizzi/trustify/tree/TC-2240?tab=readme-ov-file#tests-execution))~ the test has been "isolated" manually creating the Tokio runtime for the test execution hence no changes are requested to anyone (neither contributors nor CI jobs).