### PR TITLE
fix: test_sbom_details_cyclonedx_osv set thread_stack_size

### DIFF
--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -15,6 +15,7 @@ use trustify_test_context::TrustifyContext;
 #[test]
 fn test_sbom_details_cyclonedx_osv() {
     tokio::runtime::Builder::new_current_thread()
+        .thread_stack_size(3 * 1024 * 1024)
         .enable_all()
         .build()
         .unwrap()


### PR DESCRIPTION
Raising the stack size for the `test_sbom_details_cyclonedx_osv` after the failure in https://github.com/trustification/trustify/actions/runs/13417116433/job/37482008830#step:9:708