### PR TITLE
chore: Remove unused internal dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8871,7 +8871,6 @@ dependencies = [
  "trustify-common",
  "trustify-infrastructure",
  "trustify-module-analysis",
- "trustify-module-importer",
  "trustify-server",
 ]
 

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 [dependencies]
 trustify-common = { workspace = true }
 trustify-module-analysis = { workspace = true }
-trustify-module-importer = { workspace = true }
 trustify-infrastructure = { workspace = true }
 trustify-server = { workspace = true }
 


### PR DESCRIPTION
Noticed that this is now part of the trustify-server crate. Removing unused internal dependency improves build speed, reduces cache usage in CI, and enhances the experience with rust-analyzer and the editor (though I don't have numbers to share).