### PR TITLE
fix(terraform): only ensure the tag exists, don't require a value

### DIFF
--- a/docs/book/modules/admin/examples/trustify/database.tf
+++ b/docs/book/modules/admin/examples/trustify/database.tf
@@ -12,8 +12,9 @@ data "aws_subnets" "cluster-private" {
     name = "vpc-id"
     values = [data.aws_vpc.cluster.id]
   }
-  tags = {
-    "kubernetes.io/role/internal-elb" = ""
+  filter {
+    name   = "tag-key"
+    values = ["kubernetes.io/role/internal-elb"]
   }
 }
 


### PR DESCRIPTION
Before this change, we did check for the internal subnet by filtering for kubernetes.io/role/internal-elb having an empty value. That worked for cluster we set up in the past. However, it looks like newer clusters to have a value of "1" for this tag. This might come from openshift installers of a newer version.

As we don't require a specific value, but only look for the existence of the tag, this change perform this change. Allowing both variants.