### PR TITLE
build: add the AWS client to the xtask image

### DIFF
--- a/.github/scripts/Containerfile.xtask
+++ b/.github/scripts/Containerfile.xtask
@@ -20,14 +20,25 @@ LABEL \
     org.opencontainers.image.description="Trustify - xtask binary" \
     org.opencontainers.image.source="https://github.com/trustification/trustify"
 
-RUN dnf install --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2
+RUN dnf install --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2 unzip
 
 COPY --from=builder /unpack/xtask /usr/local/bin
+
+RUN \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install && \
+  rm -Rf aws
+
+# create a dedicated user
 
 RUN useradd -ms /bin/bash trustify
 RUN chown -R trustify /usr/local/bin
 RUN chmod -R u+rwx /usr/local/bin
+
 USER trustify
+
+# set the entrypoint
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["./xtask"]


### PR DESCRIPTION
The rationale behind that is, that we do create a dump with xtask, which we then upload to S3. Instead of having two pods run, and orchestrating a handover between those two, we simply install the AWS CLI into the image, so that we can use the S3 client.