### PR TITLE
feat: filter components by partial matches of a purl and/or cpe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8392,6 +8392,7 @@ dependencies = [
  "tracing",
  "trustify-migration",
  "trustify-test-context",
+ "urlencoding",
  "utoipa",
  "uuid",
  "walker-common",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["url"] }
 uuid = { workspace = true, features = ["v5", "serde"] }
 walker-common = { workspace = true, features = ["bzip2", "liblzma"]}

--- a/common/src/cpe.rs
+++ b/common/src/cpe.rs
@@ -9,6 +9,7 @@ use serde::{
 };
 use std::{
     borrow::Cow,
+    cmp::Ordering,
     fmt::{Debug, Display, Formatter},
     str::FromStr,
 };
@@ -59,6 +60,27 @@ impl<'de> Deserialize<'de> for Cpe {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_str(CpeVisitor)
+    }
+}
+
+impl crate::db::query::Value for Cpe {
+    fn like(&self, other: &str) -> bool {
+        match Cpe::from_str(other) {
+            Ok(cpe) => cpe.uri.is_superset(&self.uri),
+            _ => self.to_string().contains(other),
+        }
+    }
+    fn compare(&self, other: &str) -> Option<Ordering> {
+        match Cpe::from_str(other) {
+            Ok(cpe) => {
+                if self.eq(&cpe) {
+                    Some(Ordering::Equal)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 }
 

--- a/common/src/db/query/filter.rs
+++ b/common/src/db/query/filter.rs
@@ -41,8 +41,8 @@ impl TryFrom<(&str, Operator, &Vec<String>, &Columns)> for Filter {
                     .map(
                         |s| match columns.translate(field, &operator.to_string(), s) {
                             Some(x) => q(&x).filter_for(columns),
-                            None => columns.for_field(field).and_then(|(expr, col_def)| {
-                                Arg::parse(s, col_def.get_column_type()).map(|v| Filter {
+                            None => columns.for_field(field).and_then(|(expr, ref ty)| {
+                                Arg::parse(s, ty).map(|v| Filter {
                                     operands: Operand::Simple(expr, v),
                                     operator,
                                 })

--- a/modules/analysis/src/endpoints/tests/mod.rs
+++ b/modules/analysis/src/endpoints/tests/mod.rs
@@ -364,7 +364,9 @@ async fn find_component_by_query(ctx: &TrustifyContext) -> Result<(), anyhow::Er
         "cpe~cpe:/a:redhat:quarkus:3.2::el8",
         "cpe~cpe:/a:redhat:quarkus:3.2",
         "cpe~cpe:/a::quarkus",
-        "cpe~redhat",
+        "cpe~redhat",                  // invalid CPE results in a full-text search
+        "purl~quarkus-bom&cpe~redhat", // essentially the same as `quarkus|redhat`
+        "purl~quarkus-bom&cpe~cpe:/a:redhat", // valid CPE so no full-text search
     ] {
         assert!(by_query(&app, each).await.contains_subset(json!({
             "items": [{

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -425,31 +425,22 @@ impl AnalysisService {
                 })
             }
             GraphQuery::Query(query) => graph.node_weight(i).is_some_and(|node| {
-                let purls: Vec<_> = match node {
-                    graph::Node::Package(p) => p.purl.iter().map(|p| p.to_string()).collect(),
-                    _ => vec![],
-                };
-                let mut context = HashMap::from([
-                    ("sbom_id", Value::String(&node.sbom_id)),
-                    ("node_id", Value::String(&node.node_id)),
-                    ("name", Value::String(&node.name)),
-                    ("purl", Value::from(&purls)),
-                ]);
+                let mut context: HashMap<&str, Box<&dyn Value>> = HashMap::new();
+                context.insert("sbom_id", Box::new(&node.sbom_id));
+                context.insert("node_id", Box::new(&node.node_id));
+                context.insert("name", Box::new(&node.name));
                 match node {
                     graph::Node::Package(package) => {
-                        context.extend([("version", Value::String(&package.version))]);
+                        context.insert("version", Box::new(&package.version));
+                        context.insert("purl", Box::new(&package.purl));
+                        context.insert("cpe", Box::new(&package.cpe));
                     }
                     graph::Node::External(external) => {
-                        context.extend([
-                            (
-                                "external_document_reference",
-                                Value::String(&external.external_document_reference),
-                            ),
-                            (
-                                "external_node_id",
-                                Value::String(&external.external_node_id),
-                            ),
-                        ]);
+                        context.insert(
+                            "external_document_reference",
+                            Box::new(&external.external_document_reference),
+                        );
+                        context.insert("external_node_id", Box::new(&external.external_node_id));
                     }
                     _ => {}
                 }

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -7,7 +7,7 @@ use sea_orm::{
     EntityTrait, FromQueryResult, IntoActiveModel, IntoIdentity, QueryResult, QuerySelect,
     QueryTrait, RelationTrait, Select, Statement, TransactionTrait,
 };
-use sea_query::{ColumnRef, ColumnType, Expr, Func, IntoColumnRef, IntoIden, JoinType, SimpleExpr};
+use sea_query::{ColumnRef, ColumnType, Expr, Func, IntoIden, JoinType, SimpleExpr};
 use trustify_common::{
     db::{
         Database, UpdateDeprecatedAdvisory,
@@ -50,18 +50,10 @@ impl AdvisoryService {
         let inner_query = advisory::Entity::find()
             .with_deprecation(deprecation)
             .left_join(cvss3::Entity)
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                    cvss3::Column::Score.into_column_ref(),
-                ))),
-                "average_score",
-            )
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::cust("cvss3_severity".into_identity()).arg(
-                    SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                        cvss3::Column::Score.into_column_ref(),
-                    ))),
-                )),
+            .expr_as(Func::avg(Expr::col(cvss3::Column::Score)), "average_score")
+            .expr_as(
+                Func::cust("cvss3_severity".into_identity())
+                    .arg(Func::avg(Expr::col(cvss3::Column::Score))),
                 "average_severity",
             )
             .group_by(advisory::Column::Id);
@@ -143,18 +135,10 @@ impl AdvisoryService {
         // the original underlying table it expects the entity to live in.
         let inner_query = advisory::Entity::find()
             .left_join(cvss3::Entity)
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                    cvss3::Column::Score.into_column_ref(),
-                ))),
-                "average_score",
-            )
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::cust("cvss3_severity".into_identity()).arg(
-                    SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                        cvss3::Column::Score.into_column_ref(),
-                    ))),
-                )),
+            .expr_as(Func::avg(Expr::col(cvss3::Column::Score)), "average_score")
+            .expr_as(
+                Func::cust("cvss3_severity".into_identity())
+                    .arg(Func::avg(Expr::col(cvss3::Column::Score))),
                 "average_severity",
             )
             .group_by(advisory::Column::Id);

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
 };
 use sea_orm::{EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait, prelude::*};
-use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
+use sea_query::{ColumnRef, Func, IntoIden, SimpleExpr};
 use trustify_common::{
     db::{
         limiter::LimiterAsModelTrait,
@@ -35,18 +35,13 @@ impl VulnerabilityService {
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
         let inner_query = vulnerability::Entity::find()
             .left_join(cvss3::Entity)
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                    trustify_entity::cvss3::Column::Score.into_column_ref(),
-                ))),
+            .expr_as(
+                Func::avg(Expr::col(trustify_entity::cvss3::Column::Score)),
                 "average_score",
             )
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::cust("cvss3_severity".into_identity()).arg(
-                    SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                        trustify_entity::cvss3::Column::Score.into_column_ref(),
-                    ))),
-                )),
+            .expr_as(
+                Func::cust("cvss3_severity".into_identity())
+                    .arg(Func::avg(Expr::col(trustify_entity::cvss3::Column::Score))),
                 "average_severity",
             )
             .group_by(vulnerability::Column::Id);


### PR DESCRIPTION
Fixes #1280

This required translating CPE queries to their constituent fields in the CPE table.

We converted query::Value from an enum to a trait to query both purl's and cpe's because simple string comparisons won't cut it for both the loading of relevant objects *and* the comparisons within the analysis graph.

So we delegate the comparison logic to the disparate objects being queried -- each must now implement the Value trait and corresponding trait objects are then used to find matches. 