### PR TITLE
fix: permission problem with containerized xtask dump

### DIFF
--- a/.github/scripts/Containerfile.xtask
+++ b/.github/scripts/Containerfile.xtask
@@ -24,4 +24,10 @@ RUN dnf install --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2
 
 COPY --from=builder /unpack/xtask /usr/local/bin
 
-ENTRYPOINT ["/usr/local/bin/xtask"]
+RUN useradd -ms /bin/bash trustify
+RUN chown -R trustify /usr/local/bin
+RUN chmod -R u+rwx /usr/local/bin
+USER trustify
+
+WORKDIR /usr/local/bin
+ENTRYPOINT ["./xtask"]


### PR DESCRIPTION
```console
➜  scripts git:(xtask-bug) ✗ podman run localhost/test-xtask generate-dump
2025-02-24T14:18:32.460442Z  INFO bootstrap: database "test" does not exist, skipping database=Database { url: None, username: "postgres", password: "trustify", host: "localhost", port: 34461, name: "test", max_conn: 75, min_conn: 25, sslmode: Prefer, connect_timeout: 8, acquire_timeout: 8, max_lifetime: 7200, idle_timeout: 600 }
2025-02-24T14:18:32.460497Z  INFO bootstrap: summary="DROP DATABASE IF EXISTS …" db.statement="\n\nDROP DATABASE IF EXISTS \"test\";\n" rows_affected=0 rows_returned=0 elapsed=853.207µs elapsed_secs=0.000853207 database=Database { url: None, username: "postgres", password: "trustify", host: "localhost", port: 34461, name: "test", max_conn: 75, min_conn: 25, sslmode: Prefer, connect_timeout: 8, acquire_timeout: 8, max_lifetime: 7200, idle_timeout: 600 }
2025-02-24T14:18:32.512331Z  INFO bootstrap: summary="CREATE DATABASE \"test\";" db.statement="" rows_affected=0 rows_returned=0 elapsed=35.899791ms elapsed_secs=0.035899791 database=Database { url: None, username: "postgres", password: "trustify", host: "localhost", port: 34461, name: "test", max_conn: 75, min_conn: 25, sslmode: Prefer, connect_timeout: 8, acquire_timeout: 8, max_lifetime: 7200, idle_timeout: 600 }
```

Related to #1330 