### PR TITLE
chore: migrate to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 
 [workspace.package]
 version = "0.2.6"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/common/auth/src/authenticator/actix.rs
+++ b/common/auth/src/authenticator/actix.rs
@@ -1,5 +1,5 @@
-use super::user::UserInformation;
 use super::Authenticator;
+use super::user::UserInformation;
 use actix_http::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web_httpauth::extractors::bearer::BearerAuth;

--- a/common/auth/src/authenticator/mod.rs
+++ b/common/auth/src/authenticator/mod.rs
@@ -20,7 +20,7 @@ use biscuit::jws::Compact;
 use claims::AccessTokenClaims;
 use config::AuthenticatorClientConfig;
 use error::AuthenticationError;
-use futures_util::{stream, StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt, stream};
 use jsonpath_rust::{JsonPath, JsonPathValue};
 use openid::{Client, Configurable, Discovered, Empty, Jws};
 use serde_json::Value;

--- a/common/auth/src/authenticator/validate.rs
+++ b/common/auth/src/authenticator/validate.rs
@@ -2,8 +2,8 @@ use crate::authenticator::claims::AccessTokenClaims;
 use biscuit::Empty;
 use chrono::{Duration, Utc};
 use openid::{
-    error::{Expiry, Mismatch, Missing, Validation},
     Client, Config, Configurable, Jws, Provider,
+    error::{Expiry, Mismatch, Missing, Validation},
 };
 
 pub type AccessToken = Jws<AccessTokenClaims, Empty>;

--- a/common/auth/src/authorizer/mod.rs
+++ b/common/auth/src/authorizer/mod.rs
@@ -2,8 +2,8 @@ mod require;
 pub use require::*;
 
 use crate::{
-    authenticator::{error::AuthorizationError, user::UserInformation},
     Permission,
+    authenticator::{error::AuthorizationError, user::UserInformation},
 };
 
 #[derive(

--- a/common/auth/src/client/inject.rs
+++ b/common/auth/src/client/inject.rs
@@ -1,4 +1,4 @@
-use super::{error::Error, Credentials, TokenProvider};
+use super::{Credentials, TokenProvider, error::Error};
 use std::future::Future;
 use tracing::instrument;
 

--- a/common/auth/src/swagger_ui.rs
+++ b/common/auth/src/swagger_ui.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use trustify_common::tls::ClientConfig;
 use url::Url;
 use utoipa::openapi::{
+    OpenApi, SecurityRequirement,
     extensions::Extensions,
     security::{AuthorizationCode, Flow, OAuth2, Scopes, SecurityScheme},
-    OpenApi, SecurityRequirement,
 };
-use utoipa_swagger_ui::{oauth, Config, SwaggerUi};
+use utoipa_swagger_ui::{Config, SwaggerUi, oauth};
 
 #[derive(Clone, Debug, Default, clap::Args)]
 #[command(

--- a/common/auth/src/utoipa.rs
+++ b/common/auth/src/utoipa.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use utoipa::{
-    openapi::{RefOr, Response, ResponseBuilder, ResponsesBuilder},
     IntoResponses,
+    openapi::{RefOr, Response, ResponseBuilder, ResponsesBuilder},
 };
 
 pub enum AuthResponse {

--- a/common/infrastructure/src/app/http.rs
+++ b/common/infrastructure/src/app/http.rs
@@ -1,19 +1,19 @@
 use crate::{
-    app::{new_app, AppOptions},
+    app::{AppOptions, new_app},
     endpoint::Endpoint,
     otel::{Metrics, Tracing},
 };
 use actix_cors::Cors;
 use actix_tls::{accept::openssl::reexports::SslAcceptor, connect::openssl::reexports::SslMethod};
 use actix_web::{
+    App, HttpResponse, HttpServer,
     dev::{ServiceFactory, ServiceRequest},
     web::{self, JsonConfig},
-    App, HttpResponse, HttpServer,
 };
 use actix_web_opentelemetry::{RequestMetrics, RequestTracing};
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use bytesize::ByteSize;
-use clap::{value_parser, Arg, ArgMatches, Args, Command, Error, FromArgMatches};
+use clap::{Arg, ArgMatches, Args, Command, Error, FromArgMatches, value_parser};
 use openssl::ssl::SslFiletype;
 use std::{
     fmt::Debug,
@@ -27,7 +27,7 @@ use std::{
 use trustify_auth::{
     authenticator::Authenticator,
     authorizer::Authorizer,
-    swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc},
+    swagger_ui::{SwaggerUiOidc, swagger_ui_with_auth},
 };
 use trustify_common::model::BinaryByteSize;
 use utoipa::openapi::Info;
@@ -247,8 +247,8 @@ where
         let mut result = HttpServerBuilder::new()
             .workers(value.workers)
             .bind(addr)
-            .request_limit(value.request_limit.0 .0 as _)
-            .json_limit(value.json_limit.0 .0 as _);
+            .request_limit(value.request_limit.0.0 as _)
+            .json_limit(value.json_limit.0.0 as _);
 
         if value.tls_enabled {
             result = result.tls(TlsConfiguration {

--- a/common/infrastructure/src/app/mod.rs
+++ b/common/infrastructure/src/app/mod.rs
@@ -2,15 +2,15 @@ pub mod http;
 
 use actix_cors::Cors;
 use actix_web::{
+    App, Error,
     body::MessageBody,
     dev::{ServiceFactory, ServiceRequest, ServiceResponse},
     middleware::{Compress, Logger},
-    App, Error,
 };
 use actix_web_extras::middleware::Condition;
 use actix_web_httpauth::{extractors::bearer::BearerAuth, middleware::HttpAuthentication};
 use actix_web_opentelemetry::{RequestMetrics, RequestTracing};
-use futures::{future::LocalBoxFuture, FutureExt};
+use futures::{FutureExt, future::LocalBoxFuture};
 use std::sync::Arc;
 use trustify_auth::{authenticator::Authenticator, authorizer::Authorizer};
 

--- a/common/infrastructure/src/endpoint.rs
+++ b/common/infrastructure/src/endpoint.rs
@@ -1,5 +1,5 @@
 use clap::{
-    value_parser, Arg, ArgMatches, Args, Command, CommandFactory, Error, FromArgMatches, Parser,
+    Arg, ArgMatches, Args, Command, CommandFactory, Error, FromArgMatches, Parser, value_parser,
 };
 use std::{
     ffi::OsString,

--- a/common/infrastructure/src/health/checks/failure.rs
+++ b/common/infrastructure/src/health/checks/failure.rs
@@ -2,8 +2,8 @@ use crate::health::Check;
 use parking_lot::RwLock;
 use std::borrow::Cow;
 use std::future::Future;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 /// Monitor the outcome of some operation.

--- a/common/infrastructure/src/health/checks/local.rs
+++ b/common/infrastructure/src/health/checks/local.rs
@@ -2,14 +2,14 @@ use crate::health::Check;
 use anyhow::Context;
 use std::borrow::Cow;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::select;
 use tokio::sync::oneshot;
 use tokio::task::LocalSet;
-use tokio::time::{interval, MissedTickBehavior};
+use tokio::time::{MissedTickBehavior, interval};
 
 pub struct Local<T = ()> {
     error: Cow<'static, str>,

--- a/common/infrastructure/src/health/checks/probe.rs
+++ b/common/infrastructure/src/health/checks/probe.rs
@@ -1,7 +1,7 @@
 use crate::health::Check;
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Clone)]
 pub struct Probe {

--- a/common/infrastructure/src/health/mod.rs
+++ b/common/infrastructure/src/health/mod.rs
@@ -3,9 +3,9 @@ pub mod checks;
 use crate::health::checks::UninitializedCheck;
 use futures::{
     future::TryFutureExt,
-    stream::{iter, StreamExt},
+    stream::{StreamExt, iter},
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;

--- a/common/infrastructure/src/infra.rs
+++ b/common/infrastructure/src/infra.rs
@@ -1,10 +1,10 @@
 use crate::{
     health::{Checks, HealthChecks},
-    otel::{init_metrics, init_tracing, Metrics as OtelMetrics, Tracing},
+    otel::{Metrics as OtelMetrics, Tracing, init_metrics, init_tracing},
 };
 use actix_web::{
-    http::uri::Builder, middleware::Logger, web, web::ServiceConfig, App, HttpRequest,
-    HttpResponse, HttpServer, Responder,
+    App, HttpRequest, HttpResponse, HttpServer, Responder, http::uri::Builder, middleware::Logger,
+    web, web::ServiceConfig,
 };
 use anyhow::Context;
 use futures::future::select_all;
@@ -13,7 +13,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::signal;
 
 #[cfg(unix)]
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 
 const DEFAULT_BIND_ADDR: &str = "localhost:9010";
 
@@ -84,19 +84,19 @@ pub async fn index(req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(apis)
 }
 
-async fn startup(health: web::Data<HealthChecks>) -> impl Responder {
+async fn startup(health: web::Data<HealthChecks>) -> impl Responder + use<> {
     run_checks(&health.startup).await
 }
 
-async fn liveness(health: web::Data<HealthChecks>) -> impl Responder {
+async fn liveness(health: web::Data<HealthChecks>) -> impl Responder + use<> {
     run_checks(&health.liveness).await
 }
 
-async fn readiness(health: web::Data<HealthChecks>) -> impl Responder {
+async fn readiness(health: web::Data<HealthChecks>) -> impl Responder + use<> {
     run_checks(&health.readiness).await
 }
 
-async fn run_checks(checks: &Checks) -> impl Responder {
+async fn run_checks(checks: &Checks) -> impl Responder + use<> {
     let checks = checks.run().await;
 
     log::debug!("checks: {checks:?}");

--- a/common/infrastructure/src/otel.rs
+++ b/common/infrastructure/src/otel.rs
@@ -1,24 +1,24 @@
 use core::fmt;
 use opentelemetry::{
+    Context,
     global::{
         get_text_map_propagator, set_meter_provider, set_text_map_propagator, set_tracer_provider,
     },
     propagation::Injector,
     trace::TracerProvider as _,
-    Context,
 };
 use opentelemetry_otlp::{MetricExporter, SpanExporter};
 use opentelemetry_sdk::{
+    Resource,
     metrics::{PeriodicReader, SdkMeterProvider},
     propagation::TraceContextPropagator,
     trace::{Sampler, Sampler::ParentBased, SdkTracerProvider},
-    Resource,
 };
 use reqwest::RequestBuilder;
 use std::sync::Once;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-    field::MakeExt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+    EnvFilter, field::MakeExt, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Default)]

--- a/common/src/cpe.rs
+++ b/common/src/cpe.rs
@@ -4,8 +4,8 @@ use cpe::{
 };
 use deepsize::DeepSizeOf;
 use serde::{
-    de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, Visitor},
 };
 use std::{
     borrow::Cow,
@@ -13,8 +13,8 @@ use std::{
     str::FromStr,
 };
 use utoipa::{
-    openapi::{KnownFormat, ObjectBuilder, RefOr, Schema, SchemaFormat, Type},
     PartialSchema, ToSchema,
+    openapi::{KnownFormat, ObjectBuilder, RefOr, Schema, SchemaFormat, Type},
 };
 use uuid::Uuid;
 

--- a/common/src/db/embedded.rs
+++ b/common/src/db/embedded.rs
@@ -2,7 +2,7 @@ use crate::db::Database;
 use anyhow::Context;
 use postgresql_embedded::{PostgreSQL, Settings, VersionReq};
 use std::path::Path;
-use tracing::{info_span, Instrument};
+use tracing::{Instrument, info_span};
 
 /// Create common default settings for the embedded database
 fn default_settings() -> anyhow::Result<Settings> {

--- a/common/src/db/mod.rs
+++ b/common/src/db/mod.rs
@@ -8,11 +8,11 @@ pub mod query;
 
 pub use func::*;
 
-use anyhow::{ensure, Context};
+use anyhow::{Context, ensure};
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{
-    prelude::async_trait, ConnectOptions, ConnectionTrait, DatabaseConnection, DbBackend, DbErr,
-    ExecResult, QueryResult, RuntimeErr, Statement,
+    ConnectOptions, ConnectionTrait, DatabaseConnection, DbBackend, DbErr, ExecResult, QueryResult,
+    RuntimeErr, Statement, prelude::async_trait,
 };
 use sqlx::error::ErrorKind;
 use std::ops::{Deref, DerefMut};

--- a/common/src/db/multi_model.rs
+++ b/common/src/db/multi_model.rs
@@ -27,10 +27,10 @@ impl<T: QuerySelect> ColumnsPrefixed for T {
                         self = self.column_as(col, prefixed);
                     }
                     ColumnRef::Asterisk => {
-                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()));
                     }
                     ColumnRef::TableAsterisk(_) => {
-                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()));
                     }
                 }
             } else {
@@ -79,10 +79,10 @@ impl<E: EntityTrait> SelectIntoMultiModel for Select<E> {
                             .column_as(Expr::col((table_alias.into_identity(), name)), prefixed);
                     }
                     ColumnRef::Asterisk => {
-                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()));
                     }
                     ColumnRef::TableAsterisk(_) => {
-                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()))
+                        return Err(DbErr::Custom("Unable to prefix asterisk".to_string()));
                     }
                 }
             } else {

--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -227,7 +227,7 @@ pub(crate) mod tests {
     pub(crate) mod advisory {
         use std::collections::HashMap;
 
-        use sea_orm::{entity::prelude::*, FromJsonQueryResult};
+        use sea_orm::{FromJsonQueryResult, entity::prelude::*};
         use serde::{Deserialize, Serialize};
         use time::OffsetDateTime;
 

--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 
 use sea_orm::entity::ColumnDef;
-use sea_orm::{sea_query, ColumnTrait, ColumnType, EntityTrait, IntoIdentity, Iterable};
+use sea_orm::{ColumnTrait, ColumnType, EntityTrait, IntoIdentity, Iterable, sea_query};
 use sea_query::extension::postgres::PgExpr;
 use sea_query::{Alias, ColumnRef, Expr, IntoColumnRef, IntoIden};
 

--- a/common/src/db/query/filter.rs
+++ b/common/src/db/query/filter.rs
@@ -1,7 +1,7 @@
-use super::{q, Columns, Error};
-use human_date_parser::{from_human_time, ParseResult};
-use sea_orm::sea_query::{extension::postgres::PgExpr, ConditionExpression, IntoCondition};
-use sea_orm::{sea_query, ColumnType, Condition, IntoSimpleExpr, Value as SeaValue};
+use super::{Columns, Error, q};
+use human_date_parser::{ParseResult, from_human_time};
+use sea_orm::sea_query::{ConditionExpression, IntoCondition, extension::postgres::PgExpr};
+use sea_orm::{ColumnType, Condition, IntoSimpleExpr, Value as SeaValue, sea_query};
 use sea_query::{BinOper, Expr, Keyword, SimpleExpr};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;

--- a/common/src/db/query/sort.rs
+++ b/common/src/db/query/sort.rs
@@ -65,22 +65,26 @@ pub(crate) mod tests {
         assert!(Sort::parse("location:asc:foo", &columns).is_err());
 
         // Good sorts with other columns
-        assert!(Sort::parse(
-            "foo",
-            &advisory::Entity
-                .columns()
-                .add_column("foo", ColumnType::String(StringLen::None).def())
-        )
-        .is_ok());
+        assert!(
+            Sort::parse(
+                "foo",
+                &advisory::Entity
+                    .columns()
+                    .add_column("foo", ColumnType::String(StringLen::None).def())
+            )
+            .is_ok()
+        );
 
         // Bad sorts with other columns
-        assert!(Sort::parse(
-            "bar",
-            &advisory::Entity
-                .columns()
-                .add_column("foo", ColumnType::String(StringLen::None).def())
-        )
-        .is_err());
+        assert!(
+            Sort::parse(
+                "bar",
+                &advisory::Entity
+                    .columns()
+                    .add_column("foo", ColumnType::String(StringLen::None).def())
+            )
+            .is_err()
+        );
 
         Ok(())
     }

--- a/common/src/db/query/value.rs
+++ b/common/src/db/query/value.rs
@@ -1,5 +1,5 @@
 use chrono::{Local, NaiveDateTime};
-use human_date_parser::{from_human_time, ParseResult};
+use human_date_parser::{ParseResult, from_human_time};
 use std::cmp::Ordering;
 use time::OffsetDateTime;
 

--- a/common/src/hashing.rs
+++ b/common/src/hashing.rs
@@ -107,7 +107,7 @@ impl<R: Read> Read for HashingRead<R> {
 mod test {
     use super::HashingRead;
     use rand::RngCore;
-    use ring::digest::{digest, SHA256, SHA384, SHA512};
+    use ring::digest::{SHA256, SHA384, SHA512, digest};
     use std::io::Read;
 
     fn rand_bytes() -> [u8; 1024] {

--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -4,8 +4,8 @@ use ring::digest::Digest;
 use sea_orm::{EntityTrait, QueryFilter, Select, UpdateMany};
 use sea_query::Condition;
 use serde::{
-    de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, Visitor},
 };
 use serde_json::Value;
 use std::{
@@ -14,8 +14,8 @@ use std::{
     str::FromStr,
 };
 use utoipa::{
-    openapi::{Object, RefOr, Schema, Type},
     PartialSchema, ToSchema,
+    openapi::{Object, RefOr, Schema, Type},
 };
 use uuid::Uuid;
 

--- a/common/src/model/bytesize.rs
+++ b/common/src/model/bytesize.rs
@@ -7,8 +7,8 @@ use std::{
     str::FromStr,
 };
 use utoipa::{
-    openapi::{RefOr, Schema},
     PartialSchema, ToSchema,
+    openapi::{RefOr, Schema},
 };
 
 #[derive(
@@ -72,7 +72,7 @@ impl From<usize> for BinaryByteSize {
 
 impl From<BinaryByteSize> for usize {
     fn from(value: BinaryByteSize) -> Self {
-        value.0 .0 as usize
+        value.0.0 as usize
     }
 }
 

--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -1,9 +1,9 @@
 use deepsize::DeepSizeOf;
 use packageurl::PackageUrl;
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use serde::{
-    de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, Visitor},
 };
 use std::borrow::Cow;
 use std::{
@@ -13,8 +13,8 @@ use std::{
     str::FromStr,
 };
 use utoipa::{
-    openapi::{KnownFormat, ObjectBuilder, RefOr, Schema, SchemaFormat, Type},
     PartialSchema, ToSchema,
+    openapi::{KnownFormat, ObjectBuilder, RefOr, Schema, SchemaFormat, Type},
 };
 use uuid::Uuid;
 

--- a/common/src/uuid.rs
+++ b/common/src/uuid.rs
@@ -2,7 +2,7 @@ pub mod serde {
 
     pub mod urn {
 
-        use serde::{de::Error, Deserialize, Deserializer, Serializer};
+        use serde::{Deserialize, Deserializer, Serializer, de::Error};
         use uuid::Uuid;
 
         pub fn serialize<S>(value: &Option<Uuid>, serializer: S) -> Result<S::Ok, S::Error>

--- a/cvss/src/cvss3/severity.rs
+++ b/cvss/src/cvss3/severity.rs
@@ -1,5 +1,5 @@
 use crate::cvss3::Cvss3Error;
-use serde::{de, ser, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, ser};
 use std::fmt;
 use std::str::FromStr;
 use utoipa::ToSchema;

--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -1,6 +1,6 @@
 use crate::{advisory_vulnerability, cvss3, labels::Labels, organization, vulnerability};
 use async_graphql::*;
-use sea_orm::{entity::prelude::*, sea_query::IntoCondition, Condition};
+use sea_orm::{Condition, entity::prelude::*, sea_query::IntoCondition};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use trustify_common::{

--- a/entity/src/advisory_vulnerability.rs
+++ b/entity/src/advisory_vulnerability.rs
@@ -1,5 +1,5 @@
 use crate::{advisory, cvss3, purl_status, vulnerability};
-use sea_orm::{entity::prelude::*, LinkDef};
+use sea_orm::{LinkDef, entity::prelude::*};
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]

--- a/entity/src/base_purl.rs
+++ b/entity/src/base_purl.rs
@@ -1,4 +1,4 @@
-use sea_orm::{entity::prelude::*, FromQueryResult};
+use sea_orm::{FromQueryResult, entity::prelude::*};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "base_purl")]

--- a/entity/src/cpe.rs
+++ b/entity/src/cpe.rs
@@ -1,5 +1,5 @@
 use cpe::{error::CpeError, uri::Uri};
-use sea_orm::{entity::prelude::*, Set};
+use sea_orm::{Set, entity::prelude::*};
 use std::fmt::{Debug, Display, Formatter};
 use trustify_common::cpe::{Component, Cpe, CpeType, Language};
 use trustify_common::impl_try_into_cpe;

--- a/entity/src/labels.rs
+++ b/entity/src/labels.rs
@@ -5,8 +5,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 use utoipa::{
-    openapi::{schema::AdditionalProperties, Object, ObjectBuilder, RefOr, Schema, Type},
     PartialSchema, ToSchema,
+    openapi::{Object, ObjectBuilder, RefOr, Schema, Type, schema::AdditionalProperties},
 };
 
 #[derive(

--- a/entity/src/purl_status.rs
+++ b/entity/src/purl_status.rs
@@ -1,5 +1,5 @@
-use sea_orm::entity::prelude::*;
 use sea_orm::LinkDef;
+use sea_orm::entity::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "purl_status")]

--- a/entity/src/qualified_purl.rs
+++ b/entity/src/qualified_purl.rs
@@ -1,7 +1,7 @@
-use sea_orm::{entity::prelude::*, FromJsonQueryResult, FromQueryResult};
+use sea_orm::{FromJsonQueryResult, FromQueryResult, entity::prelude::*};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use trustify_common::purl::Purl;

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -1,6 +1,6 @@
 use crate::labels::Labels;
 use async_graphql::SimpleObject;
-use sea_orm::{entity::prelude::*, sea_query::IntoCondition, Condition, LinkDef};
+use sea_orm::{Condition, LinkDef, entity::prelude::*, sea_query::IntoCondition};
 use time::OffsetDateTime;
 use trustify_common::id::{Id, IdError, TryFilterForId};
 

--- a/entity/src/versioned_purl.rs
+++ b/entity/src/versioned_purl.rs
@@ -1,4 +1,4 @@
-use sea_orm::{entity::prelude::*, FromQueryResult};
+use sea_orm::{FromQueryResult, entity::prelude::*};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "versioned_purl")]

--- a/migration/src/m0000060_create_advisory.rs
+++ b/migration/src/m0000060_create_advisory.rs
@@ -1,5 +1,5 @@
-use crate::m0000022_create_organization::Organization;
 use crate::UuidV4;
+use crate::m0000022_create_organization::Organization;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]

--- a/migration/src/m0000150_create_affected_package_version_range.rs
+++ b/migration/src/m0000150_create_affected_package_version_range.rs
@@ -1,7 +1,7 @@
+use crate::UuidV4;
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000140_create_package_version_range::PackageVersionRange;
-use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]

--- a/migration/src/m0000160_create_fixed_package_version.rs
+++ b/migration/src/m0000160_create_fixed_package_version.rs
@@ -1,7 +1,7 @@
+use crate::UuidV4;
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000120_create_package_version::PackageVersion;
-use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]

