### PR TITLE
fix: find analysis components by q=purl

### DIFF
--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -78,7 +78,7 @@ impl Query {
     /// Apply the query to a mapping of field names to values,
     /// returning true if the context is successfully matched by the
     /// query, by either a filter or a full-text search of all the
-    /// values of type Value::String.
+    /// values.
     pub fn apply(&self, context: &HashMap<&'static str, Value>) -> bool {
         use Operator::*;
         self.parse().iter().all(|c| match c {
@@ -103,7 +103,6 @@ impl Query {
                 ..
             } => context
                 .values()
-                .filter(|v| matches!(v, Value::String(_)))
                 .any(|field| vs.iter().any(|v| field.contains(v))),
             _ => false,
         })

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -393,10 +393,15 @@ impl AnalysisService {
                 })
             }
             GraphQuery::Query(query) => graph.node_weight(i).is_some_and(|node| {
+                let purls: Vec<_> = match node {
+                    graph::Node::Package(p) => p.purl.iter().map(|p| p.to_string()).collect(),
+                    _ => vec![],
+                };
                 let mut context = HashMap::from([
                     ("sbom_id", Value::String(&node.sbom_id)),
                     ("node_id", Value::String(&node.node_id)),
                     ("name", Value::String(&node.name)),
+                    ("purl", Value::from(&purls)),
                 ]);
                 match node {
                     graph::Node::Package(package) => {


### PR DESCRIPTION
Fixes #1280

This introduces a new variant of `Value` that may be used to apply queries to local structs containing _arrays_ of queryable terms.