### PR TITLE
fix: improve performance of sbom/advisory endpoint

### DIFF
--- a/etc/datasets/ds3/csaf/2024/cve-2024-28834.json
+++ b/etc/datasets/ds3/csaf/2024/cve-2024-28834.json
@@ -1,0 +1,12198 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Moderate"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-28834.json"
+      }
+    ],
+    "title": "gnutls: vulnerable to Minerva side-channel information leak",
+    "tracking": {
+      "current_release_date": "2025-01-07T01:43:37+00:00",
+      "generator": {
+        "date": "2025-01-07T01:43:37+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "4.2.5"
+        }
+      },
+      "id": "CVE-2024-28834",
+      "initial_release_date": "2024-03-21T00:00:00+00:00",
+      "revision_history": [
+        {
+          "date": "2024-03-21T00:00:00+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-11-19T20:07:16+00:00",
+          "number": "2",
+          "summary": "Current version"
+        },
+        {
+          "date": "2025-01-07T01:43:37+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 6",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 6",
+                  "product_id": "red_hat_enterprise_linux_6",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:6"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 6"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 7",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 7",
+                  "product_id": "red_hat_enterprise_linux_7",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 7"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+                  "product_id": "AppStream-9.2.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_eus:9.2::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+                  "product_id": "BaseOS-9.2.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_eus:9.2::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                  "product_id": "AppStream-9.4.0.Z.MAIN.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                  "product_id": "BaseOS-9.4.0.Z.MAIN.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_eus:8.6::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+                  "product_id": "BaseOS-8.6.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_eus:8.6::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+                  "product_id": "AppStream-8.8.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_eus:8.8::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+                  "product_id": "BaseOS-8.8.0.Z.EUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_eus:8.8::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream (v. 9)",
+                  "product_id": "AppStream-9.3.0.Z.MAIN",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:9::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS (v. 9)",
+                  "product_id": "BaseOS-9.3.0.Z.MAIN",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9::baseos"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream (v. 8)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream (v. 8)",
+                  "product_id": "AppStream-8.9.0.Z.MAIN",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:enterprise_linux:8::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux BaseOS (v. 8)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux BaseOS (v. 8)",
+                  "product_id": "BaseOS-8.9.0.Z.MAIN",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:8::baseos"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux"
+          },
+          {
+            "category": "product_version",
+            "name": "gnutls",
+            "product": {
+              "name": "gnutls",
+              "product_id": "gnutls",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/gnutls?arch=src"
+              }
+            }
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.aarch64",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_id": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-5.el8_6.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.aarch64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=aarch64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "aarch64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.ppc64le",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_id": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-5.el8_6.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=ppc64le"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64le"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.i686",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.i686",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-c++-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-dane-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-devel-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.i686",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.i686",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+                  "product_id": "gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-5.el8_6.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.i686",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.i686",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.i686",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.i686",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.i686",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.i686",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=i686"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "i686"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.x86_64",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_id": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-5.el8_6.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.x86_64",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=x86_64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.s390x",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.s390x",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-c++-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-dane-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-devel-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-utils-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.s390x",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.s390x",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+                  "product_id": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-5.el8_6.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.s390x",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.s390x",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.s390x",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.s390x",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-devel@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debugsource@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-c%2B%2B-debuginfo@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-dane-debuginfo@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-debuginfo@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls-utils-debuginfo@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.s390x",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.s390x",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=s390x"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "s390x"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-21.el9_2.3.src",
+                "product": {
+                  "name": "gnutls-0:3.7.6-21.el9_2.3.src",
+                  "product_id": "gnutls-0:3.7.6-21.el9_2.3.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-21.el9_2.3?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.8.3-4.el9_4.src",
+                "product": {
+                  "name": "gnutls-0:3.8.3-4.el9_4.src",
+                  "product_id": "gnutls-0:3.8.3-4.el9_4.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-5.el8_6.4.src",
+                "product": {
+                  "name": "gnutls-0:3.6.16-5.el8_6.4.src",
+                  "product_id": "gnutls-0:3.6.16-5.el8_6.4.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-5.el8_6.4?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-7.el8_8.3.src",
+                "product": {
+                  "name": "gnutls-0:3.6.16-7.el8_8.3.src",
+                  "product_id": "gnutls-0:3.6.16-7.el8_8.3.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-7.el8_8.3?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.7.6-23.el9_3.4.src",
+                "product": {
+                  "name": "gnutls-0:3.7.6-23.el9_3.4.src",
+                  "product_id": "gnutls-0:3.7.6-23.el9_3.4.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.7.6-23.el9_3.4?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "gnutls-0:3.6.16-8.el8_9.3.src",
+                "product": {
+                  "name": "gnutls-0:3.6.16-8.el8_9.3.src",
+                  "product_id": "gnutls-0:3.6.16-8.el8_9.3.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=src"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.src as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.src as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.src",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.8.8)",
+          "product_id": "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.src as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.src",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 8)",
+          "product_id": "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "AppStream-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.src as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.src",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux AppStream EUS (v.9.2)",
+          "product_id": "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "AppStream-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.src as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.src",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "AppStream-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.src as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.src",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux AppStream (v. 9)",
+          "product_id": "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "AppStream-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.src as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.src",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.6)",
+          "product_id": "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+        "relates_to_product_reference": "BaseOS-8.6.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.src as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.src",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.8.8)",
+          "product_id": "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.8.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.src as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.src",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 8)",
+          "product_id": "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+        "relates_to_product_reference": "BaseOS-8.9.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.src as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.src",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64 as a component of Red Hat Enterprise Linux BaseOS EUS (v.9.2)",
+          "product_id": "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+        "relates_to_product_reference": "BaseOS-9.2.0.Z.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.src as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.src",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.3.0.Z.MAIN"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.src as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.src",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-devel-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64 as a component of Red Hat Enterprise Linux BaseOS (v. 9)",
+          "product_id": "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        },
+        "product_reference": "gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+        "relates_to_product_reference": "BaseOS-9.4.0.Z.MAIN.EUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:gnutls"
+        },
+        "product_reference": "gnutls",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "gnutls as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:gnutls"
+        },
+        "product_reference": "gnutls",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-28834",
+      "cwe": {
+        "id": "CWE-327",
+        "name": "Use of a Broken or Risky Cryptographic Algorithm"
+      },
+      "discovery_date": "2024-03-11T00:00:00+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2269228"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in GnuTLS. The Minerva attack is a cryptographic vulnerability that exploits deterministic behavior in systems like GnuTLS, leading to side-channel leaks. In specific scenarios, such as when using the GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE flag, it can result in a noticeable step in nonce size from 513 to 512 bits, exposing a potential timing side-channel.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "gnutls: vulnerable to Minerva side-channel information leak",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "The Minerva attack vulnerability in GnuTLS, as identified through deterministic code behavior, poses a moderate severity risk due to its potential exploitation in cryptographic systems. This vulnerability enables adversaries to infer information about the cryptographic operations by observing subtle variations in nonce sizes, leading to a side-channel attack. The deterministic nature of the code allows attackers to discern patterns in the nonce generation process, thereby compromising the confidentiality and integrity of cryptographic communications. While the impact of this vulnerability may not be immediate or widespread, its exploitation could facilitate targeted attacks against systems relying on GnuTLS for secure communication.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+          "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+          "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+          "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+          "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+          "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+          "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+          "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+          "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+          "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+          "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+          "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+          "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+          "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+          "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64"
+        ],
+        "known_affected": [
+          "red_hat_enterprise_linux_6:gnutls",
+          "red_hat_enterprise_linux_7:gnutls"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-28834"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2269228",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2269228"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-28834",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-28834"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-28834",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-28834"
+        },
+        {
+          "category": "external",
+          "summary": "https://lists.gnupg.org/pipermail/gnutls-help/2024-March/004845.html",
+          "url": "https://lists.gnupg.org/pipermail/gnutls-help/2024-March/004845.html"
+        },
+        {
+          "category": "external",
+          "summary": "https://minerva.crocs.fi.muni.cz/",
+          "url": "https://minerva.crocs.fi.muni.cz/"
+        }
+      ],
+      "release_date": "2024-03-21T00:00:00+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "date": "2024-04-25T01:28:21+00:00",
+          "details": "For details on how to apply this update, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:2044"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2024-04-23T14:42:53+00:00",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:1997"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2024-04-11T16:09:35+00:00",
+          "details": "Before applying this update, make sure all previously released errata\nrelevant to your system have been applied.\n\nFor details on how to apply this update, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:1784"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2024-05-16T18:20:27+00:00",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:2889"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2024-04-18T02:25:53+00:00",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:1879"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2024-04-30T13:43:46+00:00",
+          "details": "Before applying this update, make sure all previously released errata\nrelevant to your system have been applied.\n\nFor details on how to apply this update, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2024:2570"
+        },
+        {
+          "category": "workaround",
+          "details": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+          "product_ids": [
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "red_hat_enterprise_linux_6:gnutls",
+            "red_hat_enterprise_linux_7:gnutls"
+          ]
+        },
+        {
+          "category": "no_fix_planned",
+          "details": "Out of support scope",
+          "product_ids": [
+            "red_hat_enterprise_linux_6:gnutls",
+            "red_hat_enterprise_linux_7:gnutls"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "red_hat_enterprise_linux_6:gnutls",
+            "red_hat_enterprise_linux_7:gnutls"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "AppStream-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "AppStream-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "AppStream-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "AppStream-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "AppStream-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "AppStream-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "AppStream-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "AppStream-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "AppStream-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "AppStream-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "AppStream-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.src",
+            "BaseOS-8.6.0.Z.EUS:gnutls-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-debugsource-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-devel-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.aarch64",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.i686",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.ppc64le",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.s390x",
+            "BaseOS-8.6.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-5.el8_6.4.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.src",
+            "BaseOS-8.8.0.Z.EUS:gnutls-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-c++-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-dane-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-debugsource-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-devel-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.aarch64",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.i686",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.ppc64le",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.s390x",
+            "BaseOS-8.8.0.Z.EUS:gnutls-utils-debuginfo-0:3.6.16-7.el8_8.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.src",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-c++-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-dane-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-debugsource-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-devel-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.aarch64",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.i686",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.ppc64le",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.s390x",
+            "BaseOS-8.9.0.Z.MAIN:gnutls-utils-debuginfo-0:3.6.16-8.el8_9.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.src",
+            "BaseOS-9.2.0.Z.EUS:gnutls-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-c++-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-dane-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-debugsource-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-devel-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.aarch64",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.i686",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.ppc64le",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.s390x",
+            "BaseOS-9.2.0.Z.EUS:gnutls-utils-debuginfo-0:3.7.6-21.el9_2.3.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.src",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-c++-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-dane-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-debugsource-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-devel-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.aarch64",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.i686",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.ppc64le",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.s390x",
+            "BaseOS-9.3.0.Z.MAIN:gnutls-utils-debuginfo-0:3.7.6-23.el9_3.4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.src",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-c++-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-dane-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-debugsource-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-devel-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-0:3.8.3-4.el9_4.x86_64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.aarch64",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.i686",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.ppc64le",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.s390x",
+            "BaseOS-9.4.0.Z.MAIN.EUS:gnutls-utils-debuginfo-0:3.8.3-4.el9_4.x86_64",
+            "red_hat_enterprise_linux_6:gnutls",
+            "red_hat_enterprise_linux_7:gnutls"
+          ]
+        }
+      ],
+      "title": "gnutls: vulnerable to Minerva side-channel information leak"
+    }
+  ]
+}

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use cpe::{cpe::Cpe, uri::OwnedUri};
 use sea_orm::{
-    Condition, ConnectionTrait, DbBackend, FromQueryResult, JoinType,
-    ModelTrait, QueryFilter, QueryResult, QuerySelect, RelationTrait, Statement,
+    Condition, ConnectionTrait, DbBackend, FromQueryResult, JoinType, ModelTrait, QueryFilter,
+    QueryResult, QuerySelect, RelationTrait, Statement,
 };
 use sea_query::Query;
 use sea_query::{Asterisk, Expr, Func, SimpleExpr};