--- a/migration/src/m0000170_create_not_affected_package_version.rs
+++ b/migration/src/m0000170_create_not_affected_package_version.rs
@@ -1,7 +1,7 @@
+use crate::UuidV4;
 use crate::m0000040_create_vulnerability::Vulnerability;
 use crate::m0000060_create_advisory::Advisory;
 use crate::m0000120_create_package_version::PackageVersion;
-use crate::UuidV4;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]

--- a/migration/src/m0000290_create_product.rs
+++ b/migration/src/m0000290_create_product.rs
@@ -1,7 +1,7 @@
 use sea_orm_migration::prelude::*;
 
-use crate::m0000022_create_organization::Organization;
 use crate::UuidV4;
+use crate::m0000022_create_organization::Organization;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/src/m0000300_create_product_version.rs
+++ b/migration/src/m0000300_create_product_version.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::{m0000030_create_sbom::Sbom, m0000290_create_product::Product, Now, UuidV4};
+use crate::{Now, UuidV4, m0000030_create_sbom::Sbom, m0000290_create_product::Product};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/src/m0000301_alter_product_version_index.rs
+++ b/migration/src/m0000301_alter_product_version_index.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::m0000300_create_product_version::{ProductVersion, INDEX_BY_PID_V};
+use crate::m0000300_create_product_version::{INDEX_BY_PID_V, ProductVersion};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/src/m0000470_cascade_sbom_delete.rs
+++ b/migration/src/m0000470_cascade_sbom_delete.rs
@@ -1,8 +1,8 @@
 use sea_orm_migration::prelude::*;
 
+use crate::ForeignKeyAction::Cascade;
 use crate::m0000030_create_sbom::{Sbom, SbomNode};
 use crate::m0000220_create_package_relates_to_package::PackageRelatesToPackage;
-use crate::ForeignKeyAction::Cascade;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/src/m0000490_cascade_advisory_delete.rs
+++ b/migration/src/m0000490_cascade_advisory_delete.rs
@@ -1,7 +1,7 @@
 use sea_orm_migration::prelude::*;
 
-use crate::m0000310_alter_advisory_primary_key::Advisory;
 use crate::ForeignKeyAction::Cascade;
+use crate::m0000310_alter_advisory_primary_key::Advisory;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/src/m0000630_create_product_version_range.rs
+++ b/migration/src/m0000630_create_product_version_range.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use crate::{m0000290_create_product::Product, UuidV4};
+use crate::{UuidV4, m0000290_create_product::Product};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/migration/tests/getpurl.rs
+++ b/migration/tests/getpurl.rs
@@ -1,5 +1,5 @@
-use migration::sea_orm::{EntityTrait, Statement};
 use migration::ConnectionTrait;
+use migration::sea_orm::{EntityTrait, Statement};
 use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;

