### PR TITLE
fix: external sbom cdx example and tightened related tests

### DIFF
--- a/etc/test-data/cyclonedx/simple-ext-a.json
+++ b/etc/test-data/cyclonedx/simple-ext-a.json
@@ -91,7 +91,7 @@
     },
     {
       "ref": "a",
-      "dependsOn": ["urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#b"]
+      "dependsOn": ["urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#a"]
     }
   ]
 }

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -129,7 +129,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                     .node_indices()
                     .find(|&node| external_graph[node].node_id.eq(&external_node_id))
                 else {
-                    log::debug!("Node with ID {} not found", external_node_id);
+                    log::warn!("Node with ID {} not found", external_node_id);
                     // You can return early, log an error, or take other actions as needed
                     return None;
                 };
@@ -137,6 +137,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                 // process as normal, which is just non-DRY of following code block which we
                 // can optimise away.
                 log::debug!("external node index: {:?}", external_node_index);
+                log::debug!("external graph {:?}", external_graph);
 
                 Some(
                     self.with(external_graph, external_node_index)
@@ -151,7 +152,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
 
     pub async fn collect_graph(&self) -> Vec<Node> {
         let mut result = vec![];
-
+        log::debug!("Collecting graph for {:?}", self.node);
         for edge in self.graph.edges_directed(self.node, self.direction) {
             log::debug!("edge {edge:?}");
 

--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -695,7 +695,7 @@ async fn resolve_sbom_external_node_sbom(ctx: &TrustifyContext) -> Result<(), an
     // ingest cdx example
     ctx.ingest_document("cyclonedx/simple-ext-a.json").await?;
     let get_external_sbom = resolve_external_sbom(
-        "urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#b".to_string(),
+        "urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#a".to_string(),
         &ctx.db,
     )
     .await;
@@ -703,7 +703,7 @@ async fn resolve_sbom_external_node_sbom(ctx: &TrustifyContext) -> Result<(), an
     // now ingest cdx sbom referred in "cyclonedx/simple-ext-b.json"
     ctx.ingest_document("cyclonedx/simple-ext-b.json").await?;
     let get_external_sbom = resolve_external_sbom(
-        "urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#b".to_string(),
+        "urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#a".to_string(),
         &ctx.db,
     )
     .await;
@@ -713,7 +713,7 @@ async fn resolve_sbom_external_node_sbom(ctx: &TrustifyContext) -> Result<(), an
         node_id: external_node_id,
     }) = get_external_sbom
     {
-        assert_eq!(external_node_id, "b");
+        assert_eq!(external_node_id, "a");
     }
 
     // now try spdx example

--- a/modules/fundamental/tests/sbom/cyclonedx/external/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/external/mod.rs
@@ -20,7 +20,7 @@ async fn simple_ext_1(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let results = sbom_external_node::Entity::find()
         .filter(
             sbom_external_node::Column::NodeId
-                .eq("urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#b"),
+                .eq("urn:cdx:a4f16b62-fea9-42c1-8365-d72d3cef37d1/2#a"),
         )
         .all(&ctx.db)
         .await?;
@@ -33,7 +33,7 @@ async fn simple_ext_1(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         results[0].external_doc_ref,
         "a4f16b62-fea9-42c1-8365-d72d3cef37d1".to_string()
     );
-    assert_eq!(results[0].external_node_ref, "b".to_string());
+    assert_eq!(results[0].external_node_ref, "a".to_string());
     assert_eq!(results[0].discriminator_value, Some("2".to_string()));
 
     Ok(())


### PR DESCRIPTION
Fixed external sbom cdx test - uncommented test and tightened them using the handy `response.contains_subset(json!({` idiom.