@@ -20,17 +20,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use trustify_common::{
     cpe::CpeCompare,
-    db::{
-        VersionMatches,
-        multi_model::SelectIntoMultiModel,
-    },
+    db::{VersionMatches, multi_model::SelectIntoMultiModel},
     memo::Memo,
 };
 use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
 use trustify_entity::{
-    advisory, advisory_vulnerability, base_purl, cvss3,
-    purl_status, qualified_purl, sbom, sbom_node, sbom_package, sbom_package_cpe_ref,
-    sbom_package_purl_ref, status, version_range, versioned_purl, vulnerability,
+    advisory, advisory_vulnerability, base_purl, cvss3, purl_status, qualified_purl, sbom,
+    sbom_node, sbom_package, sbom_package_cpe_ref, sbom_package_purl_ref, status, version_range,
+    versioned_purl, vulnerability,
 };
 use utoipa::ToSchema;
 
@@ -71,6 +68,7 @@ impl SbomDetails {
                 .filter(Expr::col((status::Entity, status::Column::Slug)).is_in(statuses.clone()));
         }
 
+        // find all the CPEs associated with this SBOM
         let subquery = Query::select()
             .column(sbom_package_cpe_ref::Column::CpeId)
             .from(sbom_package_cpe_ref::Entity)
@@ -394,10 +392,7 @@ impl SbomStatus {
         packages: Vec<SbomPackage>,
         tx: &C,
     ) -> Result<Self, Error> {
-        let cvss3 = advisory_vulnerability
-            .find_related(cvss3::Entity)
-            .all(tx)
-            .await?;
+        let cvss3 = vulnerability.find_related(cvss3::Entity).all(tx).await?;
         let average_severity = Score::from_iter(cvss3.iter().map(Cvss3Base::from)).severity();
         Ok(Self {
             vulnerability: VulnerabilityHead::from_advisory_vulnerability_entity(

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -102,7 +102,7 @@ impl SbomDetails {
             ))
             .join(JoinType::LeftJoin, purl_status::Relation::ContextCpe.def())
             .join(JoinType::Join, purl_status::Relation::Advisory.def())
-            .join(JoinType::Join, advisory::Relation::Issuer.def())
+            .join(JoinType::LeftJoin, advisory::Relation::Issuer.def())
             .join(
                 JoinType::Join,
                 purl_status::Relation::AdvisoryVulnerability.def(),
@@ -205,7 +205,7 @@ impl SbomDetails {
             -- get basic status info
             JOIN "status" ON "product_status"."status_id" = "status"."id"
             JOIN "advisory" ON "product_status"."advisory_id" = "advisory"."id"
-            JOIN "organization" ON "advisory"."issuer_id" = "organization"."id"
+            LEFT JOIN "organization" ON "advisory"."issuer_id" = "organization"."id"
             JOIN "advisory_vulnerability" ON "product_status"."advisory_id" = "advisory_vulnerability"."advisory_id"
             AND "product_status"."vulnerability_id" = "advisory_vulnerability"."vulnerability_id"
             JOIN "vulnerability" ON "advisory_vulnerability"."vulnerability_id" = "vulnerability"."id"
@@ -307,7 +307,7 @@ impl SbomAdvisory {
                     SbomAdvisory {
                         head: AdvisoryHead::from_advisory(
                             &each.advisory,
-                            Memo::Provided(Some(each.organization.clone())),
+                            Memo::Provided(each.organization.clone()),
                             tx,
                         )
                         .await?,

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -32,7 +32,7 @@ use trustify_entity::{
     advisory, base_purl,
     cpe::{self, CpeDto},
     labels::Labels,
-    package_relates_to_package,
+    organization, package_relates_to_package,
     qualified_purl::{self, CanonicalPurl, Qualifiers},
     relationship::Relationship,
     sbom::{self, SbomNodeLink},
@@ -663,6 +663,7 @@ pub struct QueryCatcher {
     pub vulnerability: vulnerability::Model,
     pub context_cpe: Option<cpe::Model>,
     pub status: status::Model,
+    pub organization: organization::Model,
 }
 
 impl FromQueryResult for QueryCatcher {
@@ -677,6 +678,7 @@ impl FromQueryResult for QueryCatcher {
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
             context_cpe: Self::from_query_result_multi_model_optional(res, "", cpe::Entity)?,
             status: Self::from_query_result_multi_model(res, "", status::Entity)?,
+            organization: Self::from_query_result_multi_model(res, "", organization::Entity)?,
         })
     }
 }
@@ -692,7 +694,8 @@ impl FromQueryResultMultiModel for QueryCatcher {
             .try_model_columns(sbom_package::Entity)?
             .try_model_columns(sbom_node::Entity)?
             .try_model_columns(status::Entity)?
-            .try_model_columns(cpe::Entity)
+            .try_model_columns(cpe::Entity)?
+            .try_model_columns(organization::Entity)
     }
 }
 

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -664,7 +664,7 @@ pub struct QueryCatcher {
     pub vulnerability: vulnerability::Model,
     pub context_cpe: Option<cpe::Model>,
     pub status: status::Model,
-    pub organization: organization::Model,
+    pub organization: Option<organization::Model>,
 }
 
 impl FromQueryResult for QueryCatcher {
@@ -684,7 +684,7 @@ impl FromQueryResult for QueryCatcher {
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
             context_cpe: Self::from_query_result_multi_model_optional(res, "", cpe::Entity)?,
             status: Self::from_query_result_multi_model(res, "", status::Entity)?,
-            organization: Self::from_query_result_multi_model(res, "", organization::Entity)?,
+            organization: Self::from_query_result_multi_model_optional(res, "", organization::Entity)?,
         })
     }
 }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -684,7 +684,11 @@ impl FromQueryResult for QueryCatcher {
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
             context_cpe: Self::from_query_result_multi_model_optional(res, "", cpe::Entity)?,
             status: Self::from_query_result_multi_model(res, "", status::Entity)?,
-            organization: Self::from_query_result_multi_model_optional(res, "", organization::Entity)?,
+            organization: Self::from_query_result_multi_model_optional(
+                res,
+                "",
+                organization::Entity,
+            )?,
         })
     }
 }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -29,7 +29,7 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
 };
 use trustify_entity::{
-    advisory, base_purl,
+    advisory, advisory_vulnerability, base_purl,
     cpe::{self, CpeDto},
     labels::Labels,
     organization, package_relates_to_package,
@@ -660,6 +660,7 @@ pub struct QueryCatcher {
     pub qualified_purl: qualified_purl::Model,
     pub sbom_package: sbom_package::Model,
     pub sbom_node: sbom_node::Model,
+    pub advisory_vulnerability: advisory_vulnerability::Model,
     pub vulnerability: vulnerability::Model,
     pub context_cpe: Option<cpe::Model>,
     pub status: status::Model,
@@ -670,6 +671,11 @@ impl FromQueryResult for QueryCatcher {
     fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
         Ok(Self {
             advisory: Self::from_query_result_multi_model(res, "", advisory::Entity)?,
+            advisory_vulnerability: Self::from_query_result_multi_model(
+                res,
+                "",
+                advisory_vulnerability::Entity,
+            )?,
             vulnerability: Self::from_query_result_multi_model(res, "", vulnerability::Entity)?,
             base_purl: Self::from_query_result_multi_model(res, "", base_purl::Entity)?,
             versioned_purl: Self::from_query_result_multi_model(res, "", versioned_purl::Entity)?,
@@ -687,6 +693,7 @@ impl FromQueryResultMultiModel for QueryCatcher {
     fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr> {
         select
             .try_model_columns(advisory::Entity)?
+            .try_model_columns(advisory_vulnerability::Entity)?
             .try_model_columns(vulnerability::Entity)?
             .try_model_columns(base_purl::Entity)?
             .try_model_columns(versioned_purl::Entity)?

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -88,7 +88,7 @@ impl VulnerabilityHead {
         ))
     }
 
-    fn from_vulnerability_entity_and_description(
+    pub fn from_vulnerability_entity_and_description(
         entity: &vulnerability::Model,
         description: Option<String>,
     ) -> Self {
@@ -117,9 +117,9 @@ impl VulnerabilityHead {
             title: advisory_vulnerability.title.clone(),
             description: advisory_vulnerability.description.clone(),
             reserved: advisory_vulnerability.reserved_date,
-            published: None,
-            modified: None,
-            withdrawn: None,
+            published: vuln.published,
+            modified: vuln.modified,
+            withdrawn: vuln.withdrawn,
             discovered: advisory_vulnerability.discovery_date,
             released: advisory_vulnerability.release_date,
             cwes: advisory_vulnerability.cwes.clone().unwrap_or_default(),

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -56,7 +56,7 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     log::info!("ingest: {}", humantime::Duration::from(ingest_time));
 
     assert!(result.warnings.is_empty());
-    assert_eq!(result.files.len(), 67);
+    assert_eq!(result.files.len(), 68);
 
     // get a document
 
@@ -121,13 +121,13 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     assert!(ubi_details.is_some());
     let ubi_details = ubi_details.unwrap();
     let ubi_advisories = ubi_details.advisories;
-    assert_eq!(ubi_advisories.len(), 2);
+    assert_eq!(ubi_advisories.len(), 1);
     assert!(
         ubi_advisories
             .iter()
             .map(|adv| adv.head.document_id.clone())
             .collect::<Vec<_>>()
-            .contains(&"CVE-2024-50602".to_string())
+            .contains(&"CVE-2024-28834".to_string())
     );
 
     // done


### PR DESCRIPTION
This PR improves fetching vulnerabilities for SBOM, by improving two things:
- Pre-selecting CPEs related to the SBOM and using them in a query. This significantly improves the performance of the query in large datasets.
- Fetching missing data directly in the query, instead of running separate queries in the post-query loop. Querying things in the loop can be costly when dealing with large number of rows. This is now done for advisory issuer organisation and vulnerability description.

With these two changes the speed of the endpoint for ds4 on a laptop is increased tenfold

```
before
________________________________________________________
Executed in  276.15 secs    fish           external
   usr time    3.24 secs    0.10 millis    3.24 secs
   sys time    0.42 secs    1.36 millis    0.42 secs

after
________________________________________________________
Executed in   28.02 secs    fish           external
   usr time    2.44 secs    0.08 millis    2.44 secs
   sys time    0.39 secs    1.11 millis    0.39 secs   
```

and it makes ds4 quite usable even in the local environment.

This is just a first step in optimizing this endpoint without doing big refactoring and API changes.

Two things that needs to be addressed further:

- We still calculate score for each vulnerability in a loop which is inefficient in all cases, but especially when we are dealing with hundreds or thousands of vulnerabilities. I think this is the first case where we would want to introduce some kind of pre-processing of data and caching.
- The logic for getting all CPEs related to SBOM is a bit crude at the moment. For example, it will not cover the cases of supersets. It needs more work to filter all these CPEs properly in the future. So far I haven't found an advisory that will be affected by this.

Both of these should be addressed in separate issues.