--- a/modules/analysis/src/endpoints/mod.rs
+++ b/modules/analysis/src/endpoints/mod.rs
@@ -9,16 +9,16 @@ use crate::{
     model::{AnalysisStatus, Node},
     service::render::Renderer,
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use serde_json::json;
 use trustify_auth::{
+    Permission, ReadSbom,
     authenticator::user::UserInformation,
     authorizer::{Authorizer, Require},
     utoipa::AuthResponse,
-    Permission, ReadSbom,
 };
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 use utoipa_actix_web::service_config::ServiceConfig;

--- a/modules/analysis/src/endpoints/query.rs
+++ b/modules/analysis/src/endpoints/query.rs
@@ -1,6 +1,6 @@
 use crate::{
-    service::{ComponentReference, GraphQuery},
     Error,
+    service::{ComponentReference, GraphQuery},
 };
 use std::str::FromStr;
 use trustify_common::{cpe::Cpe, purl::Purl};

--- a/modules/analysis/src/endpoints/test.rs
+++ b/modules/analysis/src/endpoints/test.rs
@@ -2,10 +2,10 @@ use crate::test::caller;
 use actix_http::Request;
 use actix_web::test::TestRequest;
 use jsonpath_rust::JsonPathQuery;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
-use trustify_test_context::{call::CallService, subset::ContainsSubset, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService, subset::ContainsSubset};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -567,11 +567,11 @@ async fn spdx_variant_of(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?;
 
     let parents = [
-            "pkg:oci/ubi9-container@sha256:d4c5d9c980678267b81c3c197a4a0dd206382111c912875a6cdffc6ca319b769?arch=aarch64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-            "pkg:oci/ubi9-container@sha256:204383c3d96c0e6c7154c91d07764f92035738dd67aa8896679f7feb73f66bfd?arch=x86_64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-            "pkg:oci/ubi9-container@sha256:721ca837c80c8b98752010a17ffccbdf17a0d260ddd916b7097f04187f6aa3a8?arch=s390x&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-            "pkg:oci/ubi9-container@sha256:9a6092cdd8e7f4361ea3f508ae6d6d3d9dbb9458a921ab09e4cc006c0a7f0a61?arch=ppc64le&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
-        ];
+        "pkg:oci/ubi9-container@sha256:d4c5d9c980678267b81c3c197a4a0dd206382111c912875a6cdffc6ca319b769?arch=aarch64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:204383c3d96c0e6c7154c91d07764f92035738dd67aa8896679f7feb73f66bfd?arch=x86_64&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:721ca837c80c8b98752010a17ffccbdf17a0d260ddd916b7097f04187f6aa3a8?arch=s390x&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
+        "pkg:oci/ubi9-container@sha256:9a6092cdd8e7f4361ea3f508ae6d6d3d9dbb9458a921ab09e4cc006c0a7f0a61?arch=ppc64le&repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012",
+    ];
     let child = "pkg:oci/ubi9-container@sha256:2f168398c538b287fd705519b83cd5b604dc277ef3d9f479c28a2adb4d830a49?repository_url=registry.redhat.io/ubi9&tag=9.2-755.1697625012";
 
     // Ensure variant relationships

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -1,11 +1,11 @@
 use crate::model::PackageGraph;
 use crate::{
+    Error,
     model::PackageNode,
     service::{AnalysisService, ComponentReference, GraphQuery},
-    Error,
 };
 use anyhow::anyhow;
-use petgraph::{prelude::NodeIndex, Graph};
+use petgraph::{Graph, prelude::NodeIndex};
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityOrSelect, EntityTrait,
     FromQueryResult, QueryFilter, QueryOrder, QuerySelect, QueryTrait, RelationTrait, Statement,
@@ -14,8 +14,8 @@ use sea_query::{JoinType, Order, SelectStatement};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::{collections::hash_map::Entry, collections::HashMap};
-use tracing::{instrument, Level};
+use std::{collections::HashMap, collections::hash_map::Entry};
+use tracing::{Level, instrument};
 use trustify_common::{cpe::Cpe, db::query::Filtering, purl::Purl};
 use trustify_entity::{
     cpe::CpeDto, package_relates_to_package, relationship::Relationship, sbom, sbom_node,

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -10,19 +10,19 @@ pub mod render;
 mod test;
 
 use crate::{
+    Error,
     config::AnalysisConfig,
     model::{AnalysisStatus, BaseSummary, GraphMap, Node, PackageGraph, PackageNode},
-    Error,
 };
 use fixedbitset::FixedBitSet;
 use opentelemetry::global;
 use petgraph::{
+    Direction,
     graph::{Graph, NodeIndex},
     prelude::EdgeRef,
     visit::{IntoNodeIdentifiers, VisitMap, Visitable},
-    Direction,
 };
-use sea_orm::{prelude::ConnectionTrait, EntityOrSelect, EntityTrait, QueryOrder};
+use sea_orm::{EntityOrSelect, EntityTrait, QueryOrder, prelude::ConnectionTrait};
 use sea_query::Order;
 use std::{
     collections::{HashMap, HashSet},
@@ -337,7 +337,7 @@ impl AnalysisService {
 }
 
 fn acyclic(id: &str, graph: &Arc<PackageGraph>) -> bool {
-    use petgraph::visit::{depth_first_search, DfsEvent};
+    use petgraph::visit::{DfsEvent, depth_first_search};
     let g = graph.as_ref();
     let result = depth_first_search(g, g.node_identifiers(), |event| match event {
         DfsEvent::BackEdge(source, target) => Err((source, target)),

--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -15,7 +15,7 @@ use trustify_common::{
 };
 use trustify_entity::sbom_external_node;
 use trustify_entity::sbom_external_node::DiscriminatorType;
-use trustify_test_context::{document, spdx::fix_spdx_rels, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document, spdx::fix_spdx_rels};
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
@@ -300,28 +300,29 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
 
     assert_ancestors(&analysis_graph.items, |ancestors| {
         assert!(
-            matches!(ancestors, [
-                [..],
+            matches!(
+                ancestors,
                 [
-                   Node {
-                       id: "SPDXRef-e24fec28-1001-499c-827f-2e2e5f2671b5",
-                       name: "quarkus-bom",
-                       version: "3.2.12.Final-redhat-00002",
-                       cpes: [
-                           "cpe:/a:redhat:quarkus:3.2:*:el8:*",
-                       ],
-                       purls: [
-                           "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
-                       ],
-                   },
-                   Node {
-                       id: "SPDXRef-DOCUMENT",
-                       name: "quarkus-bom-3.2.12.Final-redhat-00002",
-                       version: "",
-                       ..
-                   },
+                    [..],
+                    [
+                        Node {
+                            id: "SPDXRef-e24fec28-1001-499c-827f-2e2e5f2671b5",
+                            name: "quarkus-bom",
+                            version: "3.2.12.Final-redhat-00002",
+                            cpes: ["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
+                            purls: [
+                                "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
+                            ],
+                        },
+                        Node {
+                            id: "SPDXRef-DOCUMENT",
+                            name: "quarkus-bom-3.2.12.Final-redhat-00002",
+                            version: "",
+                            ..
+                        },
+                    ]
                 ]
-            ]),
+            ),
             "doesn't match: {ancestors:#?}"
         );
     });

--- a/modules/analysis/src/test.rs
+++ b/modules/analysis/src/test.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use trustify_entity::relationship::Relationship;
 use trustify_test_context::{
-    call::{self, CallService},
     TrustifyContext,
+    call::{self, CallService},
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {

--- a/modules/fundamental/benches/bench-format.rs
+++ b/modules/fundamental/benches/bench-format.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 pub(crate) mod trustify_benches {
@@ -8,7 +8,7 @@ pub(crate) mod trustify_benches {
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
-    use criterion::{black_box, Criterion};
+    use criterion::{Criterion, black_box};
     use sea_orm::ConnectionTrait;
     use test_context::AsyncTestContext;
     use tokio::runtime::Runtime;

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 pub(crate) mod trustify_benches {
@@ -13,18 +13,18 @@ pub(crate) mod trustify_benches {
     use bytes::Bytes;
     use cpe::cpe::Cpe;
     use cpe::uri::OwnedUri;
-    use criterion::{black_box, Criterion};
+    use criterion::{Criterion, black_box};
+    use csaf::Csaf;
     use csaf::definitions::{BranchesT, ProductIdentificationHelper};
     use csaf::product_tree::ProductTree;
     use csaf::vulnerability::Vulnerability;
-    use csaf::Csaf;
     use packageurl::PackageUrl;
     use sea_orm::ConnectionTrait;
     use test_context::AsyncTestContext;
     use tokio::runtime::Runtime;
     use trustify_entity::labels::Labels;
     use trustify_module_ingestor::service::Format;
-    use trustify_test_context::{document, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document};
 
     pub fn ingestion(c: &mut Criterion) {
         let (runtime, ctx) = setup_runtime_and_ctx();

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -1,6 +1,6 @@
 use crate::advisory::service::AdvisoryService;
-use actix_web::{patch, put, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, UpdateAdvisory};
+use actix_web::{HttpResponse, Responder, patch, put, web};
+use trustify_auth::{UpdateAdvisory, authorizer::Require};
 use trustify_common::db::Database;
 use trustify_common::id::Id;
 use trustify_entity::labels::Labels;

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -4,15 +4,15 @@ mod label;
 mod test;
 
 use crate::{
+    Error,
     advisory::{
         model::{AdvisoryDetails, AdvisorySummary},
         service::AdvisoryService,
     },
     endpoints::Deprecation,
     purl::service::PurlService,
-    Error,
 };
-use actix_web::{delete, get, http::header, post, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, delete, get, http::header, post, web};
 use config::Config;
 use futures_util::TryStreamExt;
 use sea_orm::TransactionTrait;
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use trustify_auth::authorizer::Require;
 use trustify_auth::{CreateAdvisory, DeleteAdvisory, ReadAdvisory};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     decompress::decompress_async,
     id::Id,
     model::{BinaryData, Paginated, PaginatedResults},

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -6,7 +6,7 @@ use actix_http::StatusCode;
 use actix_web::test::TestRequest;
 use hex::ToHex;
 use jsonpath_rust::JsonPathQuery;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use test_context::test_context;
 use test_log::test;
@@ -18,7 +18,7 @@ use trustify_cvss::cvss3::{
 };
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{graph::advisory::AdvisoryInformation, model::IngestResult};
-use trustify_test_context::{call::CallService, document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
 use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
@@ -100,10 +100,12 @@ async fn all_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let rhsa_1 = rhsa_1.unwrap();
 
-    assert!(rhsa_1
-        .vulnerabilities
-        .iter()
-        .any(|e| e.head.identifier == "CVE-123"));
+    assert!(
+        rhsa_1
+            .vulnerabilities
+            .iter()
+            .any(|e| e.head.identifier == "CVE-123")
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -1,9 +1,9 @@
-use crate::{vulnerability::model::VulnerabilityHead, Error};
+use crate::{Error, vulnerability::model::VulnerabilityHead};
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_cvss::{cvss3::score::Score, cvss3::Cvss3Base};
+use trustify_cvss::{cvss3::Cvss3Base, cvss3::score::Score};
 use trustify_entity::{advisory, advisory_vulnerability, cvss3, vulnerability};
 use utoipa::ToSchema;
 

--- a/modules/fundamental/src/advisory/model/details/mod.rs
+++ b/modules/fundamental/src/advisory/model/details/mod.rs
@@ -2,7 +2,7 @@ pub mod advisory_vulnerability;
 
 use crate::advisory::service::AdvisoryCatcher;
 use crate::source_document::model::SourceDocument;
-use crate::{advisory::model::AdvisoryHead, Error};
+use crate::{Error, advisory::model::AdvisoryHead};
 use advisory_vulnerability::AdvisoryVulnerabilitySummary;
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
 use serde::{Deserialize, Serialize};

--- a/modules/fundamental/src/advisory/model/mod.rs
+++ b/modules/fundamental/src/advisory/model/mod.rs
@@ -5,8 +5,8 @@ pub use details::advisory_vulnerability::*;
 pub use details::*;
 pub use summary::*;
 
-use crate::{organization::model::OrganizationSummary, Error};
-use sea_orm::{prelude::Uuid, ConnectionTrait, LoaderTrait, ModelTrait};
+use crate::{Error, organization::model::OrganizationSummary};
+use sea_orm::{ConnectionTrait, LoaderTrait, ModelTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use trustify_common::memo::Memo;

--- a/modules/fundamental/src/advisory/model/summary.rs
+++ b/modules/fundamental/src/advisory/model/summary.rs
@@ -5,10 +5,10 @@ use trustify_cvss::cvss3::score::Score;
 use trustify_entity::{advisory_vulnerability, vulnerability};
 use utoipa::ToSchema;
 
+use crate::Error;
 use crate::advisory::model::{AdvisoryHead, AdvisoryVulnerabilityHead};
 use crate::advisory::service::AdvisoryCatcher;
 use crate::source_document::model::SourceDocument;
-use crate::Error;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct AdvisorySummary {

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    advisory::model::{AdvisoryDetails, AdvisorySummary},
     Error,
+    advisory::model::{AdvisoryDetails, AdvisorySummary},
 };
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTypeTrait, ConnectionTrait, DatabaseBackend, DbErr,
@@ -10,10 +10,10 @@ use sea_orm::{
 use sea_query::{ColumnRef, ColumnType, Expr, Func, IntoColumnRef, IntoIden, JoinType, SimpleExpr};
 use trustify_common::{
     db::{
+        Database, UpdateDeprecatedAdvisory,
         limiter::LimiterAsModelTrait,
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         query::{Columns, Filtering, Query},
-        Database, UpdateDeprecatedAdvisory,
     },
     id::{Id, TrySelectForId},
     model::{Paginated, PaginatedResults},

--- a/modules/fundamental/src/advisory/service/test.rs
+++ b/modules/fundamental/src/advisory/service/test.rs
@@ -6,15 +6,15 @@ use test_log::test;
 use time::OffsetDateTime;
 use trustify_common::{db::query::q, hashing::Digests, model::Paginated, purl::Purl};
 use trustify_cvss::cvss3::{
-    severity::Severity, AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base,
-    Integrity, PrivilegesRequired, Scope, UserInteraction,
+    AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
+    PrivilegesRequired, Scope, UserInteraction, severity::Severity,
 };
 use trustify_entity::version_scheme::VersionScheme;
-use trustify_module_ingestor::graph::advisory::{
-    version::{VersionInfo, VersionSpec},
-    AdvisoryContext, AdvisoryInformation,
-};
 use trustify_module_ingestor::graph::Outcome;
+use trustify_module_ingestor::graph::advisory::{
+    AdvisoryContext, AdvisoryInformation,
+    version::{VersionInfo, VersionSpec},
+};
 use trustify_test_context::TrustifyContext;
 
 pub async fn ingest_sample_advisory<'a>(

--- a/modules/fundamental/src/ai/endpoints/mod.rs
+++ b/modules/fundamental/src/ai/endpoints/mod.rs
@@ -3,22 +3,22 @@
 mod test;
 
 use crate::{
+    Error,
     ai::{
         model::{AiFlags, AiTool, ChatMessage, ChatState, Conversation, ConversationSummary},
         service::AiService,
     },
-    Error,
 };
 use actix_web::{
-    delete, get,
+    HttpResponse, Responder, delete, get,
     http::header::{self, ETag, EntityTag, IfMatch},
-    post, put, web, HttpResponse, Responder,
+    post, put, web,
 };
 use itertools::Itertools;
 use time::OffsetDateTime;
-use trustify_auth::{authenticator::user::UserDetails, authorizer::Require, Ai};
+use trustify_auth::{Ai, authenticator::user::UserDetails, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 use uuid::Uuid;

--- a/modules/fundamental/src/ai/endpoints/test.rs
+++ b/modules/fundamental/src/ai/endpoints/test.rs
@@ -1,17 +1,17 @@
 use crate::ai::model::{ChatMessage, ChatState, Conversation, ConversationSummary};
-use crate::ai::service::test::{ingest_fixtures, sanitize_uuid_field, sanitize_uuid_urn};
 use crate::ai::service::AiService;
+use crate::ai::service::test::{ingest_fixtures, sanitize_uuid_field, sanitize_uuid_urn};
 use crate::test::caller;
 use actix_http::StatusCode;
 use actix_web::dev::ServiceResponse;
-use actix_web::test::{read_body_json, TestRequest};
+use actix_web::test::{TestRequest, read_body_json};
 use serde_json::json;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::model::PaginatedResults;
+use trustify_test_context::TrustifyContext;
 use trustify_test_context::auth::TestAuthentication;
 use trustify_test_context::call::CallService;
-use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -38,12 +38,14 @@ async fn configure(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let result: ChatState = actix_web::test::read_body_json(response).await;
     log::info!("result: {:?}", result);
-    assert!(result
-        .messages
-        .last()
-        .unwrap()
-        .content
-        .contains("quarkus-bom"));
+    assert!(
+        result
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .contains("quarkus-bom")
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/ai/service/mod.rs
+++ b/modules/fundamental/src/ai/service/mod.rs
@@ -2,13 +2,13 @@ pub mod tools;
 
 use crate::ai::model::{ChatMessage, ChatState, InternalState, LLMInfo, MessageType};
 
-use crate::ai::service::tools::remote::RemoteToolsProvider;
 use crate::Error;
-use base64::engine::general_purpose::STANDARD;
+use crate::ai::service::tools::remote::RemoteToolsProvider;
 use base64::engine::Engine as _;
+use base64::engine::general_purpose::STANDARD;
 
-use langchain_rust::chain::options::ChainCallOptions;
 use langchain_rust::chain::Chain;
+use langchain_rust::chain::options::ChainCallOptions;
 use langchain_rust::language_models::options::CallOptions;
 use langchain_rust::schemas::{BaseMemory, Message};
 use langchain_rust::tools::OpenAIConfig;
@@ -19,8 +19,8 @@ use langchain_rust::{
     prompt_args,
     tools::Tool,
 };
-use sea_orm::{prelude::Uuid, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, prelude::Uuid};
 
 use std::env;
 use std::sync::Arc;
@@ -29,8 +29,8 @@ use tokio::sync::OnceCell;
 
 use trustify_common::db::limiter::LimiterTrait;
 
-use trustify_common::db::query::{Filtering, Query};
 use trustify_common::db::Database;
+use trustify_common::db::query::{Filtering, Query};
 use trustify_common::model::{Paginated, PaginatedResults};
 use trustify_entity::conversation;
 

--- a/modules/fundamental/src/ai/service/test.rs
+++ b/modules/fundamental/src/ai/service/test.rs
@@ -89,8 +89,10 @@ async fn test_completions_sbom_info(ctx: &TrustifyContext) -> Result<(), anyhow:
         termimad::inline(last_message_content.as_str())
     );
     assert!(last_message_content.contains("quarkus-bom"));
-    assert!(last_message_content
-        .contains("5a370574a991aa42f7ecc5b7d88754b258f81c230a73bea247c0a6fcc6f608ab"));
+    assert!(
+        last_message_content
+            .contains("5a370574a991aa42f7ecc5b7d88754b258f81c230a73bea247c0a6fcc6f608ab")
+    );
 
     Ok(())
 }
@@ -119,8 +121,10 @@ async fn test_completions_package_info(ctx: &TrustifyContext) -> Result<(), anyh
         termimad::inline(last_message_content.as_str())
     );
     assert!(last_message_content.contains("httpclient@4.5.13.redhat-00002"));
-    assert!(last_message_content
-        .contains("quarkus-apache-httpclient-deployment@2.13.8.Final-redhat-00004"));
+    assert!(
+        last_message_content
+            .contains("quarkus-apache-httpclient-deployment@2.13.8.Final-redhat-00004")
+    );
     assert!(last_message_content.contains("quarkus-apache-httpclient@2.13.8.Final-redhat-00004"));
 
     Ok(())

--- a/modules/fundamental/src/ai/service/tools/cve_info.rs
+++ b/modules/fundamental/src/ai/service/tools/cve_info.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use std::{error::Error, fmt::Write};
 use time::OffsetDateTime;
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     purl::Purl,
 };
 use trustify_module_ingestor::common::Deprecation;
@@ -164,7 +164,11 @@ The input should be the partial or full name of the Vulnerability to search for.
 
         let mut result = "".to_string();
         if item.head.identifier != input {
-            writeln!(result, "There is one match, but it had a different identifier.  Inform the user that that you are providing information on: {}\n", item.head.identifier)?;
+            writeln!(
+                result,
+                "There is one match, but it had a different identifier.  Inform the user that that you are providing information on: {}\n",
+                item.head.identifier
+            )?;
         }
         writeln!(result, "{}", json)?;
         Ok(result)

--- a/modules/fundamental/src/ai/service/tools/mod.rs
+++ b/modules/fundamental/src/ai/service/tools/mod.rs
@@ -4,7 +4,7 @@ use crate::ai::service::tools::{
 };
 use langchain_rust::tools::Tool;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::{error::Error, sync::Arc};
 use trustify_common::{db::Database, model::PaginatedResults};
 

--- a/modules/fundamental/src/ai/service/tools/package_info.rs
+++ b/modules/fundamental/src/ai/service/tools/package_info.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::error::Error;
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     purl::Purl,
 };
 use trustify_module_ingestor::common::Deprecation;

--- a/modules/fundamental/src/ai/service/tools/product_info.rs
+++ b/modules/fundamental/src/ai/service/tools/product_info.rs
@@ -7,7 +7,7 @@ use langchain_rust::tools::Tool;
 use serde::Serialize;
 use serde_json::Value;
 use std::error::Error;
-use trustify_common::db::{query::Query, Database};
+use trustify_common::db::{Database, query::Query};
 use uuid::Uuid;
 
 pub struct ProductInfo {

--- a/modules/fundamental/src/ai/service/tools/sbom_info.rs
+++ b/modules/fundamental/src/ai/service/tools/sbom_info.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::{error::Error, str::FromStr};
 use time::OffsetDateTime;
-use trustify_common::{db::query::Query, db::Database, id::Id};
+use trustify_common::{db::Database, db::query::Query, id::Id};
 use uuid::Uuid;
 
 pub struct SbomInfo {

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -1,4 +1,4 @@
-use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use langchain_rust::{agent::AgentError, chain::ChainError};
 use sea_orm::DbErr;
 use trustify_common::{decompress, error::ErrorInformation, id::IdError, purl::PurlErr};

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -12,7 +12,7 @@ pub mod source_document;
 pub mod vulnerability;
 pub mod weakness;
 
-pub use endpoints::{configure, Config};
+pub use endpoints::{Config, configure};
 pub use error::Error;
 
 #[cfg(test)]

--- a/modules/fundamental/src/license/endpoints/mod.rs
+++ b/modules/fundamental/src/license/endpoints/mod.rs
@@ -1,15 +1,15 @@
 use crate::{
+    Error,
     license::{
         endpoints::spdx::{get_spdx_license, list_spdx_licenses},
         model::LicenseSummary,
         service::LicenseService,
     },
-    Error,
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use std::str::FromStr;
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     id::IdError,
     model::{Paginated, PaginatedResults},
 };

--- a/modules/fundamental/src/license/endpoints/spdx.rs
+++ b/modules/fundamental/src/license/endpoints/spdx.rs
@@ -1,7 +1,7 @@
 use crate::license::{
     model::SpdxLicenseDetails, model::SpdxLicenseSummary, service::LicenseService,
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use trustify_common::{
     db::query::Query,
     model::{Paginated, PaginatedResults},

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -6,7 +6,7 @@ use actix_web::test::TestRequest;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::model::PaginatedResults;
-use trustify_test_context::{call::CallService, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]

--- a/modules/fundamental/src/license/model/mod.rs
+++ b/modules/fundamental/src/license/model/mod.rs
@@ -1,4 +1,4 @@
-use crate::{purl::model::VersionedPurlHead, sbom::model::SbomHead, Error};
+use crate::{Error, purl::model::VersionedPurlHead, sbom::model::SbomHead};
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait};
 use serde::{Deserialize, Serialize};
 use trustify_entity::{license, purl_license_assertion};

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -1,10 +1,10 @@
 use crate::{
+    Error,
     license::model::{
         LicenseDetailsPurlSummary, LicenseSummary, SpdxLicenseDetails, SpdxLicenseSummary,
     },
     purl::model::VersionedPurlHead,
     sbom::model::SbomHead,
-    Error,
 };
 use sea_orm::{
     ColumnTrait, DbErr, EntityTrait, FromQueryResult, ModelTrait, PaginatorTrait, QueryFilter,
@@ -13,10 +13,10 @@ use sea_orm::{
 use sea_query::JoinType;
 use trustify_common::{
     db::{
+        Database,
         limiter::{LimiterAsModelTrait, LimiterTrait},
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         query::{Filtering, Query},
-        Database,
     },
     model::{Paginated, PaginatedResults},
 };

--- a/modules/fundamental/src/license/service/test.rs
+++ b/modules/fundamental/src/license/service/test.rs
@@ -1,7 +1,7 @@
 use crate::license::service::LicenseService;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::query::{q, Query};
+use trustify_common::db::query::{Query, q};
 use trustify_common::model::Paginated;
 use trustify_test_context::TrustifyContext;
 
@@ -40,10 +40,12 @@ async fn list_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     assert_eq!(3, results.total);
     assert_eq!(1, results.items.len());
 
-    assert!(results
-        .items
-        .iter()
-        .any(|e| e.license == "Apache License 1.0"));
+    assert!(
+        results
+            .items
+            .iter()
+            .any(|e| e.license == "Apache License 1.0")
+    );
 
     Ok(())
 }
@@ -150,10 +152,11 @@ async fn verify_clearly_defined(ctx: &TrustifyContext) -> Result<(), anyhow::Err
     let mut seen_versions = Vec::new();
 
     for each in license_details.items {
-        assert!(each
-            .sbom
-            .authors
-            .contains(&"ClearlyDefined: Community-Curated".to_string()));
+        assert!(
+            each.sbom
+                .authors
+                .contains(&"ClearlyDefined: Community-Curated".to_string())
+        );
         assert!(each.purl.purl.to_string().starts_with("pkg:crate/chrono@"));
         seen_versions.push(each.purl.version);
     }

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -5,10 +5,10 @@ use crate::organization::{
     model::{OrganizationDetails, OrganizationSummary},
     service::OrganizationService,
 };
-use actix_web::{get, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, ReadMetadata};
+use actix_web::{HttpResponse, Responder, get, web};
+use trustify_auth::{ReadMetadata, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::Paginated,
 };
 use uuid::Uuid;

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -2,14 +2,14 @@ use crate::test::caller;
 use actix_web::cookie::time::OffsetDateTime;
 use actix_web::test::TestRequest;
 use jsonpath_rust::JsonPathQuery;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::query::Query;
 use trustify_common::hashing::Digests;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;
-use trustify_test_context::{call::CallService, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]

--- a/modules/fundamental/src/organization/model/details/mod.rs
+++ b/modules/fundamental/src/organization/model/details/mod.rs
@@ -5,8 +5,8 @@ use utoipa::ToSchema;
 use crate::advisory::model::AdvisoryHead;
 use trustify_entity::{advisory, organization};
 
-use crate::organization::model::OrganizationHead;
 use crate::Error;
+use crate::organization::model::OrganizationHead;
 
 #[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct OrganizationDetails {

--- a/modules/fundamental/src/organization/model/summary.rs
+++ b/modules/fundamental/src/organization/model/summary.rs
@@ -1,5 +1,5 @@
-use crate::organization::model::OrganizationHead;
 use crate::Error;
+use crate::organization::model::OrganizationHead;
 use serde::{Deserialize, Serialize};
 use trustify_entity::organization;
 use utoipa::ToSchema;

--- a/modules/fundamental/src/organization/service/mod.rs
+++ b/modules/fundamental/src/organization/service/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    organization::model::{OrganizationDetails, OrganizationSummary},
     Error,
+    organization::model::{OrganizationDetails, OrganizationSummary},
 };
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use trustify_common::{

--- a/modules/fundamental/src/product/endpoints/mod.rs
+++ b/modules/fundamental/src/product/endpoints/mod.rs
@@ -2,17 +2,17 @@
 mod test;
 
 use crate::{
+    Error,
     product::{
         model::{details::ProductDetails, summary::ProductSummary},
         service::ProductService,
     },
-    Error,
 };
-use actix_web::{delete, get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, delete, get, web};
 use sea_orm::TransactionTrait;
-use trustify_auth::{authorizer::Require, DeleteMetadata, ReadMetadata};
+use trustify_auth::{DeleteMetadata, ReadMetadata, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 use uuid::Uuid;

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -2,13 +2,13 @@ use crate::test::caller;
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
 use jsonpath_rust::JsonPathQuery;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
 use trustify_common::db::query::Query;
 use trustify_common::model::Paginated;
 use trustify_module_ingestor::graph::product::ProductInformation;
-use trustify_test_context::{call::CallService, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]

--- a/modules/fundamental/src/product/model/details.rs
+++ b/modules/fundamental/src/product/model/details.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use crate::organization::model::OrganizationSummary;
 use crate::product::model::{ProductHead, ProductVersionHead};
-use crate::Error;
 use itertools::izip;
 use sea_orm::ModelTrait;
 use sea_orm::{ConnectionTrait, LoaderTrait};

--- a/modules/fundamental/src/product/model/summary.rs
+++ b/modules/fundamental/src/product/model/summary.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use crate::organization::model::OrganizationSummary;
 use crate::product::model::{ProductHead, ProductVersionHead};
-use crate::Error;
 use itertools::izip;
 use sea_orm::{ConnectionTrait, LoaderTrait};
 use serde::{Deserialize, Serialize};

--- a/modules/fundamental/src/product/service/mod.rs
+++ b/modules/fundamental/src/product/service/mod.rs
@@ -1,5 +1,5 @@
 use super::model::summary::ProductSummary;
-use crate::{product::model::details::ProductDetails, Error};
+use crate::{Error, product::model::details::ProductDetails};
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use trustify_common::{
     db::{

--- a/modules/fundamental/src/purl/endpoints/base.rs
+++ b/modules/fundamental/src/purl/endpoints/base.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Error,
     purl::{
         model::{details::base_purl::BasePurlDetails, summary::base_purl::BasePurlSummary},
         service::PurlService,
     },
-    Error,
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use sea_orm::prelude::Uuid;
 use std::str::FromStr;
-use trustify_auth::{authorizer::Require, ReadSbom};
+use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     id::IdError,
     model::{Paginated, PaginatedResults},
     purl::Purl,

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -1,17 +1,17 @@
 use crate::{
+    Error,
     endpoints::Deprecation,
     purl::{
         model::{details::purl::PurlDetails, summary::purl::PurlSummary},
         service::PurlService,
     },
-    Error,
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use sea_orm::prelude::Uuid;
 use std::str::FromStr;
-use trustify_auth::{authorizer::Require, ReadSbom};
+use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{
-    db::query::Query, db::Database, id::IdError, model::Paginated, model::PaginatedResults,
+    db::Database, db::query::Query, id::IdError, model::Paginated, model::PaginatedResults,
     purl::Purl,
 };
 

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -14,7 +14,7 @@ use trustify_common::db::Database;
 use trustify_common::model::PaginatedResults;
 use trustify_common::purl::Purl;
 use trustify_module_ingestor::graph::Graph;
-use trustify_test_context::{call::CallService, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService};
 use urlencoding::encode;
 use uuid::Uuid;
 
@@ -170,14 +170,18 @@ async fn type_package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     let request = TestRequest::get().uri(uri).to_request();
     let response: VersionedPurlDetails = app.call_and_read_body_json(request).await;
     assert_eq!(2, response.purls.len());
-    assert!(response
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11"));
-    assert!(response
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17"));
+    assert!(
+        response
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11")
+    );
+    assert!(
+        response
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17")
+    );
 
     let uri = "/api/v2/purl/type/rpm/sendmail@4.4.4";
     let request = TestRequest::get().uri(uri).to_request();

--- a/modules/fundamental/src/purl/endpoints/type.rs
+++ b/modules/fundamental/src/purl/endpoints/type.rs
@@ -5,10 +5,10 @@ use crate::purl::{
     },
     service::PurlService,
 };
-use actix_web::{get, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, ReadSbom};
+use actix_web::{HttpResponse, Responder, get, web};
+use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 

--- a/modules/fundamental/src/purl/endpoints/version.rs
+++ b/modules/fundamental/src/purl/endpoints/version.rs
@@ -1,11 +1,11 @@
 use crate::{
-    purl::{model::details::versioned_purl::VersionedPurlDetails, service::PurlService},
     Error,
+    purl::{model::details::versioned_purl::VersionedPurlDetails, service::PurlService},
 };
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get, web};
 use sea_orm::prelude::Uuid;
 use std::str::FromStr;
-use trustify_auth::{authorizer::Require, ReadSbom};
+use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{db::Database, id::IdError, purl::Purl};
 
 #[utoipa::path(

--- a/modules/fundamental/src/purl/model/details/base_purl.rs
+++ b/modules/fundamental/src/purl/model/details/base_purl.rs
@@ -1,6 +1,6 @@
-use crate::purl::model::summary::versioned_purl::VersionedPurlSummary;
-use crate::purl::model::BasePurlHead;
 use crate::Error;
+use crate::purl::model::BasePurlHead;
+use crate::purl::model::summary::versioned_purl::VersionedPurlSummary;
 use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use trustify_entity::{base_purl, versioned_purl};

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -1,9 +1,9 @@
 use crate::{
+    Error,
     advisory::model::AdvisoryHead,
     purl::model::{BasePurlHead, PurlHead, VersionedPurlHead},
     sbom::model::SbomHead,
     vulnerability::model::VulnerabilityHead,
-    Error,
 };
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, LoaderTrait, ModelTrait,
@@ -11,15 +11,15 @@ use sea_orm::{
 };
 use sea_query::{Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{HashMap, hash_map::Entry};
 use strum::IntoEnumIterator;
 use trustify_common::{
-    db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
     db::VersionMatches,
+    db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
     memo::Memo,
     purl::Purl,
 };
-use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
+use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
     advisory, base_purl, cpe, cvss3, license, organization, product, product_status,
     product_version, product_version_range, purl_license_assertion, purl_status, qualified_purl,

--- a/modules/fundamental/src/purl/model/details/versioned_purl.rs
+++ b/modules/fundamental/src/purl/model/details/versioned_purl.rs
@@ -1,8 +1,8 @@
 use crate::{
+    Error,
     advisory::model::AdvisoryHead,
     purl::model::{BasePurlHead, PurlHead, VersionedPurlHead},
     vulnerability::model::VulnerabilityHead,
-    Error,
 };
 use sea_orm::{
     ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, ModelTrait, QueryFilter, QuerySelect,

--- a/modules/fundamental/src/purl/model/mod.rs
+++ b/modules/fundamental/src/purl/model/mod.rs
@@ -1,6 +1,6 @@
 use crate::Error;
-use sea_orm::prelude::Uuid;
 use sea_orm::ConnectionTrait;
+use sea_orm::prelude::Uuid;
 use serde::{Deserialize, Serialize};
 use trustify_common::purl::Purl;
 use trustify_entity::{base_purl, qualified_purl, versioned_purl};

--- a/modules/fundamental/src/purl/model/summary/base_purl.rs
+++ b/modules/fundamental/src/purl/model/summary/base_purl.rs
@@ -1,5 +1,5 @@
-use crate::purl::model::BasePurlHead;
 use crate::Error;
+use crate::purl::model::BasePurlHead;
 use serde::{Deserialize, Serialize};
 use trustify_entity::base_purl;
 use utoipa::ToSchema;

--- a/modules/fundamental/src/purl/model/summary/purl.rs
+++ b/modules/fundamental/src/purl/model/summary/purl.rs
@@ -1,5 +1,5 @@
-use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
 use crate::Error;
+use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
 use sea_orm::{ConnectionTrait, LoaderTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/modules/fundamental/src/purl/model/summary/type.rs
+++ b/modules/fundamental/src/purl/model/summary/type.rs
@@ -1,5 +1,5 @@
-use crate::purl::model::TypeHead;
 use crate::Error;
+use crate::purl::model::TypeHead;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DeriveColumn, EntityTrait, EnumIter, QueryFilter, QuerySelect,
 };

--- a/modules/fundamental/src/purl/model/summary/versioned_purl.rs
+++ b/modules/fundamental/src/purl/model/summary/versioned_purl.rs
@@ -1,5 +1,5 @@
-use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
 use crate::Error;
+use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
 use sea_orm::{ConnectionTrait, LoaderTrait};
 use serde::{Deserialize, Serialize};
 use trustify_entity::{base_purl, qualified_purl, versioned_purl};

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -1,15 +1,15 @@
 use crate::{
+    Error,
     purl::model::{
         details::{
             base_purl::BasePurlDetails, purl::PurlDetails, versioned_purl::VersionedPurlDetails,
         },
         summary::{base_purl::BasePurlSummary, purl::PurlSummary, r#type::TypeSummary},
     },
-    Error,
 };
 use sea_orm::{
-    prelude::Uuid, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, QueryFilter,
-    QueryOrder, QuerySelect,
+    ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, QueryFilter, QueryOrder,
+    QuerySelect, prelude::Uuid,
 };
 use sea_query::Order;
 use tracing::instrument;

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{
-    db::query::{q, Query},
+    db::query::{Query, q},
     id::Id,
     model::Paginated,
     purl::Purl,
@@ -121,15 +121,19 @@ async fn packages_for_type(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(packages.total, 2);
 
-    assert!(packages
-        .items
-        .iter()
-        .any(|e| e.head.purl.to_string() == "pkg:maven/org.apache/log4j"));
+    assert!(
+        packages
+            .items
+            .iter()
+            .any(|e| e.head.purl.to_string() == "pkg:maven/org.apache/log4j")
+    );
 
-    assert!(packages
-        .items
-        .iter()
-        .any(|e| e.head.purl.to_string() == "pkg:maven/org.myspace/tom"));
+    assert!(
+        packages
+            .items
+            .iter()
+            .any(|e| e.head.purl.to_string() == "pkg:maven/org.myspace/tom")
+    );
 
     Ok(())
 }
@@ -173,10 +177,12 @@ async fn packages_for_type_with_filtering(ctx: &TrustifyContext) -> Result<(), a
 
     assert_eq!(packages.total, 1);
 
-    assert!(packages
-        .items
-        .iter()
-        .any(|e| e.head.purl.to_string() == "pkg:maven/org.myspace/tom"));
+    assert!(
+        packages
+            .items
+            .iter()
+            .any(|e| e.head.purl.to_string() == "pkg:maven/org.myspace/tom")
+    );
 
     Ok(())
 }
@@ -335,15 +341,19 @@ async fn package_version(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(2, log4j_123.purls.len());
 
-    assert!(log4j_123
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11"));
+    assert!(
+        log4j_123
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11")
+    );
 
-    assert!(log4j_123
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17"));
+    assert!(
+        log4j_123
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17")
+    );
 
     Ok(())
 }
@@ -415,15 +425,19 @@ async fn package_version_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Er
 
     assert_eq!(2, log4j_123.purls.len());
 
-    assert!(log4j_123
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11"));
+    assert!(
+        log4j_123
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=11")
+    );
 
-    assert!(log4j_123
-        .purls
-        .iter()
-        .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17"));
+    assert!(
+        log4j_123
+            .purls
+            .iter()
+            .any(|e| e.purl.to_string() == "pkg:maven/org.apache/log4j@1.2.3?jdk=17")
+    );
 
     Ok(())
 }

--- a/modules/fundamental/src/sbom/endpoints/label.rs
+++ b/modules/fundamental/src/sbom/endpoints/label.rs
@@ -1,6 +1,6 @@
 use crate::sbom::service::SbomService;
-use actix_web::{patch, put, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, UpdateSbom};
+use actix_web::{HttpResponse, Responder, patch, put, web};
+use trustify_auth::{UpdateSbom, authorizer::Require};
 use trustify_common::db::Database;
 use trustify_common::id::Id;
 use trustify_entity::labels::Labels;

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -7,29 +7,28 @@ mod test;
 pub use query::*;
 
 use crate::{
+    Error::{self, Internal},
     purl::service::PurlService,
     sbom::{
         model::{
-            details::SbomAdvisory, SbomExternalPackageReference, SbomNodeReference, SbomPackage,
-            SbomPackageRelation, SbomSummary, Which,
+            SbomExternalPackageReference, SbomNodeReference, SbomPackage, SbomPackageRelation,
+            SbomSummary, Which, details::SbomAdvisory,
         },
         service::SbomService,
     },
-    Error::{self, Internal},
 };
-use actix_web::{delete, get, http::header, post, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, delete, get, http::header, post, web};
 use config::Config;
 use futures_util::TryStreamExt;
-use sea_orm::{prelude::Uuid, TransactionTrait};
+use sea_orm::{TransactionTrait, prelude::Uuid};
 use std::str::FromStr;
 use trustify_auth::{
-    all,
+    CreateSbom, DeleteSbom, Permission, ReadAdvisory, ReadSbom, all,
     authenticator::user::UserInformation,
     authorizer::{Authorizer, Require},
-    CreateSbom, DeleteSbom, Permission, ReadAdvisory, ReadSbom,
 };
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     decompress::decompress_async,
     id::Id,
     model::{BinaryData, Paginated, PaginatedResults},

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{id::Id, model::PaginatedResults};
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::model::IngestResult;
-use trustify_test_context::{call::CallService, document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
 use uuid::Uuid;
 
 #[test_context(TrustifyContext)]

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -1,13 +1,13 @@
 use super::SbomSummary;
 use crate::{
+    Error,
     advisory::model::AdvisoryHead,
     purl::model::{details::purl::StatusContext, summary::purl::PurlSummary},
     sbom::{
         model::SbomPackage,
-        service::{sbom::QueryCatcher, SbomService},
+        service::{SbomService, sbom::QueryCatcher},
     },
     vulnerability::model::VulnerabilityHead,
-    Error,
 };
 use cpe::{cpe::Cpe, uri::OwnedUri};
 use sea_orm::{
@@ -20,12 +20,12 @@ use std::collections::HashMap;
 use trustify_common::{
     cpe::CpeCompare,
     db::{
-        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         VersionMatches,
+        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
     },
     memo::Memo,
 };
-use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
+use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
     advisory, base_purl, cvss3, product_status, product_version, purl_status, qualified_purl, sbom,
     sbom_node, sbom_package, sbom_package_purl_ref, status, version_range, versioned_purl,

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -2,10 +2,10 @@ pub mod details;
 
 use super::service::SbomService;
 use crate::{
-    purl::model::summary::purl::PurlSummary, source_document::model::SourceDocument, Error,
+    Error, purl::model::summary::purl::PurlSummary, source_document::model::SourceDocument,
 };
 use async_graphql::SimpleObject;
-use sea_orm::{prelude::Uuid, ConnectionTrait, ModelTrait, PaginatorTrait};
+use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use trustify_common::{cpe::Cpe, model::Paginated, purl::Purl};

--- a/modules/fundamental/src/sbom/service/label.rs
+++ b/modules/fundamental/src/sbom/service/label.rs
@@ -1,4 +1,4 @@
-use crate::{sbom::service::SbomService, Error};
+use crate::{Error, sbom::service::SbomService};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ConnectionTrait, DatabaseBackend, EntityTrait,
     IntoActiveModel, QueryTrait, TransactionTrait,

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -1,19 +1,18 @@
 use super::SbomService;
 use crate::{
+    Error,
     purl::model::summary::purl::PurlSummary,
     sbom::model::{
-        details::SbomDetails, SbomExternalPackageReference, SbomNodeReference, SbomPackage,
-        SbomPackageRelation, SbomSummary, Which,
+        SbomExternalPackageReference, SbomNodeReference, SbomPackage, SbomPackageRelation,
+        SbomSummary, Which, details::SbomDetails,
     },
-    Error,
 };
-use futures_util::{stream, StreamExt, TryStreamExt};
+use futures_util::{StreamExt, TryStreamExt, stream};
 use sea_orm::{
-    prelude::Uuid, ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult,
-    IntoSimpleExpr, QueryFilter, QueryOrder, QueryResult, QuerySelect, RelationTrait, Select,
-    SelectColumns,
+    ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, IntoSimpleExpr, QueryFilter,
+    QueryOrder, QueryResult, QuerySelect, RelationTrait, Select, SelectColumns, prelude::Uuid,
 };
-use sea_query::{extension::postgres::PgExpr, Expr, Func, JoinType, SimpleExpr};
+use sea_query::{Expr, Func, JoinType, SimpleExpr, extension::postgres::PgExpr};
 use serde::Deserialize;
 use serde_json::Value;
 use std::{collections::HashMap, fmt::Debug};
@@ -21,10 +20,10 @@ use tracing::instrument;
 use trustify_common::{
     cpe::Cpe,
     db::{
-        limiter::{limit_selector, LimiterTrait},
+        ArrayAgg, JsonBuildObject, ToJson,
+        limiter::{LimiterTrait, limit_selector},
         multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         query::{Columns, Filtering, IntoColumns, Query},
-        ArrayAgg, JsonBuildObject, ToJson,
     },
     id::{Id, TrySelectForId},
     model::{Paginated, PaginatedResults},

--- a/modules/fundamental/src/sbom/service/test.rs
+++ b/modules/fundamental/src/sbom/service/test.rs
@@ -53,9 +53,15 @@ async fn count_sboms(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let service = SbomService::new(ctx.db.clone());
 
-    let neither_purl = Purl::from_str("pkg:maven/io.smallrye/smallrye-graphql@0.0.0.redhat-00000?repository_url=https://maven.repository.redhat.com/ga/&type=jar")?;
-    let both_purl = Purl::from_str("pkg:maven/io.smallrye/smallrye-graphql@2.2.3.redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=jar")?;
-    let one_purl = Purl::from_str("pkg:maven/io.quarkus/quarkus-kubernetes-service-binding-deployment@3.2.12.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=jar")?;
+    let neither_purl = Purl::from_str(
+        "pkg:maven/io.smallrye/smallrye-graphql@0.0.0.redhat-00000?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+    )?;
+    let both_purl = Purl::from_str(
+        "pkg:maven/io.smallrye/smallrye-graphql@2.2.3.redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+    )?;
+    let one_purl = Purl::from_str(
+        "pkg:maven/io.quarkus/quarkus-kubernetes-service-binding-deployment@3.2.12.Final-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+    )?;
 
     let neither_cpe = Cpe::from_str("cpe:/a:redhat:quarkus:0.0::el8")?;
     let both_cpe = Cpe::from_str("cpe:/a:redhat:quarkus:3.2::el8")?;

--- a/modules/fundamental/src/test/mod.rs
+++ b/modules/fundamental/src/test/mod.rs
@@ -1,2 +1,2 @@
-use crate::endpoints::{configure, Config};
+use crate::endpoints::{Config, configure};
 include!("common.rs");

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -2,19 +2,19 @@
 mod test;
 
 use crate::{
+    Error,
+    Error::Internal,
     endpoints::Deprecation,
     vulnerability::{
         model::{VulnerabilityDetails, VulnerabilitySummary},
         service::VulnerabilityService,
     },
-    Error,
-    Error::Internal,
 };
-use actix_web::{delete, get, web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, delete, get, web};
 use sea_orm::TransactionTrait;
-use trustify_auth::{authorizer::Require, DeleteVulnerability, ReadAdvisory};
+use trustify_auth::{DeleteVulnerability, ReadAdvisory, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -5,7 +5,7 @@ use actix_web::test::TestRequest;
 use serde_json::Value;
 use test_context::test_context;
 use test_log::test;
-use time::{macros::datetime, OffsetDateTime};
+use time::{OffsetDateTime, macros::datetime};
 use trustify_common::{hashing::Digests, model::PaginatedResults};
 use trustify_cvss::cvss3::{
     AttackComplexity, AttackVector, Availability, Confidentiality, Cvss3Base, Integrity,
@@ -14,7 +14,7 @@ use trustify_cvss::cvss3::{
 use trustify_module_ingestor::graph::{
     advisory::AdvisoryInformation, vulnerability::VulnerabilityInformation,
 };
-use trustify_test_context::{call::CallService, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService};
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -2,11 +2,11 @@ mod vulnerability_advisory;
 
 pub use vulnerability_advisory::*;
 
-use crate::{vulnerability::model::VulnerabilityHead, Error};
+use crate::{Error, vulnerability::model::VulnerabilityHead};
 use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
-use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
+use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -1,8 +1,8 @@
 use crate::{
-    advisory::model::AdvisoryHead,
-    purl::model::{details::purl::StatusContext, summary::purl::PurlSummary, BasePurlHead},
-    sbom::model::SbomHead,
     Error,
+    advisory::model::AdvisoryHead,
+    purl::model::{BasePurlHead, details::purl::StatusContext, summary::purl::PurlSummary},
+    sbom::model::SbomHead,
 };
 use ::cpe::uri::OwnedUri;
 use sea_orm::{
@@ -15,13 +15,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use trustify_common::{
     db::{
-        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
         VersionMatches,
+        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
     },
     memo::Memo,
     purl::Purl,
 };
-use trustify_cvss::cvss3::{score::Score, severity::Severity, Cvss3Base};
+use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
     advisory, advisory_vulnerability, base_purl, cpe, cvss3, organization,
     package_relates_to_package, purl_status, qualified_purl, relationship::Relationship, sbom,
@@ -397,11 +397,7 @@ impl PurlStatusCatcher {
 
     fn open_delim(incl: Option<bool>) -> char {
         if let Some(incl) = incl {
-            if incl {
-                '['
-            } else {
-                '('
-            }
+            if incl { '[' } else { '(' }
         } else {
             '('
         }
@@ -409,11 +405,7 @@ impl PurlStatusCatcher {
 
     fn close_delim(incl: Option<bool>) -> char {
         if let Some(incl) = incl {
-            if incl {
-                ']'
-            } else {
-                ')'
-            }
+            if incl { ']' } else { ')' }
         } else {
             ')'
         }

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -1,6 +1,6 @@
 use crate::{
-    vulnerability::model::{VulnerabilityAdvisoryHead, VulnerabilityHead},
     Error,
+    vulnerability::model::{VulnerabilityAdvisoryHead, VulnerabilityHead},
 };
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
     Error,
+    vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
 };
-use sea_orm::{prelude::*, EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait};
+use sea_orm::{EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait, prelude::*};
 use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
 use trustify_common::{
     db::{

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -5,7 +5,7 @@ use crate::sbom::service::SbomService;
 use crate::vulnerability::service::VulnerabilityService;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::query::{q, Query};
+use trustify_common::db::query::{Query, q};
 use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
 use trustify_test_context::TrustifyContext;
@@ -29,12 +29,14 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 
     assert_eq!(1, vulns.items.len());
 
-    assert!(vulns.items[0]
-        .head
-        .description
-        .as_ref()
-        .unwrap()
-        .starts_with("hyper is an HTTP library for Rust"));
+    assert!(
+        vulns.items[0]
+            .head
+            .description
+            .as_ref()
+            .unwrap()
+            .starts_with("hyper is an HTTP library for Rust")
+    );
 
     Ok(())
 }
@@ -291,9 +293,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(
         sboms,
-        [
-            "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-2.13.8.Final-redhat-00004",
-        ],
+        ["https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-2.13.8.Final-redhat-00004",],
     );
 
     // Ensure that purl->vuln mapping is good
@@ -338,10 +338,12 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     let affected = service.delete_vulnerability(id, &ctx.db).await?;
     assert_eq!(1, affected);
 
-    assert!(service
-        .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
-        .await?
-        .is_none());
+    assert!(
+        service
+            .fetch_vulnerability("CVE-2024-29025", Default::default(), &ctx.db)
+            .await?
+            .is_none()
+    );
 
     let affected = service.delete_vulnerability(id, &ctx.db).await?;
     assert_eq!(0, affected);

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -1,8 +1,8 @@
 use crate::{license::model::LicenseSummary, weakness::service::WeaknessService};
-use actix_web::{get, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, ReadWeakness};
+use actix_web::{HttpResponse, Responder, get, web};
+use trustify_auth::{ReadWeakness, authorizer::Require};
 use trustify_common::{
-    db::{query::Query, Database},
+    db::{Database, query::Query},
     model::{Paginated, PaginatedResults},
 };
 

--- a/modules/fundamental/src/weakness/endpoints/test.rs
+++ b/modules/fundamental/src/weakness/endpoints/test.rs
@@ -4,7 +4,7 @@ use actix_web::test::TestRequest;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::model::PaginatedResults;
-use trustify_test_context::{call::CallService, document_read, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService, document_read};
 use zip::ZipArchive;
 
 #[test_context(TrustifyContext)]

--- a/modules/fundamental/src/weakness/service/mod.rs
+++ b/modules/fundamental/src/weakness/service/mod.rs
@@ -1,13 +1,13 @@
 use crate::{
-    weakness::model::{WeaknessDetails, WeaknessSummary},
     Error,
+    weakness::model::{WeaknessDetails, WeaknessSummary},
 };
 use sea_orm::EntityTrait;
 use trustify_common::{
     db::{
+        Database,
         limiter::LimiterTrait,
         query::{Filtering, Query},
-        Database,
     },
     model::{Paginated, PaginatedResults},
 };

--- a/modules/fundamental/tests/advisory/csaf/mod.rs
+++ b/modules/fundamental/tests/advisory/csaf/mod.rs
@@ -3,11 +3,11 @@
 mod delete;
 mod reingest;
 
+use csaf::Csaf;
 use csaf::definitions::ProductIdT;
 use csaf::document::Revision;
-use csaf::Csaf;
 use trustify_module_ingestor::model::IngestResult;
-use trustify_test_context::{document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_bytes};
 
 /// Ingest a document twice, mutating it using the provided closure.
 async fn twice<M1, M2>(

--- a/modules/fundamental/tests/advisory/cve/mod.rs
+++ b/modules/fundamental/tests/advisory/cve/mod.rs
@@ -5,13 +5,13 @@ mod delete;
 mod reingest;
 
 use cve::{
+    Cve, Rejected,
     common::{self, Description},
     rejected::{CnaContainer, Containers, Metadata, State},
-    Cve, Rejected,
 };
 use time::macros::datetime;
 use trustify_module_ingestor::model::IngestResult;
-use trustify_test_context::{document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_bytes};
 
 /// Ingest a document twice, mutating it using the provided closure.
 async fn twice<M1, M2>(

--- a/modules/fundamental/tests/advisory/osv/mod.rs
+++ b/modules/fundamental/tests/advisory/osv/mod.rs
@@ -8,7 +8,7 @@ mod reingest;
 use osv::schema::{Event, Vulnerability};
 use trustify_module_ingestor::model::IngestResult;
 use trustify_module_ingestor::service::advisory::osv::{from_yaml, to_yaml};
-use trustify_test_context::{document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_bytes};
 
 /// Ingest a document twice, mutating it using the provided closure.
 async fn twice<M1, M2>(

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -122,11 +122,13 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     let ubi_details = ubi_details.unwrap();
     let ubi_advisories = ubi_details.advisories;
     assert_eq!(ubi_advisories.len(), 2);
-    assert!(ubi_advisories
-        .iter()
-        .map(|adv| adv.head.document_id.clone())
-        .collect::<Vec<_>>()
-        .contains(&"CVE-2024-50602".to_string()));
+    assert!(
+        ubi_advisories
+            .iter()
+            .map(|adv| adv.head.document_id.clone())
+            .collect::<Vec<_>>()
+            .contains(&"CVE-2024-50602".to_string())
+    );
 
     // done
 

--- a/modules/fundamental/tests/limit.rs
+++ b/modules/fundamental/tests/limit.rs
@@ -2,7 +2,7 @@ use actix_http::StatusCode;
 use actix_web::test::TestRequest;
 use test_context::test_context;
 use test_log::test;
-use trustify_module_fundamental::{configure, Config};
+use trustify_module_fundamental::{Config, configure};
 use trustify_test_context::document_bytes_raw;
 
 include!("../src/test/common.rs");

--- a/modules/fundamental/tests/sbom/cyclonedx/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/mod.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{model::Paginated, purl::Purl};
-use trustify_module_fundamental::purl::model::{summary::purl::PurlSummary, PurlHead};
+use trustify_module_fundamental::purl::model::{PurlHead, summary::purl::PurlSummary};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]

--- a/modules/fundamental/tests/sbom/cyclonedx/purl.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/purl.rs
@@ -63,12 +63,13 @@ async fn simple_ref(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(result.total, 1);
     let relation = &result.items[0];
-    assert_eq!(to_strings(&relation.package.purl),
-       // we must find two purls here, one from the main section, the other from the evidence
-       vec![
-           "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz",
-           "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz&foo=bar"
-       ]
+    assert_eq!(
+        to_strings(&relation.package.purl),
+        // we must find two purls here, one from the main section, the other from the evidence
+        vec![
+            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz",
+            "pkg:generic/openssl@3.0.7?checksum=SHA-512:1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e&download_url=https://pkgs.devel.redhat.com/repo/openssl/openssl-3.0.7-hobbled.tar.gz/sha512/1aea183b0b6650d9d5e7ba87b613bb1692c71720b0e75377b40db336b40bad780f7e8ae8dfb9f60841eeb4381f4b79c4c5043210c96e7cb51f90791b80c8285e/openssl-3.0.7-hobbled.tar.gz&foo=bar"
+        ]
     );
 
     // done

--- a/modules/fundamental/tests/sbom/graph.rs
+++ b/modules/fundamental/tests/sbom/graph.rs
@@ -6,8 +6,8 @@ use trustify_common::hashing::Digests;
 use trustify_common::purl::Purl;
 use trustify_common::sbom::SbomLocator;
 use trustify_entity::relationship::Relationship;
-use trustify_module_fundamental::purl::model::summary::purl::PurlSummary;
 use trustify_module_fundamental::purl::model::PurlHead;
+use trustify_module_fundamental::purl::model::summary::purl::PurlSummary;
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_test_context::TrustifyContext;
 

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -8,17 +8,17 @@ mod spdx;
 
 use sea_orm::{DatabaseTransaction, TransactionTrait};
 use std::{future::Future, pin::Pin, time::Instant};
-use tracing::{info_span, instrument, Instrument};
+use tracing::{Instrument, info_span, instrument};
 use trustify_common::{db::Database, hashing::Digests};
 use trustify_module_fundamental::sbom::service::SbomService;
 use trustify_module_ingestor::{
     graph::{
-        sbom::{self, SbomContext, SbomInformation},
         Graph,
+        sbom::{self, SbomContext, SbomInformation},
     },
     service::Discard,
 };
-use trustify_test_context::{document_bytes, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_bytes};
 
 #[allow(dead_code)]
 pub struct WithContext {

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -15,10 +15,10 @@ use tracing::instrument;
 use trustify_common::{id::Id, purl::Purl, sbom::spdx::parse_spdx};
 use trustify_entity::relationship::Relationship;
 use trustify_module_fundamental::{
-    purl::model::{summary::purl::PurlSummary, PurlHead},
+    purl::model::{PurlHead, summary::purl::PurlSummary},
     sbom::{model::Which, service::SbomService},
 };
-use trustify_test_context::{spdx::fix_spdx_rels, TrustifyContext};
+use trustify_test_context::{TrustifyContext, spdx::fix_spdx_rels};
 
 #[test_context(TrustifyContext)]
 #[instrument]

--- a/modules/fundamental/tests/weakness/mod.rs
+++ b/modules/fundamental/tests/weakness/mod.rs
@@ -8,7 +8,7 @@ use trustify_common::{hashing::HashingRead, model::Paginated};
 use trustify_entity::labels::Labels;
 use trustify_module_fundamental::weakness::service::WeaknessService;
 use trustify_module_ingestor::{graph::Graph, service::weakness::CweCatalogLoader};
-use trustify_test_context::{document_read, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_read};
 use zip::ZipArchive;
 
 #[test_context(TrustifyContext)]
@@ -57,7 +57,12 @@ async fn simple(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .await?
         .expect("must be found");
 
-    assert_eq!(w.head.description.as_deref(), Some("The product uses a cookie to store sensitive information, but the cookie is not marked with the HttpOnly flag."));
+    assert_eq!(
+        w.head.description.as_deref(),
+        Some(
+            "The product uses a cookie to store sensitive information, but the cookie is not marked with the HttpOnly flag."
+        )
+    );
 
     // now update (poor man's XML update)
 

--- a/modules/graphql/src/endpoints.rs
+++ b/modules/graphql/src/endpoints.rs
@@ -1,6 +1,6 @@
 use crate::RootQuery;
-use actix_web::{guard, web, HttpResponse, Result};
-use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
+use actix_web::{HttpResponse, Result, guard, web};
+use async_graphql::{EmptyMutation, EmptySubscription, Schema, http::GraphiQLSource};
 use async_graphql_actix_web::GraphQL;
 use std::sync::Arc;
 use trustify_common::db::Database;

--- a/modules/graphql/src/sbomstatus.rs
+++ b/modules/graphql/src/sbomstatus.rs
@@ -8,8 +8,8 @@ use trustify_module_fundamental::{
     purl::model::details::purl::StatusContext,
     sbom::{
         model::{
-            details::{SbomDetails, SbomStatus},
             SbomPackage,
+            details::{SbomDetails, SbomStatus},
         },
         service::SbomService,
     },

--- a/modules/importer/src/endpoints.rs
+++ b/modules/importer/src/endpoints.rs
@@ -1,10 +1,10 @@
 use super::service::{Error, ImporterService, PatchError};
 use crate::model::{Importer, ImporterConfiguration, ImporterReport};
 use actix_web::{
-    delete, get,
+    HttpResponse, Responder, delete, get,
     guard::{self, Guard, GuardContext},
     http::header::{self, ETag, EntityTag, IfMatch},
-    patch, post, put, web, HttpResponse, Responder,
+    patch, post, put, web,
 };
 use std::convert::Infallible;
 use trustify_auth::authorizer::Require;

--- a/modules/importer/src/runner/clearly_defined_curation/mod.rs
+++ b/modules/importer/src/runner/clearly_defined_curation/mod.rs
@@ -3,10 +3,10 @@ mod handler;
 use crate::{
     model::ClearlyDefinedCurationImporter,
     runner::{
+        RunOutput,
         common::walker::{CallbackError, Callbacks, GitWalker},
         context::RunContext,
         report::{Phase, ReportBuilder, ScannerError},
-        RunOutput,
     },
 };
 use handler::ClearlyDefinedHandler;

--- a/modules/importer/src/runner/common/walker/git.rs
+++ b/modules/importer/src/runner/common/walker/git.rs
@@ -1,8 +1,8 @@
 use crate::runner::common::walker::WorkingDirectory;
 use anyhow::anyhow;
 use git2::{
-    build::RepoBuilder, Cred, ErrorClass, ErrorCode, FetchOptions, RemoteCallbacks, Repository,
-    ResetType,
+    Cred, ErrorClass, ErrorCode, FetchOptions, RemoteCallbacks, Repository, ResetType,
+    build::RepoBuilder,
 };
 use std::{
     borrow::Cow,

--- a/modules/importer/src/runner/csaf/mod.rs
+++ b/modules/importer/src/runner/csaf/mod.rs
@@ -4,11 +4,11 @@ pub mod storage;
 use crate::{
     model::CsafImporter,
     runner::{
+        RunOutput,
         common::{filter::Filter, validation},
         context::RunContext,
         csaf::report::CsafReportVisitor,
         report::{ReportBuilder, ReportVisitor, ScannerError},
-        RunOutput,
     },
     server::context::WalkerProgress,
 };

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -3,10 +3,10 @@ mod handler;
 use crate::{
     model::CveImporter,
     runner::{
+        RunOutput,
         common::walker::{CallbackError, Callbacks, GitWalker},
         context::RunContext,
         report::{Phase, ReportBuilder, ScannerError},
-        RunOutput,
     },
 };
 use handler::CveHandler;

--- a/modules/importer/src/runner/cwe/mod.rs
+++ b/modules/importer/src/runner/cwe/mod.rs
@@ -2,10 +2,10 @@ mod walker;
 
 use crate::model::CweImporter;
 use crate::runner::{
+    RunOutput,
     context::RunContext,
     cwe::walker::CweWalker,
     report::{ReportBuilder, ScannerError},
-    RunOutput,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/modules/importer/src/runner/osv/mod.rs
+++ b/modules/importer/src/runner/osv/mod.rs
@@ -3,10 +3,10 @@ mod handler;
 use crate::{
     model::OsvImporter,
     runner::{
+        RunOutput,
         common::walker::{CallbackError, Callbacks, GitWalker},
         context::RunContext,
         report::{Phase, ReportBuilder, ScannerError},
-        RunOutput,
     },
 };
 use chrono::Datelike;
@@ -19,7 +19,7 @@ use tracing::instrument;
 use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{
     graph::Graph,
-    service::{advisory::osv::parse, Format, IngestorService},
+    service::{Format, IngestorService, advisory::osv::parse},
 };
 
 struct Context<C: RunContext + 'static> {

--- a/modules/importer/src/runner/sbom/mod.rs
+++ b/modules/importer/src/runner/sbom/mod.rs
@@ -4,11 +4,11 @@ pub mod storage;
 use crate::{
     model::SbomImporter,
     runner::{
+        RunOutput,
         common::{filter::Filter, validation},
         context::RunContext,
         report::{ReportBuilder, ReportVisitor, ScannerError},
         sbom::report::SbomReportVisitor,
-        RunOutput,
     },
     server::context::WalkerProgress,
 };

--- a/modules/importer/src/server/context.rs
+++ b/modules/importer/src/server/context.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::Mutex;
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 
 /// Context for an import run
 #[derive(Debug)]

--- a/modules/importer/src/server/mod.rs
+++ b/modules/importer/src/server/mod.rs
@@ -4,8 +4,8 @@ pub(crate) mod progress;
 use crate::{
     model::{Importer, State},
     runner::{
-        report::{Report, ScannerError},
         ImportRunner,
+        report::{Report, ScannerError},
     },
     server::context::ServiceRunContext,
     service::{Error, ImporterService},
@@ -13,7 +13,7 @@ use crate::{
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 use time::OffsetDateTime;
 use tokio::{
-    task::{spawn_local, JoinHandle, LocalSet},
+    task::{JoinHandle, LocalSet, spawn_local},
     time::MissedTickBehavior,
 };
 use tracing::instrument;

--- a/modules/importer/src/service.rs
+++ b/modules/importer/src/service.rs
@@ -1,5 +1,5 @@
 use crate::model::{Importer, ImporterConfiguration, ImporterReport};
-use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait,
     QueryFilter, QueryOrder, TransactionTrait,
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Display};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::{
-    db::{limiter::LimiterTrait, Database, DatabaseErrors},
+    db::{Database, DatabaseErrors, limiter::LimiterTrait},
     error::ErrorInformation,
     model::{Paginated, PaginatedResults, Revisioned},
 };

--- a/modules/importer/src/test.rs
+++ b/modules/importer/src/test.rs
@@ -4,14 +4,15 @@ use super::model::{
     CommonImporter, Importer, ImporterConfiguration, ImporterData, SbomImporter, State,
 };
 use actix_web::{
-    http::{header, StatusCode},
-    test as actix, App,
+    App,
+    http::{StatusCode, header},
+    test as actix,
 };
 use serde_json::json;
 use std::time::Duration;
 use test_context::test_context;
 use test_log::test;
-use trustify_test_context::{app::TestApp, TrustifyContext};
+use trustify_test_context::{TrustifyContext, app::TestApp};
 use utoipa_actix_web::AppExt;
 
 fn mock_configuration(source: impl Into<String>) -> ImporterConfiguration {

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -2,8 +2,8 @@ use crate::{
     graph::Graph,
     service::{Error, IngestorService},
 };
-use actix_web::{post, web, HttpResponse, Responder};
-use trustify_auth::{authorizer::Require, UploadDataset};
+use actix_web::{HttpResponse, Responder, post, web};
+use trustify_auth::{UploadDataset, authorizer::Require};
 use trustify_common::{db::Database, model::BinaryData};
 use trustify_entity::labels::Labels;
 use trustify_module_analysis::service::AnalysisService;

--- a/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
+++ b/modules/ingestor/src/graph/advisory/advisory_vulnerability.rs
@@ -166,8 +166,8 @@ impl AdvisoryVulnerabilityContext<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::graph::advisory::version::{Version, VersionInfo, VersionSpec};
     use crate::graph::Graph;
+    use crate::graph::advisory::version::{Version, VersionInfo, VersionSpec};
     use test_context::test_context;
     use test_log::test;
     use trustify_common::hashing::Digests;

--- a/modules/ingestor/src/graph/advisory/mod.rs
+++ b/modules/ingestor/src/graph/advisory/mod.rs
@@ -3,8 +3,8 @@
 use crate::{
     common::{Deprecation, DeprecationExt},
     graph::{
-        advisory::advisory_vulnerability::AdvisoryVulnerabilityContext, error::Error, Graph,
-        Outcome,
+        Graph, Outcome, advisory::advisory_vulnerability::AdvisoryVulnerabilityContext,
+        error::Error,
     },
 };
 use hex::ToHex;
@@ -328,12 +328,12 @@ impl<'g> AdvisoryContext<'g> {
 #[cfg(test)]
 mod test {
     use crate::common::Deprecation;
-    use crate::graph::advisory::AdvisoryInformation;
     use crate::graph::Graph;
+    use crate::graph::advisory::AdvisoryInformation;
     use test_context::test_context;
     use test_log::test;
-    use time::macros::datetime;
     use time::OffsetDateTime;
+    use time::macros::datetime;
     use trustify_common::hashing::Digests;
     use trustify_entity::labels::Labels;
     use trustify_test_context::TrustifyContext;

--- a/modules/ingestor/src/graph/cpe.rs
+++ b/modules/ingestor/src/graph/cpe.rs
@@ -1,4 +1,4 @@
-use crate::graph::{error::Error, Graph};
+use crate::graph::{Graph, error::Error};
 use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
 use sea_query::{OnConflict, SelectStatement};
 use std::{

--- a/modules/ingestor/src/graph/organization.rs
+++ b/modules/ingestor/src/graph/organization.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use tracing::instrument;
 use trustify_entity::organization;
 
-use crate::graph::{error::Error, Graph};
+use crate::graph::{Graph, error::Error};
 
 #[derive(Clone, Debug)]
 pub struct OrganizationInformation {

--- a/modules/ingestor/src/graph/product/mod.rs
+++ b/modules/ingestor/src/graph/product/mod.rs
@@ -12,7 +12,7 @@ use trustify_entity as entity;
 use trustify_entity::product;
 use uuid::Uuid;
 
-use crate::graph::{error::Error, organization::OrganizationInformation, Graph};
+use crate::graph::{Graph, error::Error, organization::OrganizationInformation};
 
 use self::product_version::ProductVersionContext;
 

--- a/modules/ingestor/src/graph/purl/mod.rs
+++ b/modules/ingestor/src/graph/purl/mod.rs
@@ -4,11 +4,11 @@ pub mod creator;
 pub mod package_version;
 pub mod qualified_package;
 
-use crate::graph::{error::Error, Graph};
+use crate::graph::{Graph, error::Error};
 use package_version::PackageVersionContext;
 use qualified_package::QualifiedPackageContext;
 use sea_orm::{
-    prelude::Uuid, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, prelude::Uuid,
 };
 use sea_query::SelectStatement;
 use std::fmt::{Debug, Formatter};
@@ -348,8 +348,8 @@ mod tests {
     use trustify_entity::qualified_purl::Qualifiers;
     use trustify_test_context::TrustifyContext;
 
-    use crate::graph::error::Error;
     use crate::graph::Graph;
+    use crate::graph::error::Error;
 
     #[test_context(TrustifyContext, skip_teardown)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/graph/purl/package_version.rs
+++ b/modules/ingestor/src/graph/purl/package_version.rs
@@ -2,7 +2,7 @@
 
 use crate::graph::{
     error::Error,
-    purl::{qualified_package::QualifiedPackageContext, PackageContext},
+    purl::{PackageContext, qualified_package::QualifiedPackageContext},
 };
 use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
 use std::fmt::{Debug, Formatter};

--- a/modules/ingestor/src/graph/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/graph/sbom/cyclonedx.rs
@@ -3,11 +3,11 @@ use crate::graph::{
     product::ProductInformation,
     purl::creator::PurlCreator,
     sbom::{
+        CycloneDx as CycloneDxProcessor, LicenseCreator, LicenseInfo, PackageCreator,
+        PackageReference, RelationshipCreator, SbomContext, SbomInformation,
         processor::{
             InitContext, PostContext, Processor, RedHatProductComponentRelationships, RunProcessors,
         },
-        CycloneDx as CycloneDxProcessor, LicenseCreator, LicenseInfo, PackageCreator,
-        PackageReference, RelationshipCreator, SbomContext, SbomInformation,
     },
 };
 use sea_orm::ConnectionTrait;
@@ -15,7 +15,7 @@ use serde_cyclonedx::cyclonedx::v_1_6::{
     Component, ComponentEvidenceIdentity, CycloneDx, LicenseChoiceUrl,
 };
 use std::str::FromStr;
-use time::{format_description::well_known::Iso8601, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Iso8601};
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, purl::Purl};
 use trustify_entity::relationship::Relationship;

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -13,20 +13,20 @@ use super::error::Error;
 use crate::{
     db::{LeftPackageId, QualifiedPackageTransitive},
     graph::{
-        cpe::CpeContext,
-        product::{product_version::ProductVersionContext, ProductContext},
-        purl::{creator::PurlCreator, qualified_package::QualifiedPackageContext},
         Graph, Outcome,
+        cpe::CpeContext,
+        product::{ProductContext, product_version::ProductVersionContext},
+        purl::{creator::PurlCreator, qualified_package::QualifiedPackageContext},
     },
 };
 use cpe::uri::OwnedUri;
 use entity::{product, product_version};
 use hex::ToHex;
 use sea_orm::{
-    prelude::Uuid, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait,
-    QueryFilter, QuerySelect, RelationTrait, Select, Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter,
+    QuerySelect, RelationTrait, Select, Set, prelude::Uuid,
 };
-use sea_query::{extension::postgres::PgExpr, Condition, Expr, Func, JoinType, Query, SimpleExpr};
+use sea_query::{Condition, Expr, Func, JoinType, Query, SimpleExpr, extension::postgres::PgExpr};
 use std::{
     fmt::{Debug, Formatter},
     iter,

--- a/modules/ingestor/src/graph/sbom/processor/rh_prod_comp.rs
+++ b/modules/ingestor/src/graph/sbom/processor/rh_prod_comp.rs
@@ -1,8 +1,8 @@
 use crate::graph::{
     cpe::CpeCreator,
     sbom::{
-        processor::{InitContext, PostContext},
         ExternalReference,
+        processor::{InitContext, PostContext},
     },
 };
 use sea_orm::ActiveValue::Set;

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -4,17 +4,17 @@ use crate::{
         product::ProductInformation,
         purl::creator::PurlCreator,
         sbom::{
+            FileCreator, LicenseCreator, LicenseInfo, PackageCreator, PackageReference, References,
+            RelationshipCreator, SbomContext, SbomInformation, Spdx,
             processor::{
                 InitContext, PostContext, Processor, RedHatProductComponentRelationships,
                 RunProcessors,
             },
-            FileCreator, LicenseCreator, LicenseInfo, PackageCreator, PackageReference, References,
-            RelationshipCreator, SbomContext, SbomInformation, Spdx,
         },
     },
     service::Error,
 };
-use sbom_walker::report::{check, ReportSink};
+use sbom_walker::report::{ReportSink, check};
 use sea_orm::ConnectionTrait;
 use spdx_rs::models::{RelationshipType, SPDX};
 use std::{collections::HashMap, str::FromStr};

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -1,7 +1,7 @@
 //! Support for CVEs.
 
 use crate::common::{Deprecation, DeprecationExt};
-use crate::{graph::advisory::AdvisoryContext, graph::error::Error, graph::Graph};
+use crate::{graph::Graph, graph::advisory::AdvisoryContext, graph::error::Error};
 use sea_orm::{
     ActiveValue::Set, ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter,
     QuerySelect, RelationTrait,

--- a/modules/ingestor/src/service/advisory/csaf/creator.rs
+++ b/modules/ingestor/src/service/advisory/csaf/creator.rs
@@ -1,5 +1,6 @@
 use crate::{
     graph::{
+        Graph,
         advisory::{
             product_status::ProductVersionRange,
             purl_status::PurlStatus,
@@ -9,14 +10,13 @@ use crate::{
         organization::{OrganizationContext, OrganizationInformation},
         product::ProductInformation,
         purl::creator::PurlCreator,
-        Graph,
     },
     service::{
-        advisory::csaf::{product_status::ProductStatus, util::ResolveProductIdCache},
         Error,
+        advisory::csaf::{product_status::ProductStatus, util::ResolveProductIdCache},
     },
 };
-use csaf::{definitions::ProductIdT, Csaf};
+use csaf::{Csaf, definitions::ProductIdT};
 use sea_orm::{ActiveValue::Set, ConnectionTrait, EntityTrait};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;

--- a/modules/ingestor/src/service/advisory/csaf/loader.rs
+++ b/modules/ingestor/src/service/advisory/csaf/loader.rs
@@ -1,20 +1,20 @@
 use crate::{
     graph::{
-        advisory::{
-            advisory_vulnerability::AdvisoryVulnerabilityContext, AdvisoryContext,
-            AdvisoryInformation, AdvisoryVulnerabilityInformation,
-        },
         Graph,
+        advisory::{
+            AdvisoryContext, AdvisoryInformation, AdvisoryVulnerabilityInformation,
+            advisory_vulnerability::AdvisoryVulnerabilityContext,
+        },
     },
     model::IngestResult,
     service::{
-        advisory::csaf::{util::gen_identifier, StatusCreator},
         Error, Warnings,
+        advisory::csaf::{StatusCreator, util::gen_identifier},
     },
 };
 use csaf::{
-    vulnerability::{ProductStatus, Vulnerability},
     Csaf,
+    vulnerability::{ProductStatus, Vulnerability},
 };
 use hex::ToHex;
 use sbom_walker::report::ReportSink;
@@ -228,7 +228,7 @@ mod test {
     use crate::graph::Graph;
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/service/advisory/csaf/util.rs
+++ b/modules/ingestor/src/service/advisory/csaf/util.rs
@@ -1,7 +1,7 @@
 use csaf::{
+    Csaf,
     definitions::{Branch, BranchesT, ProductIdT},
     product_tree::{ProductTree, Relationship},
-    Csaf,
 };
 use packageurl::PackageUrl;
 use std::collections::HashMap;

--- a/modules/ingestor/src/service/advisory/cve/loader.rs
+++ b/modules/ingestor/src/service/advisory/cve/loader.rs
@@ -1,18 +1,18 @@
 use crate::{
     graph::{
+        Graph,
         advisory::{
-            version::{Version, VersionInfo, VersionSpec},
             AdvisoryInformation, AdvisoryVulnerabilityInformation,
+            version::{Version, VersionInfo, VersionSpec},
         },
         vulnerability::VulnerabilityInformation,
-        Graph,
     },
     model::IngestResult,
-    service::{advisory::cve::divination::divine_purl, Error},
+    service::{Error, advisory::cve::divination::divine_purl},
 };
 use cve::{
-    common::{Description, Product, Status, VersionRange},
     Cve, Timestamp,
+    common::{Description, Product, Status, VersionRange},
 };
 use sea_orm::TransactionTrait;
 use std::fmt::Debug;
@@ -259,11 +259,7 @@ impl<'g> CveLoader<'g> {
                         .flat_map(|pt| pt.descriptions.iter())
                         .flat_map(|desc| desc.cwe_id.clone())
                         .collect::<Vec<_>>();
-                    if cwes.is_empty() {
-                        None
-                    } else {
-                        Some(cwes)
-                    }
+                    if cwes.is_empty() { None } else { Some(cwes) }
                 },
                 published
                     .containers
@@ -311,7 +307,7 @@ mod test {
     use test_log::test;
     use time::macros::datetime;
     use trustify_common::purl::Purl;
-    use trustify_test_context::{document, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]
@@ -348,8 +344,10 @@ mod test {
 
         let descriptions = loaded_vulnerability.descriptions("en", &ctx.db).await?;
         assert_eq!(1, descriptions.len());
-        assert!(descriptions[0]
-            .starts_with("Canarytokens helps track activity and actions on a network"));
+        assert!(
+            descriptions[0]
+                .starts_with("Canarytokens helps track activity and actions on a network")
+        );
 
         Ok(())
     }

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -1,17 +1,17 @@
 use crate::{
     graph::{
+        Graph,
         advisory::{
+            AdvisoryInformation, AdvisoryVulnerabilityInformation,
             advisory_vulnerability::AdvisoryVulnerabilityContext,
             version::{Version, VersionInfo, VersionSpec},
-            AdvisoryInformation, AdvisoryVulnerabilityInformation,
         },
         purl::creator::PurlCreator,
-        Graph,
     },
     model::IngestResult,
     service::{
-        advisory::osv::{prefix::get_well_known_prefixes, translate},
         Error, Warnings,
+        advisory::osv::{prefix::get_well_known_prefixes, translate},
     },
 };
 use osv::schema::{Ecosystem, Event, Range, RangeType, ReferenceType, SeverityType, Vulnerability};
@@ -523,7 +523,7 @@ mod test {
     use rstest::rstest;
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]
@@ -577,10 +577,12 @@ mod test {
             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
         );
 
-        assert!(loaded_advisory
-            .get_vulnerability("CVE-8675309", &ctx.db)
-            .await?
-            .is_none());
+        assert!(
+            loaded_advisory
+                .get_vulnerability("CVE-8675309", &ctx.db)
+                .await?
+                .is_none()
+        );
 
         Ok(())
     }

--- a/modules/ingestor/src/service/dataset/mod.rs
+++ b/modules/ingestor/src/service/dataset/mod.rs
@@ -19,7 +19,7 @@ use tokio_util::io::ReaderStream;
 use tracing::instrument;
 use trustify_common::hashing::Digests;
 use trustify_entity::labels::Labels;
-use trustify_module_storage::{service::dispatch::DispatchBackend, service::StorageBackend};
+use trustify_module_storage::{service::StorageBackend, service::dispatch::DispatchBackend};
 
 pub struct DatasetLoader<'g> {
     graph: &'g Graph,

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -1,21 +1,21 @@
 use crate::service::sbom::clearly_defined::ClearlyDefinedLoader;
 use crate::{
-    graph::{sbom::clearly_defined::Curation, Graph},
+    graph::{Graph, sbom::clearly_defined::Curation},
     model::IngestResult,
     service::{
+        Error,
         advisory::{csaf::loader::CsafLoader, cve::loader::CveLoader, osv::loader::OsvLoader},
         sbom::{
             clearly_defined_curation::ClearlyDefinedCurationLoader, cyclonedx::CyclonedxLoader,
             spdx::SpdxLoader,
         },
         weakness::CweCatalogLoader,
-        Error,
     },
 };
 use csaf::Csaf;
 use cve::Cve;
-use jsn::{mask::*, Format as JsnFormat, TokenReader};
-use quick_xml::{events::Event, Reader};
+use jsn::{Format as JsnFormat, TokenReader, mask::*};
+use quick_xml::{Reader, events::Event};
 use serde_json::Value;
 use std::io::Cursor;
 use tracing::instrument;

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -8,7 +8,7 @@ pub use format::Format;
 
 use crate::service::dataset::{DatasetIngestResult, DatasetLoader};
 use crate::{graph::Graph, model::IngestResult};
-use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use anyhow::anyhow;
 use parking_lot::Mutex;
 use sbom_walker::report::ReportSink;
@@ -21,7 +21,7 @@ use tracing::instrument;
 use trustify_common::{error::ErrorInformation, id::IdError};
 use trustify_entity::labels::Labels;
 use trustify_module_analysis::service::AnalysisService;
-use trustify_module_storage::service::{dispatch::DispatchBackend, StorageBackend};
+use trustify_module_storage::service::{StorageBackend, dispatch::DispatchBackend};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graph::{sbom::SbomInformation, Graph, Outcome},
+    graph::{Graph, Outcome, sbom::SbomInformation},
     model::IngestResult,
     service::Error,
 };
@@ -146,8 +146,8 @@ mod test {
     use crate::service::{Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::document_bytes;
     use trustify_test_context::TrustifyContext;
+    use trustify_test_context::document_bytes;
 
     #[test]
     fn coords_conversion_no_namespace() {

--- a/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graph::{sbom::clearly_defined::Curation, Graph, Outcome},
+    graph::{Graph, Outcome, sbom::clearly_defined::Curation},
     model::IngestResult,
     service::Error,
 };
@@ -63,8 +63,8 @@ mod test {
     use crate::service::{Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::document_bytes;
     use trustify_test_context::TrustifyContext;
+    use trustify_test_context::document_bytes;
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graph::{sbom::cyclonedx, Graph, Outcome},
+    graph::{Graph, Outcome, sbom::cyclonedx},
     model::IngestResult,
     service::Error,
 };
@@ -81,7 +81,7 @@ mod test {
     use crate::{graph::Graph, service::Format};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document_bytes, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document_bytes};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -1,7 +1,7 @@
 use crate::{
     graph::{
-        sbom::spdx::{self},
         Graph, Outcome,
+        sbom::spdx::{self},
     },
     model::IngestResult,
     service::{Error, Warnings},
@@ -79,7 +79,7 @@ mod test {
     use crate::{graph::Graph, service::Format};
     use test_context::test_context;
     use test_log::test;
-    use trustify_test_context::{document_bytes, TrustifyContext};
+    use trustify_test_context::{TrustifyContext, document_bytes};
 
     #[test_context(TrustifyContext)]
     #[test(tokio::test)]

--- a/modules/ingestor/src/service/weakness/mod.rs
+++ b/modules/ingestor/src/service/weakness/mod.rs
@@ -197,8 +197,8 @@ mod test {
     use test_log::test;
     use trustify_common::hashing::HashingRead;
     use trustify_entity::labels::Labels;
-    use trustify_test_context::document_read;
     use trustify_test_context::TrustifyContext;
+    use trustify_test_context::document_read;
     use zip::ZipArchive;
 
     #[test_context(TrustifyContext)]

--- a/modules/ingestor/tests/common.rs
+++ b/modules/ingestor/tests/common.rs
@@ -1,9 +1,9 @@
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
-use trustify_module_ingestor::endpoints::{configure, Config};
+use trustify_module_ingestor::endpoints::{Config, configure};
 use trustify_test_context::{
-    call::{self, CallService},
     TrustifyContext,
+    call::{self, CallService},
 };
 
 pub async fn caller_with(

--- a/modules/ingestor/tests/db.rs
+++ b/modules/ingestor/tests/db.rs
@@ -3,7 +3,7 @@ use sea_orm::{ConnectionTrait, EntityTrait, QueryOrder};
 use std::fmt::Display;
 use test_context::test_context;
 use test_log::test;
-use time::{macros::datetime, Duration};
+use time::{Duration, macros::datetime};
 use trustify_common::hashing::Digests;
 use trustify_entity::{advisory, source_document};
 use trustify_module_ingestor::graph::advisory::AdvisoryInformation;

--- a/modules/ingestor/tests/limit.rs
+++ b/modules/ingestor/tests/limit.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, Write};
 use test_context::test_context;
 use test_log::test;
 use trustify_module_ingestor::endpoints::Config;
-use trustify_test_context::{call::CallService, document_bytes_raw, TrustifyContext};
+use trustify_test_context::{TrustifyContext, call::CallService, document_bytes_raw};
 use zip::write::FileOptions;
 
 #[test_context(TrustifyContext)]

--- a/modules/ingestor/tests/parallel.rs
+++ b/modules/ingestor/tests/parallel.rs
@@ -16,7 +16,7 @@ use trustify_module_ingestor::{
     },
     service::{Discard, Format},
 };
-use trustify_test_context::{document_bytes, spdx::fix_spdx_rels, TrustifyContext};
+use trustify_test_context::{TrustifyContext, document_bytes, spdx::fix_spdx_rels};
 use uuid::Uuid;
 
 /// Ingest x SBOMs in parallel

--- a/modules/ingestor/tests/version/mavenver.rs
+++ b/modules/ingestor/tests/version/mavenver.rs
@@ -1,4 +1,4 @@
-use crate::version::common::{version_matches, Version, VersionRange};
+use crate::version::common::{Version, VersionRange, version_matches};
 use sea_orm::{ConnectionTrait, Statement};
 use test_context::test_context;
 use test_log::test;

--- a/modules/ingestor/tests/version/mod.rs
+++ b/modules/ingestor/tests/version/mod.rs
@@ -4,7 +4,7 @@ mod pythonver;
 mod rpmver;
 mod semver;
 
-use crate::version::common::{version_matches, VersionRange};
+use crate::version::common::{VersionRange, version_matches};
 use rstest::rstest;
 use test_context::AsyncTestContext;
 use trustify_entity::version_scheme::VersionScheme;

--- a/modules/ingestor/tests/version/pythonver.rs
+++ b/modules/ingestor/tests/version/pythonver.rs
@@ -1,4 +1,4 @@
-use crate::version::common::{version_matches, Version, VersionRange};
+use crate::version::common::{Version, VersionRange, version_matches};
 use sea_orm::{ConnectionTrait, Statement};
 use test_context::test_context;
 use test_log::test;

--- a/modules/ingestor/tests/version/semver.rs
+++ b/modules/ingestor/tests/version/semver.rs
@@ -1,4 +1,4 @@
-use crate::version::common::{version_matches, Version, VersionRange};
+use crate::version::common::{Version, VersionRange, version_matches};
 use sea_orm::{ConnectionTrait, Statement};
 use test_context::test_context;
 use test_log::test;

--- a/modules/storage/src/service/compression/mod.rs
+++ b/modules/storage/src/service/compression/mod.rs
@@ -103,8 +103,8 @@ where
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         match &mut self.inner {
-            InnerDecompression::None(ref mut r) => Pin::new(r).poll_read(cx, buf),
-            InnerDecompression::Zstd(ref mut r) => Pin::new(r).poll_read(cx, buf),
+            InnerDecompression::None(r) => Pin::new(r).poll_read(cx, buf),
+            InnerDecompression::Zstd(r) => Pin::new(r).poll_read(cx, buf),
         }
     }
 }

--- a/modules/storage/src/service/fs.rs
+++ b/modules/storage/src/service/fs.rs
@@ -1,5 +1,5 @@
 use crate::service::{
-    compression::Compression, temp::TempFile, StorageBackend, StorageKey, StorageResult, StoreError,
+    StorageBackend, StorageKey, StorageResult, StoreError, compression::Compression, temp::TempFile,
 };
 use anyhow::Context;
 use bytes::Bytes;
@@ -11,9 +11,9 @@ use std::{
     pin::pin,
 };
 use strum::IntoEnumIterator;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use tokio::{
-    fs::{create_dir_all, File},
+    fs::{File, create_dir_all},
     io::AsyncWriteExt,
 };
 use tokio_util::io::ReaderStream;

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -1,14 +1,14 @@
 use crate::{
     config::S3Config,
     service::{
-        compression::Compression, temp::TempFile, StorageBackend, StorageKey, StorageResult,
-        StoreError,
+        StorageBackend, StorageKey, StorageResult, StoreError, compression::Compression,
+        temp::TempFile,
     },
 };
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
-use http::{header::CONTENT_ENCODING, HeaderMap, HeaderValue};
-use s3::{creds::Credentials, error::S3Error, Bucket};
+use http::{HeaderMap, HeaderValue, header::CONTENT_ENCODING};
+use s3::{Bucket, creds::Credentials, error::S3Error};
 use std::{fmt::Debug, io, pin::pin, str::FromStr};
 use tokio_util::io::{ReaderStream, StreamReader};
 use tracing::instrument;

--- a/modules/storage/src/service/temp.rs
+++ b/modules/storage/src/service/temp.rs
@@ -47,7 +47,7 @@ impl TempFile {
     }
 
     /// Return a clone of the temp file after resetting its position
-    pub async fn reader(&mut self) -> Result<impl AsyncBufRead, Error> {
+    pub async fn reader(&mut self) -> Result<impl AsyncBufRead + use<>, Error> {
         self.file.seek(SeekFrom::Start(0)).await?;
         Ok(BufReader::new(self.file.try_clone().await?))
     }

--- a/modules/ui/src/endpoints.rs
+++ b/modules/ui/src/endpoints.rs
@@ -1,7 +1,7 @@
 use actix_web::web;
-use actix_web_static_files::{deps::static_files::Resource, ResourceFiles};
+use actix_web_static_files::{ResourceFiles, deps::static_files::Resource};
 use std::collections::HashMap;
-use trustify_ui::{trustify_ui, UI};
+use trustify_ui::{UI, trustify_ui};
 
 pub struct UiResources {
     resources: HashMap<&'static str, Resource>,

--- a/modules/user/src/endpoints.rs
+++ b/modules/user/src/endpoints.rs
@@ -1,8 +1,8 @@
 use crate::service::{Error, UserPreferenceService};
 use actix_web::{
-    delete, get,
+    HttpResponse, Responder, delete, get,
     http::header::{self, ETag, EntityTag, IfMatch},
-    put, web, HttpResponse, Responder,
+    put, web,
 };
 use trustify_auth::authenticator::user::UserDetails;
 use trustify_common::{db::Database, model::Revisioned};

--- a/modules/user/src/service.rs
+++ b/modules/user/src/service.rs
@@ -1,7 +1,7 @@
-use actix_web::{body::BoxBody, HttpResponse, ResponseError};
+use actix_web::{HttpResponse, ResponseError, body::BoxBody};
 use sea_orm::{
-    prelude::Uuid, ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter,
-    TransactionTrait,
+    ActiveValue::Set, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, TransactionTrait,
+    prelude::Uuid,
 };
 use sea_query::{Alias, Expr, OnConflict};
 use trustify_common::{db::Database, error::ErrorInformation, model::Revisioned};

--- a/modules/user/src/test.rs
+++ b/modules/user/src/test.rs
@@ -2,13 +2,13 @@
 
 use crate::service::{Error, UserPreferenceService};
 use actix_http::header;
-use actix_web::{http::StatusCode, test as actix, App};
+use actix_web::{App, http::StatusCode, test as actix};
 use serde_json::json;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::model::Revisioned;
-use trustify_test_context::auth::TestAuthentication;
 use trustify_test_context::TrustifyContext;
+use trustify_test_context::auth::TestAuthentication;
 use utoipa_actix_web::AppExt;
 
 #[test_context(TrustifyContext, skip_teardown)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = [ "rustfmt", "clippy" ]

--- a/server/src/embedded_oidc.rs
+++ b/server/src/embedded_oidc.rs
@@ -4,8 +4,8 @@ use garage_door::{
     issuer::{Client, Issuer, RedirectUrl},
     server::{Server, StartupError},
 };
-use rand::distributions::Alphanumeric;
 use rand::Rng;
+use rand::distributions::Alphanumeric;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;

--- a/server/src/endpoints.rs
+++ b/server/src/endpoints.rs
@@ -1,12 +1,11 @@
 use actix_web::{
-    get,
+    HttpRequest, HttpResponse, get,
     http::header::AUTHORIZATION,
     web::{self},
-    HttpRequest, HttpResponse,
 };
 use build_info::BuildInfo;
 use std::sync::Arc;
-use trustify_auth::authenticator::{user::UserInformation, Authenticator};
+use trustify_auth::authenticator::{Authenticator, user::UserInformation};
 use trustify_infrastructure::app::new_auth;
 use utoipa::OpenApi;
 use utoipa_actix_web::service_config::ServiceConfig;

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,12 +1,12 @@
-use crate::profile::api::{configure, default_openapi_info, Config, ModuleConfig};
+use crate::profile::api::{Config, ModuleConfig, configure, default_openapi_info};
 use actix_web::App;
 use trustify_common::{config::Database, db};
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
 use trustify_module_storage::service::{dispatch::DispatchBackend, fs::FileSystemBackend};
 use utoipa::{
-    openapi::security::{OpenIdConnect, SecurityScheme},
     Modify, OpenApi,
+    openapi::security::{OpenIdConnect, SecurityScheme},
 };
 use utoipa_actix_web::AppExt;
 

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -3,12 +3,12 @@ use crate::embedded_oidc;
 
 use crate::{endpoints, sample_data};
 use actix_web::{
+    HttpRequest, HttpResponse, Responder, Result,
     body::MessageBody,
     dev::{ConnectionInfo, Url},
     error::UrlGenerationError,
     get, middleware, web,
     web::Json,
-    HttpRequest, HttpResponse, Responder, Result,
 };
 use anyhow::Context;
 use bytesize::ByteSize;
@@ -22,10 +22,11 @@ use trustify_auth::{
     authenticator::Authenticator,
     authorizer::Authorizer,
     devmode::{FRONTEND_CLIENT_ID, ISSUER_URL, PUBLIC_CLIENT_IDS},
-    swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc, SwaggerUiOidcConfig},
+    swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig, swagger_ui_with_auth},
 };
 use trustify_common::{config::Database, db, model::BinaryByteSize};
 use trustify_infrastructure::{
+    Infrastructure, InfrastructureConfig, InitContext, Metrics,
     app::{
         http::{HttpServerBuilder, HttpServerConfig},
         new_auth,
@@ -33,7 +34,6 @@ use trustify_infrastructure::{
     endpoint::Trustify,
     health::checks::{Local, Probe},
     otel::{Metrics as OtelMetrics, Tracing},
-    Infrastructure, InfrastructureConfig, InitContext, Metrics,
 };
 use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
 use trustify_module_graphql::RootQuery;
@@ -43,10 +43,10 @@ use trustify_module_storage::{
     config::{StorageConfig, StorageStrategy},
     service::{dispatch::DispatchBackend, fs::FileSystemBackend, s3::S3Backend},
 };
-use trustify_module_ui::{endpoints::UiResources, UI};
+use trustify_module_ui::{UI, endpoints::UiResources};
 use utoipa::{
-    openapi::{Info, License},
     OpenApi,
+    openapi::{Info, License},
 };
 use utoipa_rapidoc::RapiDoc;
 use utoipa_redoc::{Redoc, Servable};
@@ -483,11 +483,11 @@ fn build_url(ci: &ConnectionInfo, path: impl Display) -> Option<url::Url> {
 mod test {
     use super::*;
     use actix_web::{
-        body::{to_bytes, to_bytes_limited},
-        http::{header, StatusCode},
-        test::{call_and_read_body, call_service, TestRequest},
-        web::{self, Bytes},
         App,
+        body::{to_bytes, to_bytes_limited},
+        http::{StatusCode, header},
+        test::{TestRequest, call_and_read_body, call_service},
+        web::{self, Bytes},
     };
     use std::sync::Arc;
     use test_context::test_context;
@@ -496,9 +496,9 @@ mod test {
     use trustify_module_storage::{
         service::dispatch::DispatchBackend, service::fs::FileSystemBackend,
     };
-    use trustify_module_ui::{endpoints::UiResources, UI};
-    use trustify_test_context::app::TestApp;
+    use trustify_module_ui::{UI, endpoints::UiResources};
     use trustify_test_context::TrustifyContext;
+    use trustify_test_context::app::TestApp;
     use utoipa_actix_web::AppExt;
 
     #[test_context(TrustifyContext, skip_teardown)]

--- a/server/src/profile/importer.rs
+++ b/server/src/profile/importer.rs
@@ -1,11 +1,11 @@
 use crate::{endpoints, sample_data};
 use actix_web::{
+    HttpRequest, HttpResponse, Responder, Result,
     body::MessageBody,
     dev::{ConnectionInfo, Url},
     error::UrlGenerationError,
     get, middleware, web,
     web::Json,
-    HttpRequest, HttpResponse, Responder, Result,
 };
 use anyhow::Context;
 use bytesize::ByteSize;
@@ -19,10 +19,11 @@ use trustify_auth::{
     authenticator::Authenticator,
     authorizer::Authorizer,
     devmode::{FRONTEND_CLIENT_ID, ISSUER_URL, PUBLIC_CLIENT_IDS},
-    swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc, SwaggerUiOidcConfig},
+    swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig, swagger_ui_with_auth},
 };
 use trustify_common::{config::Database, db, model::BinaryByteSize};
 use trustify_infrastructure::{
+    Infrastructure, InfrastructureConfig, InitContext, Metrics,
     app::{
         http::{HttpServerBuilder, HttpServerConfig},
         new_auth,
@@ -30,7 +31,6 @@ use trustify_infrastructure::{
     endpoint::Trustify,
     health::checks::{Local, Probe},
     otel::Tracing,
-    Infrastructure, InfrastructureConfig, InitContext, Metrics,
 };
 use trustify_module_graphql::RootQuery;
 use trustify_module_importer::server::importer;
@@ -39,9 +39,9 @@ use trustify_module_storage::{
     config::{StorageConfig, StorageStrategy},
     service::{dispatch::DispatchBackend, fs::FileSystemBackend, s3::S3Backend},
 };
-use trustify_module_ui::{endpoints::UiResources, UI};
-use utoipa::openapi::{Info, License};
+use trustify_module_ui::{UI, endpoints::UiResources};
 use utoipa::OpenApi;
+use utoipa::openapi::{Info, License};
 use utoipa_rapidoc::RapiDoc;
 use utoipa_redoc::{Redoc, Servable};
 

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -6,8 +6,8 @@ use trustify_module_importer::model::{
 };
 use trustify_module_importer::{
     model::{
-        ClearlyDefinedCurationImporter, CommonImporter, CsafImporter, ImporterConfiguration,
-        OsvImporter, SbomImporter, DEFAULT_SOURCE_CLEARLY_DEFINED,
+        ClearlyDefinedCurationImporter, CommonImporter, CsafImporter,
+        DEFAULT_SOURCE_CLEARLY_DEFINED, ImporterConfiguration, OsvImporter, SbomImporter,
     },
     service::{Error, ImporterService},
 };

--- a/test-context/src/app.rs
+++ b/test-context/src/app.rs
@@ -1,6 +1,7 @@
 use actix_web::{
+    App,
     dev::{ServiceFactory, ServiceRequest},
-    web, App,
+    web,
 };
 use trustify_auth::authorizer::Authorizer;
 use utoipa_actix_web::UtoipaApp;

--- a/test-context/src/call.rs
+++ b/test-context/src/call.rs
@@ -1,13 +1,14 @@
 use actix_http::Request;
 use actix_web::{
+    App, Error,
     dev::{Service, ServiceResponse},
-    web, App, Error,
+    web,
 };
 use bytes::Bytes;
 use serde::de::DeserializeOwned;
 use std::future::Future;
 use trustify_auth::authorizer::Authorizer;
-use utoipa_actix_web::{service_config::ServiceConfig, AppExt};
+use utoipa_actix_web::{AppExt, service_config::ServiceConfig};
 
 /// A trait wrapping an `impl Service` in a way that we can pass it as a reference.
 pub trait CallService {

--- a/trustd/src/db.rs
+++ b/trustd/src/db.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 use trustify_common::config::Database;
 use trustify_common::db;
-use trustify_infrastructure::otel::{init_tracing, Tracing};
+use trustify_infrastructure::otel::{Tracing, init_tracing};
 
 #[derive(clap::Args, Debug)]
 pub struct Run {

--- a/trustd/src/main.rs
+++ b/trustd/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use std::env;
 use std::process::{ExitCode, Termination};
 use tokio::select;
-use tokio::task::{spawn_local, LocalSet};
+use tokio::task::{LocalSet, spawn_local};
 
 mod db;
 mod openapi;

--- a/trustd/src/openapi.rs
+++ b/trustd/src/openapi.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 use trustify_server::openapi::create_openapi;
 
 #[derive(clap::Args, Debug)]

--- a/xtask/src/dataset.rs
+++ b/xtask/src/dataset.rs
@@ -1,18 +1,18 @@
 use clap::Parser;
-use postgresql_commands::{pg_dump::PgDumpBuilder, CommandBuilder, CommandExecutor};
+use postgresql_commands::{CommandBuilder, CommandExecutor, pg_dump::PgDumpBuilder};
 use serde_json::Value;
 use std::{io::BufReader, path::PathBuf, time::Duration};
 use trustify_common::{db, model::BinaryByteSize};
 use trustify_module_importer::{
     model::{CommonImporter, CsafImporter, CveImporter, ImporterConfiguration, SbomImporter},
     runner::{
+        ImportRunner,
         context::RunContext,
         progress::{Progress, TracingProgress},
-        ImportRunner,
     },
 };
-use trustify_module_storage::service::fs::FileSystemBackend;
 use trustify_module_storage::service::Compression;
+use trustify_module_storage::service::fs::FileSystemBackend;
 
 #[derive(Debug, Parser)]
 pub struct GenerateDump {

--- a/xtask/src/log.rs
+++ b/xtask/src/log.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use tracing_subscriber::{
-    filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+    EnvFilter, filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
 pub fn init_log() -> anyhow::Result<()> {

--- a/xtask/src/openapi.rs
+++ b/xtask/src/openapi.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use clap::Parser;
 use std::env::current_dir;
 use std::{


### PR DESCRIPTION
This updates to Rust edition 2024. It's actually a requirement from PR https://github.com/trustification/trustify/pull/1326 where we use async closures. And while yes, we could do this without the new syntactic sugar, it is way simpler now. And less headaches.