### PR TITLE
ci: allow workflow openapi.yaml to support release/0.2.z

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
     paths:
       - openapi.yaml
 
@@ -20,6 +21,7 @@ jobs:
         with:
           repository: trustification/trustify-ui
           path: trustify-ui
+          ref: ${{ github.ref_name }}
       - name: Update trustify-ui
         run: |
           rm ./trustify-ui/client/openapi/trustd.yaml
@@ -27,16 +29,13 @@ jobs:
           cd ./trustify-ui
           git diff
       - name: Create Pull Request - trustify-ui
-        uses: peter-evans/create-pull-request@v5
-        id: ui-pr
+        uses: trustification/release-tools/.github/actions/create-pr@main
         with:
-          token: ${{ secrets.GH_PAT }}
           path: ./trustify-ui
           commit-message: "update client/openapi/trustd.yaml"
-          signoff: true
-          branch-suffix: short-commit-hash
-          title: "update client/openapi/trustd.yaml"
-          body: "Update trustify openapi definition"
-      - name: PR Notifications
-        run: |
-          echo "::notice:: Trustify UI Pull Request URL - ${{ steps.ui-pr.outputs.pull-request-url }}"
+          title: ":seedling: [${{ github.ref_name }}] update client/openapi/trustd.yaml"
+          body: |
+            The openapi.yaml of trustify has changed
+        env:
+          TRUSTIFICATION_BOT_ID: ${{ vars.TRUSTIFICATION_BOT_ID }}
+          TRUSTIFICATION_BOT_KEY: ${{ secrets.TRUSTIFICATION_BOT_KEY }}


### PR DESCRIPTION
With this PR:
- openapi.yaml from `main` branch will be push to the `main` branch of the ui repository
- openapi.yaml from `release/0.2.z` branch will be push to the `release/0.2.z` branch of the ui repository

This PR will need to be backported to the release/0.2.z branch in this repository and I will take care of it once this PR is merged