### PR TITLE
feat: introduce new dataset (ds4)

### DIFF
--- a/etc/datasets/Makefile
+++ b/etc/datasets/Makefile
@@ -10,3 +10,8 @@ ds1.zip:
 ds3.zip:
 	-rm ds3.zip
 	cd ds3 && zip -r ../ds3.zip .
+
+.PHONY: ds3-sboms.zip
+ds3-sboms.zip:
+	-rm ds3-sbom.zip
+	cd ds3 && zip -r ../ds3-sboms.zip ./spdx

--- a/etc/datasets/README.md
+++ b/etc/datasets/README.md
@@ -27,3 +27,36 @@ pushd ds3
 zip -r ../ds3.zip .
 popd
 ```
+
+You can also create just a collection of SBOMs from this dataset
+
+```shell
+make ds3-sboms
+```
+
+You can then upload it to the existing instance like
+
+```shell
+http POST localhost:8080/api/v2/dataset @etc/datasets/ds3-sboms.zip
+```
+
+## DS4
+
+This dataset contains the following data:
+
+* Red Hat SBOMs
+* CVEs since 2020
+* GHSA since 2020
+* Red Hat CSAF since 2020
+
+You can generate database dump based on this, by using the command like
+
+```shell
+cargo xtask generate-dump --input etc/datasets/ds4.yaml --output dump-ds4.sql
+```
+
+The dump can be loaded to the database like:
+
+```shell
+cat dump-ds4.sql | env PGPASSWORD=trustify psql -U postgres -d trustify -h localhost -p 5432 -v ON_ERROR_STOP=1
+```

--- a/etc/datasets/ds4.yaml
+++ b/etc/datasets/ds4.yaml
@@ -1,0 +1,29 @@
+$schema: ../../xtask/schema/generate-dump.json
+import:
+  - !sbom
+    description: Red Hat SBOMs
+    source: https://access.redhat.com/security/data/sbom/beta/
+    period: 1s
+    fetchRetries: 50
+    ignoreMissing: true
+    keys:
+      - https://access.redhat.com/security/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4
+  - !cve
+    description: CVEs since 2020
+    source: https://github.com/CVEProject/cvelistV5
+    period: 1s
+    Years: 2020, 2021, 2022, 2023, 2024, 2025
+  - !osv
+    description: GHSA since 2020
+    period: 1s
+    source: https://github.com/github/advisory-database
+    path: advisories
+    fetchRetries: 50
+    Years: 2020, 2021, 2022, 2023, 2024, 2025
+  - !csaf
+    description: Red Hat CSAF advisories since 2020
+    source: redhat.com
+    period: 1s
+    fetchRetries: 50
+    ignoreMissing: true
+    onlyPatterns: ["^cve-202"]


### PR DESCRIPTION
This PR creates a way to create a new dataset (with db dump) with the following data:

* Red Hat SBOMs
* CVEs since 2020
* GHSA since 2020
* Red Hat CSAF since 2020

This dataset can be used as a lighter and more diverse one for load testing and also a end-to-end testing.

It also provides a way to create an archive with only SBOMs from DS3. It can be very handy during testing. We should enhance SBOM importer to support git as a source, which would make this process easier (#1310)