### PR TITLE
fix: imageindex>imagevariant external sboms

### DIFF
--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_index.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_index.json
@@ -18,6 +18,7 @@
       ]
     },
     "component": {
+      "bom-ref": "pkg:oci/openshift-ose-openstack-cinder-csi-driver-operator@sha256%3A4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8",
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/openshift-ose-openstack-cinder-csi-driver-operator@sha256%3A4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8",
       "type": "container",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
@@ -18,7 +18,6 @@
       ]
     },
     "component": {
-      "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_arm64",
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256%3A0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f?arch=arm64&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8",
       "type": "container"

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imageindex_quarkus_mandrel.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imageindex_quarkus_mandrel.json
@@ -1,0 +1,97 @@
+{
+  "version": 1,
+  "metadata": {
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "b6cff18d"
+        }
+      ]
+    },
+    "component": {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/quarkus-mandrel-for-jdk-21-rhel8@sha256%3A04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/quarkus-mandrel-for-jdk-21-rhel8@sha256%3A04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a"
+    },
+    "timestamp": "2025-02-17T02:40:50Z"
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/quarkus-mandrel-for-jdk-21-rhel8@sha256%3A04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a",
+      "type": "container",
+      "bom-ref": "quarkus-mandrel-231-rhel8-container_image-index",
+      "version": "sha256:04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a",
+      "pedigree": {
+        "variants": [
+          {
+            "name": "quarkus/mandrel-for-jdk-21-rhel8",
+            "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da?arch=amd64&os=linux&tag=23.1-19.1739757566",
+            "type": "container",
+            "bom-ref": "quarkus-mandrel-231-rhel8-container_amd64",
+            "version": "sha256:6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "quarkus/mandrel-for-jdk-21-rhel8",
+            "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2?arch=arm64&os=linux&tag=23.1-19.1739757566",
+            "type": "container",
+            "bom-ref": "quarkus-mandrel-231-rhel8-container_arm64",
+            "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "quarkus-mandrel-231-rhel8-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "quarkus/mandrel-for-jdk-21-rhel8"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "19.1739757566"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "23.1"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:8262934b-6d8f-30a7-a216-d933ded97451"
+}

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
@@ -1,0 +1,19737 @@
+{
+  "version": 1,
+  "metadata": {
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.16.0"
+        }
+      ]
+    },
+    "component": {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da?arch=amd64&os=linux&tag=23.1-19.1739757566",
+      "type": "container",
+      "properties": [
+        {
+          "name": "errata-tool-product-name",
+          "value": "RHBQ"
+        },
+        {
+          "name": "errata-tool-product-version",
+          "value": "RHEL-8-RHBQ-3.8"
+        },
+        {
+          "name": "errata-tool-product-variant",
+          "value": "8Base-RHBQ-3.8"
+        }
+      ]
+    },
+    "timestamp": "2025-02-17T02:39:46Z"
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da?arch=amd64&os=linux&tag=23.1-19.1739757566",
+      "type": "container",
+      "bom-ref": "1c4abceaa349a8c2",
+      "version": "sha256:6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "72f7a5ed37f428182ee76cde302ea3300ddc96e9",
+            "url": "https://pkgs.devel.redhat.com/git/containers/quarkus-mandrel#72f7a5ed37f428182ee76cde302ea3300ddc96e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-02-17T02:00:15"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "quarkus-mandrel-231-rhel8-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/en/about/agreements#quarkus"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Quarkus Native builder image (version 23.1) providing the `native-image` executable. JDK 21-based."
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.8"
+        },
+        {
+          "name": "sbomer:image:labels:io.cekit.version",
+          "value": "4.10.0"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Quarkus Native builder image (version 23.1) providing the `native-image` executable. JDK 21-based."
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "Quarkus Native builder image (Version 23.1, GraalVM Native, Mandrel distribution, JDK 21-based)"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "executable,java,quarkus,mandrel,native"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "Red Hat OpenJDK Team <openjdk@redhat.com>"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "quarkus/mandrel-for-jdk-21-rhel8"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "19.1739757566"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Quarkus Native builder (Version 23.1, GraalVM Native, Mandrel distribution, JDK 21-based)"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/quarkus/mandrel-for-jdk-21-rhel8/images/23.1-19.1739757566"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "72f7a5ed37f428182ee76cde302ea3300ddc96e9"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "23.1"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3513101",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/quarkus-mandrel#72f7a5ed37f428182ee76cde302ea3300ddc96e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "abattis-cantarell-fonts",
+      "purl": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+      "version": "0.0.25-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "OFL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe01fbdac570da234c78f809e93cf1a5c72431f3",
+            "url": "git://pkgs.devel.redhat.com/rpms/abattis-cantarell-fonts#fe01fbdac570da234c78f809e93cf1a5c72431f3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1428698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/abattis-cantarell-fonts#fe01fbdac570da234c78f809e93cf1a5c72431f3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=d9a5accf56f24c33&upstream=acl-2.2.53-3.el8.src.rpm",
+      "version": "2.2.53-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64d42070c251d4b78dc897999b1ff36c5be04002",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2710224",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "adwaita-cursor-theme",
+      "purl": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "version": "3.28.0-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or CC-BY-SA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+            "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1805673",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "adwaita-icon-theme",
+      "purl": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "version": "3.28.0-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or CC-BY-SA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+            "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1805673",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alsa-lib",
+      "purl": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=x86_64&distro=rhel-8.10&package-id=e687411599c00951&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+      "version": "1.2.10-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1df50921065d04c3409c6d50e45188316530582a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#1df50921065d04c3409c6d50e45188316530582a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2801117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#1df50921065d04c3409c6d50e45188316530582a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "at-spi2-atk",
+      "purl": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6f0e2bd1ba41f221&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+      "version": "2.26.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a99891d57d7618cff33507cee2205cc6ad464709",
+            "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-atk#a99891d57d7618cff33507cee2205cc6ad464709"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746020",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-atk#a99891d57d7618cff33507cee2205cc6ad464709",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "at-spi2-core",
+      "purl": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=18bf4eca2dcb5d41&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+      "version": "2.28.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "66bd1458234282b1b0f62bb16f89437864dc1067",
+            "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-core#66bd1458234282b1b0f62bb16f89437864dc1067"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746030",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-core#66bd1458234282b1b0f62bb16f89437864dc1067",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "atk",
+      "purl": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=f90533d328f2b7ef&upstream=atk-2.28.1-1.el8.src.rpm",
+      "version": "2.28.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d8243796680126f5a6991e92d05fbdef1fb363fc",
+            "url": "git://pkgs.devel.redhat.com/rpms/atk#d8243796680126f5a6991e92d05fbdef1fb363fc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746010",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/atk#d8243796680126f5a6991e92d05fbdef1fb363fc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=3daa175bec117741&upstream=audit-3.1.2-1.el8.src.rpm",
+      "version": "3.1.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3b0c2631cd2710642353b96943214221b23a2bf",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#d3b0c2631cd2710642353b96943214221b23a2bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2766534",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#d3b0c2631cd2710642353b96943214221b23a2bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "avahi-libs",
+      "purl": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=308de131028314a6&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+      "version": "0.7-27.el8_10.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b34c66d255ae0ac833a85a6b1274b3216fab9e93",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#b34c66d255ae0ac833a85a6b1274b3216fab9e93"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3250821",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#b34c66d255ae0ac833a85a6b1274b3216fab9e93",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+      "version": "11-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5396e2dfce9e5a71fa15c63cf074f949ea2677c",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#a5396e2dfce9e5a71fa15c63cf074f949ea2677c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746023",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#a5396e2dfce9e5a71fa15c63cf074f949ea2677c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=x86_64&distro=rhel-8.10&package-id=4d3216e237d4772a&upstream=bash-4.4.20-5.el8.src.rpm",
+      "version": "4.4.20-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2cd7e4238fbd1aed0611f7227734511b25cfe63f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#2cd7e4238fbd1aed0611f7227734511b25cfe63f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2900299",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#2cd7e4238fbd1aed0611f7227734511b25cfe63f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "binutils",
+      "purl": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=x86_64&distro=rhel-8.10&package-id=546f5310974cd65f&upstream=binutils-2.30-125.el8_10.src.rpm",
+      "version": "2.30-125.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93ebd35fa24871ad51914892733ba8cb626feed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/binutils#93ebd35fa24871ad51914892733ba8cb626feed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382340",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/binutils#93ebd35fa24871ad51914892733ba8cb626feed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "brotli",
+      "purl": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=x86_64&distro=rhel-8.10&package-id=2fe1dc3826c55b7f&upstream=brotli-1.0.6-3.el8.src.rpm",
+      "version": "1.0.6-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0ee161fd58068d9081ef1f9825adc72e88500b",
+            "url": "git://pkgs.devel.redhat.com/rpms/brotli#1c0ee161fd58068d9081ef1f9825adc72e88500b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1337704",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/brotli#1c0ee161fd58068d9081ef1f9825adc72e88500b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-devel",
+      "purl": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8b61c2a24f04e8f0&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "version": "1.0.6-28.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc96ec6647dfc148&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "version": "1.0.6-28.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+      "version": "2024.2.69_v8.0.303-80.0.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3189502",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cairo",
+      "purl": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=f10327d118a11076&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "version": "1.15.12-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or MPLv1.1"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+            "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1856752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cairo-gobject",
+      "purl": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6a998977e2992ef1&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "version": "1.15.12-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or MPLv1.1"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+            "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1856752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "chkconfig",
+      "purl": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=331234308ac7a0d9&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+      "version": "1.19.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b",
+            "url": "git://pkgs.devel.redhat.com/rpms/chkconfig#82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2503740",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/chkconfig#82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "collections",
+      "purl": "pkg:maven/org.graalvm.sdk/collections@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79d666407d73654a38693a2e5cc9bb90"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9aef5575f25f021d7a83928ee6c8244aaa28a4a5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c85252a2047d75b669c256cc8f36955f311676be11de5160533e41a6b43e1f35"
+        }
+      ],
+      "bom-ref": "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9aef5575f25f021d7a83928ee6c8244aaa28a4a5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347863",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "collections-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/collections@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3cdb9fb4dfb13ac881806fd4d90636e1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bf3802eb5026ef9ae4ea258142328a1643c612be"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "960583fdbe25d8ea594dbd1573c6e1d43bbb00fbb6584eaea63c7e0ca8cc42f5"
+        }
+      ],
+      "bom-ref": "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bf3802eb5026ef9ae4ea258142328a1643c612be"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347888",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "colord-libs",
+      "purl": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=beb3c422d82ba036&upstream=colord-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b8b9b530a28c8ab42471284d434afe9ee3c47299",
+            "url": "git://pkgs.devel.redhat.com/rpms/colord#b8b9b530a28c8ab42471284d434afe9ee3c47299"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746106",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/colord#b8b9b530a28c8ab42471284d434afe9ee3c47299",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "compiler",
+      "purl": "pkg:maven/org.graalvm.compiler/compiler@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "72225170e7fcf6bc7351ef3b45b3a86e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5b92e665aae823e6f9ae0ce4a1dfc212702c5129"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aa1cf4a7eeb6d35d6120979404e3a53a44bdf6ae759a2d8e6dba7a09a5c2fffe"
+        }
+      ],
+      "bom-ref": "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5b92e665aae823e6f9ae0ce4a1dfc212702c5129"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347856",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "compiler-sources",
+      "purl": "pkg:maven/org.graalvm.compiler/compiler@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3932562b61c626758d8cd45e89821a5e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4e7b48a5ece076047a23c499efe610b0167792ff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ec7a7feee3e54849473c48d1b97920c659f6780aa29f2e79a71fb8968779637a"
+        }
+      ],
+      "bom-ref": "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4e7b48a5ece076047a23c499efe610b0167792ff"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347883",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "copy-jdk-configs",
+      "purl": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+      "version": "4.0-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0f065c185b51f47d2d3a825f33c5fb2dfda5657d",
+            "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#0f065c185b51f47d2d3a825f33c5fb2dfda5657d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1638485",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#0f065c185b51f47d2d3a825f33c5fb2dfda5657d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=x86_64&distro=rhel-8.10&package-id=fbfda60c10f25f78&upstream=coreutils-8.30-15.el8.src.rpm",
+      "version": "8.30-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0",
+            "url": "git://pkgs.devel.redhat.com/rpms/coreutils#a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2324367",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/coreutils#a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cpp",
+      "purl": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc967e75e06e97d5&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=69294411c9a2d835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "version": "2.9.6-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=804625",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=6f5a17a48d3922cf&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "version": "2.9.6-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=804625",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "version": "20230731-1.git3177e06.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c698dc49e0972391ac247a342789e3a021af69d",
+            "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2621975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "version": "20230731-1.git3177e06.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c698dc49e0972391ac247a342789e3a021af69d",
+            "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2621975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cryptsetup-libs",
+      "purl": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a75f80dba0f3a0f7&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+      "version": "2.3.7-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25",
+            "url": "git://pkgs.devel.redhat.com/rpms/cryptsetup#b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2588613",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cryptsetup#b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cups-libs",
+      "purl": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=b3d18b40fd9590f8&upstream=cups-2.2.6-62.el8_10.src.rpm",
+      "version": "1:2.2.6-62.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "83b5a019975a2e63167d471e33535cbe43f8523e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#83b5a019975a2e63167d471e33535cbe43f8523e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3415903",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#83b5a019975a2e63167d471e33535cbe43f8523e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl",
+      "purl": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=67c8cdb501d51041&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "version": "7.61.1-34.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3375089",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=x86_64&distro=rhel-8.10&package-id=26a897ee42073d2f&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+      "version": "2.1.27-6.el8_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03d2c0663f4a25fe455b867d0c2b28501b3f28c2",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#03d2c0663f4a25fe455b867d0c2b28501b3f28c2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892190",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#03d2c0663f4a25fe455b867d0c2b28501b3f28c2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=f89b9e929eac9b10&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-daemon",
+      "purl": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=18b79fc94c901ed7&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-glib",
+      "purl": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=x86_64&distro=rhel-8.10&package-id=89265388117ac552&upstream=dbus-glib-0.110-2.el8.src.rpm",
+      "version": "0.110-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "AFL and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5eb05e6c24dd7ccebca79678a8bcc876ada6db0f",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-glib#5eb05e6c24dd7ccebca79678a8bcc876ada6db0f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746151",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-glib#5eb05e6c24dd7ccebca79678a8bcc876ada6db0f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=233d3813cd179460&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-tools",
+      "purl": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=6cfefdeb2079d438&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dconf",
+      "purl": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=x86_64&distro=rhel-8.10&package-id=82014b60c2c31aa4&upstream=dconf-0.28.0-4.el8.src.rpm",
+      "version": "0.28.0-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b9117cee6006bec458091955949dffb128aa0ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/dconf#7b9117cee6006bec458091955949dffb128aa0ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1390833",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dconf#7b9117cee6006bec458091955949dffb128aa0ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-fonts-common",
+      "purl": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "version": "2.35-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1410980",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-mono-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "version": "2.35-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1410980",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "device-mapper",
+      "purl": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=x86_64&epoch=8",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=2ca7d48283969523&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "version": "8:1.02.181-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09f895338878b2481897562d4c478c596609167c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2886869",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "device-mapper-libs",
+      "purl": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=x86_64&epoch=8",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=8d450b0b684f93e2&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "version": "8:1.02.181-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09f895338878b2481897562d4c478c596609167c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2886869",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=74d1497fb48abbfe&upstream=dmidecode-3.5-1.el8.src.rpm",
+      "version": "1:3.5-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "715b44b5163c3ead4fa58113a72745c57dc5fa2b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#715b44b5163c3ead4fa58113a72745c57dc5fa2b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2828442",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#715b44b5163c3ead4fa58113a72745c57dc5fa2b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=dec2d1d0978e8ff2&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=28b80caf9216b1c1&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=45471cb62ebee70d&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d4395aa9af150f17&upstream=expat-2.2.5-16.el8_10.src.rpm",
+      "version": "2.2.5-16.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ef654fce79bdb84c4d96eef8e781913506ae1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#00ef654fce79bdb84c4d96eef8e781913506ae1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3383793",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#00ef654fce79bdb84c4d96eef8e781913506ae1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=x86_64&distro=rhel-8.10&package-id=75f1bf4aa9e18cac&upstream=file-5.33-26.el8.src.rpm",
+      "version": "5.33-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2751139",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=x86_64&distro=rhel-8.10&package-id=530cae3194c7bc81&upstream=filesystem-3.8-6.el8.src.rpm",
+      "version": "3.8-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0888a057be6b19d775e219b22aaadaa6825a4493",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#0888a057be6b19d775e219b22aaadaa6825a4493"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1640139",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#0888a057be6b19d775e219b22aaadaa6825a4493",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=7bdec5ea3b91a11d&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+      "version": "1:4.6.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be0c981099552be94b8e759c8113f70f30ffa574",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#be0c981099552be94b8e759c8113f70f30ffa574"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3166029",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#be0c981099552be94b8e759c8113f70f30ffa574",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fontconfig",
+      "purl": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ff91750b39d6154c&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+      "version": "2.13.1-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Public Domain and UCD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9b8add415a851e8c83851cbf497ab36a379dc1c9",
+            "url": "git://pkgs.devel.redhat.com/rpms/fontconfig#9b8add415a851e8c83851cbf497ab36a379dc1c9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1699029",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fontconfig#9b8add415a851e8c83851cbf497ab36a379dc1c9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fontpackages-filesystem",
+      "purl": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+      "version": "1.44-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "67e7529185d4a64eb77c1c383ea479b704e3f6fe",
+            "url": "git://pkgs.devel.redhat.com/rpms/fontpackages#67e7529185d4a64eb77c1c383ea479b704e3f6fe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746265",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fontpackages#67e7529185d4a64eb77c1c383ea479b704e3f6fe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "freetype",
+      "purl": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=798a1a6ce043b83a&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "version": "2.9.1-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "352ceda9b7b8521f5812faea931314e480e15430",
+            "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2029792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "freetype-devel",
+      "purl": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=7fb7501cfb112967&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "version": "2.9.1-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "352ceda9b7b8521f5812faea931314e480e15430",
+            "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2029792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fribidi",
+      "purl": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=x86_64&distro=rhel-8.10&package-id=0091172b1339820c&upstream=fribidi-1.0.4-9.el8.src.rpm",
+      "version": "1.0.4-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and UCD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25",
+            "url": "git://pkgs.devel.redhat.com/rpms/fribidi#8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1972637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fribidi#8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=0c05100f89a630da&upstream=gawk-4.2.1-4.el8.src.rpm",
+      "version": "4.2.1-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2894f879f91f263ecb702981bdcaf8012ac299bc",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#2894f879f91f263ecb702981bdcaf8012ac299bc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1884677",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#2894f879f91f263ecb702981bdcaf8012ac299bc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gcc",
+      "purl": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=3d20ce55e2320b78&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gcc-c++",
+      "purl": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2607bc43cf5c2a4b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=x86_64&distro=rhel-8.10&package-id=179000405ec99ff8&upstream=gdb-8.2-20.el8.src.rpm",
+      "version": "8.2-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6c06900a0891d6807b46dad7f0b06d0114ff5fe3",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdb#6c06900a0891d6807b46dad7f0b06d0114ff5fe3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2447068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdb#6c06900a0891d6807b46dad7f0b06d0114ff5fe3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm",
+      "purl": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=91b9bcc71236f11e&upstream=gdbm-1.18-2.el8.src.rpm",
+      "version": "1:1.18-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92ca20d1833e263d5990060445e6516c018dfb26",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2078608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=60ef0563eb70d44e&upstream=gdbm-1.18-2.el8.src.rpm",
+      "version": "1:1.18-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92ca20d1833e263d5990060445e6516c018dfb26",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2078608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdk-pixbuf2",
+      "purl": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=95a1d7c736d8de13&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "version": "2.36.12-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51c11c568980903a55d65d0e709bd37b9a54affa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3059697",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdk-pixbuf2-modules",
+      "purl": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=fb3b2b45efc128f2&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "version": "2.36.12-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51c11c568980903a55d65d0e709bd37b9a54affa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3059697",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib-networking",
+      "purl": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=x86_64&distro=rhel-8.10&package-id=096180e123e8406f&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+      "version": "2.56.1-1.1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "022e922bfd62720b931cbb917c5f25392bc8ccb4",
+            "url": "git://pkgs.devel.redhat.com/rpms/glib-networking#022e922bfd62720b931cbb917c5f25392bc8ccb4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=808537",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/glib-networking#022e922bfd62720b931cbb917c5f25392bc8ccb4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7a2a1554ab953ced&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+      "version": "2.56.4-165.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5c5396905d7c0632c3d4dffee21553cdb3587773",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#5c5396905d7c0632c3d4dffee21553cdb3587773"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3310831",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#5c5396905d7c0632c3d4dffee21553cdb3587773",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=68a1afa47f2c3b1d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=83e5c3b52d33cd4d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-devel",
+      "purl": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=8c6c06fb42848c8f&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-headers",
+      "purl": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=023f8ce189ff21a6&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-langpack-en",
+      "purl": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=fea1cee95cc1770b&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=24d224b650aa4868&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=682fed2cbd3416af&upstream=gmp-6.1.2-11.el8.src.rpm",
+      "version": "1:6.1.2-11.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad3d169c431b4fab7675c90887dd3528605f17eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gmp#ad3d169c431b4fab7675c90887dd3528605f17eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2888918",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gmp#ad3d169c431b4fab7675c90887dd3528605f17eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=389b497b6ede3b42&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+      "version": "2.2.20-3.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "de234834ad4638434c686e1073ede1add35add72",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#de234834ad4638434c686e1073ede1add35add72"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2114977",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#de234834ad4638434c686e1073ede1add35add72",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=x86_64&distro=rhel-8.10&package-id=f59dc71cd27c2eef&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+      "version": "3.6.16-8.el8_9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dd3e410bdeb6d4126b24d0d24347dc8d4758207b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#dd3e410bdeb6d4126b24d0d24347dc8d4758207b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2973710",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#dd3e410bdeb6d4126b24d0d24347dc8d4758207b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fe6d53a664001f4b&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+      "version": "1.56.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+, LGPLv2+, MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36eb0ce62a6550943166ca0fc6ad5819ad12acd1",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#36eb0ce62a6550943166ca0fc6ad5819ad12acd1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746526",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#36eb0ce62a6550943166ca0fc6ad5819ad12acd1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+      "version": "d4082792-5b32db75",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=4b9096e1d72fba6c&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "version": "1.13.1-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30ce989734661681faba06ceb0a2573a5c66b85f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2903739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "graal-sdk",
+      "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "154e55e710ff408baee7ecfd0466fa30"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d41619a29cd775e1b75f2a406b7a0d4658bde1e0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e33844b38bbebb7fee75138b2260c2eb574351006111c4e669d63766fbab5166"
+        }
+      ],
+      "bom-ref": "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d41619a29cd775e1b75f2a406b7a0d4658bde1e0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347890",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "graal-sdk-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6689c7ce9b7450afcc1a55ee91894617"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "11f213da066f81db16d9d699df47f81baaec8b60"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bb5d2cf660498c1d5d7ec1ea5b4cfb4ad5902ee3b4bda9e3e66fc2f621d4b18f"
+        }
+      ],
+      "bom-ref": "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "11f213da066f81db16d9d699df47f81baaec8b60"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347880",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "graphite2",
+      "purl": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=x86_64&distro=rhel-8.10&package-id=a4d5e3a755746745&upstream=graphite2-1.3.10-10.el8.src.rpm",
+      "version": "1.3.10-10.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv2+ or GPLv2+ or MPL) and (Netscape or GPLv2+ or LGPLv2+)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b71ee5b21e8f2c2247d0f547e60ccea7030db7dd",
+            "url": "git://pkgs.devel.redhat.com/rpms/graphite2#b71ee5b21e8f2c2247d0f547e60ccea7030db7dd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=762158",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/graphite2#b71ee5b21e8f2c2247d0f547e60ccea7030db7dd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.1-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=0d92b5058935e5ce&upstream=grep-3.1-6.el8.src.rpm",
+      "version": "3.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c300a00f9d91514feb8a5eef8d06800c4be6a03b",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#c300a00f9d91514feb8a5eef8d06800c4be6a03b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=745934",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#c300a00f9d91514feb8a5eef8d06800c4be6a03b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gsettings-desktop-schemas",
+      "purl": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=x86_64&distro=rhel-8.10&package-id=efa1ae4e2cc32b52&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+      "version": "3.32.0-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "934b1f14fd093e9073ab3091507f45d5a6406a8c",
+            "url": "git://pkgs.devel.redhat.com/rpms/gsettings-desktop-schemas#934b1f14fd093e9073ab3091507f45d5a6406a8c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1668107",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gsettings-desktop-schemas#934b1f14fd093e9073ab3091507f45d5a6406a8c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gtk-update-icon-cache",
+      "purl": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a3990f63e65ca2d4&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "version": "3.22.30-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3215246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gtk3",
+      "purl": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f9d2b29b30a6527a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "version": "3.22.30-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3215246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=x86_64&distro=rhel-8.10&package-id=85bfed57331050b8&upstream=gzip-1.9-13.el8_5.src.rpm",
+      "version": "1.9-13.el8_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1978968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "harfbuzz",
+      "purl": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=a7f512046ee7adb6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+      "version": "1.7.5-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/harfbuzz#a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2691402",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/harfbuzz#a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hicolor-icon-theme",
+      "purl": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+      "version": "0.17-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e299e4a26c78c50f595c6929681fe66f3c6fef4",
+            "url": "git://pkgs.devel.redhat.com/rpms/hicolor-icon-theme#3e299e4a26c78c50f595c6929681fe66f3c6fef4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746592",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/hicolor-icon-theme#3e299e4a26c78c50f595c6929681fe66f3c6fef4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=x86_64&distro=rhel-8.10&package-id=698a2ee03511ee82&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+      "version": "1.3.2-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14ff723c10237225d71585ee05524248b63a05e2",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#14ff723c10237225d71585ee05524248b63a05e2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1509562",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#14ff723c10237225d71585ee05524248b63a05e2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "info",
+      "purl": "pkg:rpm/redhat/info@6.5-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/info@6.5-7.el8?arch=x86_64&distro=rhel-8.10&package-id=de4110a3b17745a9&upstream=texinfo-6.5-7.el8.src.rpm",
+      "version": "6.5-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fcd588440f00fc27457e5c31cd05f3ac06799982",
+            "url": "git://pkgs.devel.redhat.com/rpms/texinfo#fcd588440f00fc27457e5c31cd05f3ac06799982"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852265",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/texinfo#fcd588440f00fc27457e5c31cd05f3ac06799982",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "isl",
+      "purl": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=a754b86118c6038f&upstream=isl-0.16.1-6.el8.src.rpm",
+      "version": "0.16.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0e53516c24774dd2377f56e2e8e52cb5cbeeab84",
+            "url": "git://pkgs.devel.redhat.com/rpms/isl#0e53516c24774dd2377f56e2e8e52cb5cbeeab84"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746861",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/isl#0e53516c24774dd2377f56e2e8e52cb5cbeeab84",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jasper-libs",
+      "purl": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=af996aedcac3f597&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+      "version": "2.0.14-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "JasPer"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/jasper#0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3463584",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/jasper#0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk",
+      "purl": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=3394ab0ab230be76&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-devel",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=c3c548a1cf4277b9&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-headless",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=87d1d39715488da6&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-src",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=a8f850dce4001448&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-static-libs",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=071410ef311a2c01&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "javapackages-filesystem",
+      "purl": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+      "version": "5.3.0-1.module+el8+2447+6f56d9a6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5321498d8cb1dbcd241e8eee0523661a16a9e4",
+            "url": "git://pkgs.devel.redhat.com/rpms/javapackages-tools#8b5321498d8cb1dbcd241e8eee0523661a16a9e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=815001",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/javapackages-tools#8b5321498d8cb1dbcd241e8eee0523661a16a9e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jbigkit-libs",
+      "purl": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=x86_64&distro=rhel-8.10&package-id=d8699e1e2662d072&upstream=jbigkit-2.1-14.el8.src.rpm",
+      "version": "2.1-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8effde482b7c059bb265dd1e05ead891c29ecfae",
+            "url": "git://pkgs.devel.redhat.com/rpms/jbigkit#8effde482b7c059bb265dd1e05ead891c29ecfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=788163",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jbigkit#8effde482b7c059bb265dd1e05ead891c29ecfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jrt-fs",
+      "purl": "pkg:maven/jrt-fs/jrt-fs@21.0.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=e4a415a46ed0b08a",
+      "version": "21.0.6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.6.0.7-1.el8.x86_64/lib/jrt-fs.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.6.0.7-1.el8.x86_64/lib/jrt-fs.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8fd24c77c3f670e9ddc1dce502528e781d0a12be"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3be41816d8f28dfc&upstream=json-c-0.13.1-3.el8.src.rpm",
+      "version": "0.13.1-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c499538bdd7ee11647cb04770c55e720d9850a89",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#c499538bdd7ee11647cb04770c55e720d9850a89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787596",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#c499538bdd7ee11647cb04770c55e720d9850a89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=1cc0f9bd2e60c960&upstream=json-glib-1.4.4-1.el8.src.rpm",
+      "version": "1.4.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9c5843980e980d2c8163e684ff2b81a7acf49bad",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#9c5843980e980d2c8163e684ff2b81a7acf49bad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#9c5843980e980d2c8163e684ff2b81a7acf49bad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jvmti-agent-base",
+      "purl": "pkg:maven/org.graalvm.nativeimage/jvmti-agent-base@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d1a5ae5f4c1b3a365e79bb01a082098f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c663280e87e9f895b9541a2939386c46e66c0789"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e4058939634248a37da3f6f052d08ac5eb5bbbb7b06db2b4e3a28697d0c47835"
+        }
+      ],
+      "bom-ref": "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c663280e87e9f895b9541a2939386c46e66c0789"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347893",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jvmti-agent-base-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/jvmti-agent-base@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1de883a52eb34899fa29030240cb6477"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "feee00388852d1f248cc78b9ac6e171d204c993e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1bb579589e3b6281032694a3b913855ed826ab59f99c046cd6b3657608c595ac"
+        }
+      ],
+      "bom-ref": "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "feee00388852d1f248cc78b9ac6e171d204c993e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347904",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "kernel-headers",
+      "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b87b2a1a83ea5ae&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+      "version": "4.18.0-553.40.1.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Redistributable, no modification permitted"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e322ab635fa43c1980ceb05d3ff83fc762569917",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/kernel#e322ab635fa43c1980ceb05d3ff83fc762569917"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3497910",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/kernel#e322ab635fa43c1980ceb05d3ff83fc762569917",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=x86_64&distro=rhel-8.10&package-id=9cebf87852c8b719&upstream=keyutils-1.5.10-9.el8.src.rpm",
+      "version": "1.5.10-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6d9d9e2016a2bbdf84034cd72c77532044537588",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#6d9d9e2016a2bbdf84034cd72c77532044537588"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1636344",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#6d9d9e2016a2bbdf84034cd72c77532044537588",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=x86_64&distro=rhel-8.10&package-id=5eaf92d12e6e8b83&upstream=kmod-25-20.el8.src.rpm",
+      "version": "25-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e909931d9fb6b40c76dee1369a11fe5098ebd0f9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/kmod#e909931d9fb6b40c76dee1369a11fe5098ebd0f9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2747988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/kmod#e909931d9fb6b40c76dee1369a11fe5098ebd0f9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=x86_64&distro=rhel-8.10&package-id=b32043faf4582a8e&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+      "version": "1.18.2-30.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1b992ccc4e31bcd32004d00be03e0c01a308a7ff",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#1b992ccc4e31bcd32004d00be03e0c01a308a7ff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3348161",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#1b992ccc4e31bcd32004d00be03e0c01a308a7ff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+      "version": "1.0-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lcms2",
+      "purl": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=x86_64&distro=rhel-8.10&package-id=5991da020ab31dad&upstream=lcms2-2.9-2.el8.src.rpm",
+      "version": "2.9-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc4d80a58b7e391730c79700239bbfd9d7fa4946",
+            "url": "git://pkgs.devel.redhat.com/rpms/lcms2#dc4d80a58b7e391730c79700239bbfd9d7fa4946"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746989",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lcms2#dc4d80a58b7e391730c79700239bbfd9d7fa4946",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libX11",
+      "purl": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=024152497459451d&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "version": "1.6.8-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "15a649f949df2a70afb109ea64293dd7c9036e16",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3285753",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libX11-common",
+      "purl": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "version": "1.6.8-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "15a649f949df2a70afb109ea64293dd7c9036e16",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3285753",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXau",
+      "purl": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d98acce1b0f6dbf&upstream=libXau-1.0.9-3.el8.src.rpm",
+      "version": "1.0.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXau#b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXau#b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXcomposite",
+      "purl": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=2f5c10ae1d5b6ee0&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+      "version": "0.4.4-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11a091cf8f79e28c16a6400926448949a472d2b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXcomposite#11a091cf8f79e28c16a6400926448949a472d2b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747373",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXcomposite#11a091cf8f79e28c16a6400926448949a472d2b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXcursor",
+      "purl": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3d69163030db7151&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+      "version": "1.1.15-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9a2bd659d4620bfd1f1c382cdf90ef14002e99e2",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXcursor#9a2bd659d4620bfd1f1c382cdf90ef14002e99e2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747355",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXcursor#9a2bd659d4620bfd1f1c382cdf90ef14002e99e2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXdamage",
+      "purl": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=4e6d7f19fab9655f&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+      "version": "1.1.4-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c51981e69e3a27b3d3e792f81937fc6c74a205a7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXdamage#c51981e69e3a27b3d3e792f81937fc6c74a205a7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747346",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXdamage#c51981e69e3a27b3d3e792f81937fc6c74a205a7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXext",
+      "purl": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=873a3bb46d2b4967&upstream=libXext-1.3.4-1.el8.src.rpm",
+      "version": "1.3.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "76c0aa859ddcdeaacee677f583d437540e819d46",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXext#76c0aa859ddcdeaacee677f583d437540e819d46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214999",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXext#76c0aa859ddcdeaacee677f583d437540e819d46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXfixes",
+      "purl": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=9ff054eb2c69e450&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+      "version": "5.0.3-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1da8edf4ed249a235d0e9a09dc0e06003be57498",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXfixes#1da8edf4ed249a235d0e9a09dc0e06003be57498"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747353",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXfixes#1da8edf4ed249a235d0e9a09dc0e06003be57498",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXft",
+      "purl": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6da3b9e99fbfd4ec&upstream=libXft-2.3.3-1.el8.src.rpm",
+      "version": "2.3.3-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed837265cedf0f5e61e8d6f668e931e3bb58f7d1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXft#ed837265cedf0f5e61e8d6f668e931e3bb58f7d1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214061",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXft#ed837265cedf0f5e61e8d6f668e931e3bb58f7d1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXi",
+      "purl": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=x86_64&distro=rhel-8.10&package-id=811246ee1794dc4d&upstream=libXi-1.7.10-1.el8.src.rpm",
+      "version": "1.7.10-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "072476f025ad1ecdd0e6d6ceb5cd1139fac31d55",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXi#072476f025ad1ecdd0e6d6ceb5cd1139fac31d55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215343",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXi#072476f025ad1ecdd0e6d6ceb5cd1139fac31d55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXinerama",
+      "purl": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b11e77e7ad718f54&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+      "version": "1.1.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "568c3db2a300d250c0e83a43be5c40117593774d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXinerama#568c3db2a300d250c0e83a43be5c40117593774d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747354",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXinerama#568c3db2a300d250c0e83a43be5c40117593774d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXrandr",
+      "purl": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d7ce0edbccb3de17&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+      "version": "1.5.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXrandr#c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215377",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXrandr#c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXrender",
+      "purl": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a7872c77d81efdaf&upstream=libXrender-0.9.10-7.el8.src.rpm",
+      "version": "0.9.10-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "90e38e62624a34867ee066a19ddecda68ce49dfd",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXrender#90e38e62624a34867ee066a19ddecda68ce49dfd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747368",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXrender#90e38e62624a34867ee066a19ddecda68ce49dfd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXtst",
+      "purl": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=1fdf1f9af9334a9c&upstream=libXtst-1.2.3-7.el8.src.rpm",
+      "version": "1.2.3-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "88da2182682f3d6f76b225ec07bff26eb0068868",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXtst#88da2182682f3d6f76b225ec07bff26eb0068868"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747385",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXtst#88da2182682f3d6f76b225ec07bff26eb0068868",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4625a584e9b2b6ea&upstream=acl-2.2.53-3.el8.src.rpm",
+      "version": "2.2.53-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64d42070c251d4b78dc897999b1ff36c5be04002",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2710224",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cf310560d737d7b0&upstream=libarchive-3.3.3-5.el8.src.rpm",
+      "version": "3.3.3-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "104b7b68bae0f2bc8cdda1220b675cb93ab7250a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libarchive#104b7b68bae0f2bc8cdda1220b675cb93ab7250a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2293131",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libarchive#104b7b68bae0f2bc8cdda1220b675cb93ab7250a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3c2c05fa2e65b482&upstream=libassuan-2.5.1-3.el8.src.rpm",
+      "version": "2.5.1-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3de5b0bcfc1ed6c812fd4bb6e171584655be414a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#3de5b0bcfc1ed6c812fd4bb6e171584655be414a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747020",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#3de5b0bcfc1ed6c812fd4bb6e171584655be414a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d9e03bd84141733&upstream=attr-2.4.48-3.el8.src.rpm",
+      "version": "2.4.48-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdfcc6e99dda82ee784f779aea1e6583d6a9114f",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#fdfcc6e99dda82ee784f779aea1e6583d6a9114f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746019",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#fdfcc6e99dda82ee784f779aea1e6583d6a9114f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=16ca121e3b0dacdb&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=x86_64&distro=rhel-8.10&package-id=90ec99a4d3d54a2c&upstream=libcap-2.48-6.el8_9.src.rpm",
+      "version": "2.48-6.el8_9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820182",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=x86_64&distro=rhel-8.10&package-id=71d6200076770364&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+      "version": "0.7.11-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81596f2d86a07a87e7114728f34610a4efe7e67b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#81596f2d86a07a87e7114728f34610a4efe7e67b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1621556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#81596f2d86a07a87e7114728f34610a4efe7e67b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ef01434b20a692cd&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+      "version": "1.45.6-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "56bb7dc240dbaa63a9b44a865b6167d34f484128",
+            "url": "git://pkgs.devel.redhat.com/rpms/e2fsprogs#56bb7dc240dbaa63a9b44a865b6167d34f484128"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2014246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/e2fsprogs#56bb7dc240dbaa63a9b44a865b6167d34f484128",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6004137764ffb113&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "version": "0.1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4135df9c80076d65c4818b24201054bf2f1be50d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcurl",
+      "purl": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=8ba50251b960d097&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "version": "7.61.1-34.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3375089",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdatrie",
+      "purl": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=x86_64&distro=rhel-8.10&package-id=4927708ea0661e71&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+      "version": "0.2.9-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f635f110e56b9d5bf47821f7012ce5266ea9831",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdatrie#9f635f110e56b9d5bf47821f7012ce5266ea9831"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdatrie#9f635f110e56b9d5bf47821f7012ce5266ea9831",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=9dcc22fdf0d465d0&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "version": "5.3.28-42.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1724416",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdb-utils",
+      "purl": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=33d103636531829f&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "version": "5.3.28-42.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1724416",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=1b437b219242ccbc&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libepoxy",
+      "purl": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b2f8dcf273fa3d6e&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+      "version": "1.5.8-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cd28d1e02402539789c4f28b0eb7ea1f33503e88",
+            "url": "git://pkgs.devel.redhat.com/rpms/libepoxy#cd28d1e02402539789c4f28b0eb7ea1f33503e88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1647414",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libepoxy#cd28d1e02402539789c4f28b0eb7ea1f33503e88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=70487d6e9c60434d&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=x86_64&distro=rhel-8.10&package-id=d12942964336c965&upstream=libffi-3.1-24.el8.src.rpm",
+      "version": "3.1-24.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c565b3a03c15455f315d054f69da5f9dc5c648fb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#c565b3a03c15455f315d054f69da5f9dc5c648fb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2281599",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#c565b3a03c15455f315d054f69da5f9dc5c648fb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libfontenc",
+      "purl": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=x86_64&distro=rhel-8.10&package-id=1291ddc02147059e&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+      "version": "1.1.3-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf2feb55c26033eaeb9e151cb7ec701cf55fc62b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libfontenc#bf2feb55c26033eaeb9e151cb7ec701cf55fc62b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747099",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libfontenc#bf2feb55c26033eaeb9e151cb7ec701cf55fc62b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=0e695a071ee24d8f&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=x86_64&distro=rhel-8.10&package-id=6aad648da8bc9385&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+      "version": "1.8.5-7.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgcrypt#fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1987493",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgcrypt#fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=aeda3d65f9995507&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=x86_64&distro=rhel-8.10&package-id=33a7fbe1cf5b2659&upstream=libgpg-error-1.31-1.el8.src.rpm",
+      "version": "1.31-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac00f435a46e5609f4a4504a87fed9edcd51f374",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#ac00f435a46e5609f4a4504a87fed9edcd51f374"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747111",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#ac00f435a46e5609f4a4504a87fed9edcd51f374",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgusb",
+      "purl": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fc70f518e05a2e09&upstream=libgusb-0.3.0-1.el8.src.rpm",
+      "version": "0.3.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14d7241bc2a77370fd275cf1c65664259f0464fb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgusb#14d7241bc2a77370fd275cf1c65664259f0464fb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgusb#14d7241bc2a77370fd275cf1c65664259f0464fb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=139540dbb555a062&upstream=libidn2-2.2.0-1.el8.src.rpm",
+      "version": "2.2.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "844711723d62e709fb16cc01b988468b226e9659",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#844711723d62e709fb16cc01b988468b226e9659"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=909244",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#844711723d62e709fb16cc01b988468b226e9659",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libjpeg-turbo",
+      "purl": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=x86_64&distro=rhel-8.10&package-id=74007dc1b00bff55&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+      "version": "1.5.3-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "IJG"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6c3165c96e35faab383b164294460eccba517907",
+            "url": "git://pkgs.devel.redhat.com/rpms/libjpeg-turbo#6c3165c96e35faab383b164294460eccba517907"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1663830",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libjpeg-turbo#6c3165c96e35faab383b164294460eccba517907",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=x86_64&distro=rhel-8.10&package-id=4189b45d8b066ed1&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+      "version": "1.3.5-9.el8_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a641d587945a523e806d95a5873327bd5bbee07",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7a641d587945a523e806d95a5873327bd5bbee07"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345799",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7a641d587945a523e806d95a5873327bd5bbee07",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodman",
+      "purl": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=x86_64&distro=rhel-8.10&package-id=d38d8a0207f3b579&upstream=libmodman-2.0.1-17.el8.src.rpm",
+      "version": "2.0.1-17.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodman#f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747175",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodman#f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=99fb83cf0454297f&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+      "version": "2.13.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93951985e28c28d784bbb8b084bae6e428148e35",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#93951985e28c28d784bbb8b084bae6e428148e35"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695734",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#93951985e28c28d784bbb8b084bae6e428148e35",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=d3d0f503ea9d3051&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmpc",
+      "purl": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=x86_64&distro=rhel-8.10&package-id=ebb3b71859019ae6&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+      "version": "1.1.0-9.1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6b1a2d5892f12e777e1ef3a29bc1d0c83e499317",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmpc#6b1a2d5892f12e777e1ef3a29bc1d0c83e499317"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1345966",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmpc#6b1a2d5892f12e777e1ef3a29bc1d0c83e499317",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=0eb3d862523d0548&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+      "version": "1.33.0-6.el8_10.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eab77a0da66f15bc5084a2fd0ea1514636cbfe69",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#eab77a0da66f15bc5084a2fd0ea1514636cbfe69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#eab77a0da66f15bc5084a2fd0ea1514636cbfe69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=449118949812d0d2&upstream=libnl3-3.7.0-1.el8.src.rpm",
+      "version": "3.7.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e4cb0e98768f5184b2ca03d07a0c7a1d074f230",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnl3#3e4cb0e98768f5184b2ca03d07a0c7a1d074f230"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2077667",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnl3#3e4cb0e98768f5184b2ca03d07a0c7a1d074f230",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnsl2",
+      "purl": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=x86_64&distro=rhel-8.10&package-id=ef43e4d2fbb09d0d&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+      "version": "1.2.0-2.20180605git4a062cf.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3aaef48927091509dfedb2a21bf8b81f460f89e1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnsl2#3aaef48927091509dfedb2a21bf8b81f460f89e1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747205",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnsl2#3aaef48927091509dfedb2a21bf8b81f460f89e1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpkgconf",
+      "purl": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e24e2f3bc22ffe13&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpng",
+      "purl": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=664883aa573607f5&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "version": "2:1.6.34-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "Zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31d64ebe86bf6eaec320369f80bea745379bab83",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpng-devel",
+      "purl": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=18dbfd6f3afa0ce4&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "version": "2:1.6.34-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "Zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31d64ebe86bf6eaec320369f80bea745379bab83",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libproxy",
+      "purl": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9e5c394bd88d169f&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+      "version": "0.4.15-5.5.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9beb82f2dfe210e349fe719f94034e6169dbccf9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libproxy#9beb82f2dfe210e349fe719f94034e6169dbccf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libproxy#9beb82f2dfe210e349fe719f94034e6169dbccf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpsl",
+      "purl": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9194b925e7a3bebf&upstream=libpsl-0.20.2-6.el8.src.rpm",
+      "version": "0.20.2-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "752b285122bce7c00a05be51e81f253d6ee8c00a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpsl#752b285122bce7c00a05be51e81f253d6ee8c00a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215600",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpsl#752b285122bce7c00a05be51e81f253d6ee8c00a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6085dfcccefaea69&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+      "version": "1.4.4-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79b7f02763a3c4be9121d767959588b8068acf32",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#79b7f02763a3c4be9121d767959588b8068acf32"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2375421",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#79b7f02763a3c4be9121d767959588b8068acf32",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "library-support",
+      "purl": "pkg:maven/org.graalvm.nativeimage/library-support@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7005288c99795d06f9d1c7a9f6bd83d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "86eb2169e2efb24c036c779e53e2ebbe8dc9bf5b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bdc8f42bdfd63453e843571ba9fe67c6e6a5e8a2ac88fcf3a0c30d4b3ae7bcad"
+        }
+      ],
+      "bom-ref": "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "86eb2169e2efb24c036c779e53e2ebbe8dc9bf5b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347866",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "library-support-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/library-support@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "81189f47b7f0f3d951395c393fd6bee9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0ef34f03d7098887b1ea5a364a5cf3077ce4a7fe"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a2cefec3c90bdb846d331703368b22c91fb3d3ee3addbf9d330129a6066f8c1"
+        }
+      ],
+      "bom-ref": "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0ef34f03d7098887b1ea5a364a5cf3077ce4a7fe"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347867",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=9780f211eda573e6&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "version": "1.14.2-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc58d5532f28202ecd07557fc2934484fbd0674d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=x86_64&distro=rhel-8.10&package-id=256edfa407c3b660&upstream=libreport-2.9.5-15.el8.src.rpm",
+      "version": "2.9.5-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cd702428f310bfec7ef6fb24f959a8ba3d1e7a99",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#cd702428f310bfec7ef6fb24f959a8ba3d1e7a99"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1290417",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#cd702428f310bfec7ef6fb24f959a8ba3d1e7a99",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cd55edd53a4bce8a&upstream=librhsm-0.0.3-5.el8.src.rpm",
+      "version": "0.0.3-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2772e1aa2d7193707e72eb2d1c727d06a16c9989",
+            "url": "git://pkgs.devel.redhat.com/rpms/librhsm#2772e1aa2d7193707e72eb2d1c727d06a16c9989"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2323402",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/librhsm#2772e1aa2d7193707e72eb2d1c727d06a16c9989",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e4eb640ed71d1387&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+      "version": "2.5.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e3a0fd6837173bb76b091d65e591a1ce7311378",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#2e3a0fd6837173bb76b091d65e591a1ce7311378"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1786669",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#2e3a0fd6837173bb76b091d65e591a1ce7311378",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=40b14020c3a76059&upstream=libselinux-2.9-9.el8_10.src.rpm",
+      "version": "2.9-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed8e2baba154118c35626186ed3e654c10b5f491",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#ed8e2baba154118c35626186ed3e654c10b5f491"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3239387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#ed8e2baba154118c35626186ed3e654c10b5f491",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d353a56719b280d0&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+      "version": "2.9-10.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "997cbe2630d6429ee45f6cfef84ff7509a4ea058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#997cbe2630d6429ee45f6cfef84ff7509a4ea058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3239522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#997cbe2630d6429ee45f6cfef84ff7509a4ea058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=a493c97a5a749b13&upstream=libsepol-2.9-3.el8.src.rpm",
+      "version": "2.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad6a367f763be53b4d0e436a21b280b69c8597c9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsepol#ad6a367f763be53b4d0e436a21b280b69c8597c9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707351",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsepol#ad6a367f763be53b4d0e436a21b280b69c8597c9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=x86_64&distro=rhel-8.10&package-id=c2082e19a7d6e3c1&upstream=libsigsegv-2.11-5.el8.src.rpm",
+      "version": "2.11-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "67798a99164bf6a86104365323cdd1e96aa481ac",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#67798a99164bf6a86104365323cdd1e96aa481ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747270",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#67798a99164bf6a86104365323cdd1e96aa481ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=c5c5a2cbb0227d12&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=x86_64&distro=rhel-8.10&package-id=18ed592ae788b75e&upstream=libsolv-0.7.20-6.el8.src.rpm",
+      "version": "0.7.20-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3591046e11dc93a168b2746adc2cea187517125b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#3591046e11dc93a168b2746adc2cea187517125b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563470",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#3591046e11dc93a168b2746adc2cea187517125b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsoup",
+      "purl": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7f51719269909e33&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+      "version": "2.62.3-7.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5c427b629b65ec0bbc9ac68c202782c460d99ea0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsoup#5c427b629b65ec0bbc9ac68c202782c460d99ea0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3487919",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsoup#5c427b629b65ec0bbc9ac68c202782c460d99ea0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=efb80d980b17a2b2&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "version": "0.9.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2928407",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "version": "0.9.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2928407",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=53184858d25776ab&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++-devel",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=13fb33eabcbdd348&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=x86_64&distro=rhel-8.10&package-id=635524cc0dab781f&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+      "version": "4.13-4.el8_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8353f7abddd9a5fdad86a0f8a1aa00059190fff1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#8353f7abddd9a5fdad86a0f8a1aa00059190fff1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2288152",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#8353f7abddd9a5fdad86a0f8a1aa00059190fff1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libthai",
+      "purl": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=x86_64&distro=rhel-8.10&package-id=348223321fdebdeb&upstream=libthai-0.1.27-2.el8.src.rpm",
+      "version": "0.1.27-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "86c327f4c74fe5d4b41929bafb1c4ab9088f48ce",
+            "url": "git://pkgs.devel.redhat.com/rpms/libthai#86c327f4c74fe5d4b41929bafb1c4ab9088f48ce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747296",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libthai#86c327f4c74fe5d4b41929bafb1c4ab9088f48ce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtiff",
+      "purl": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=x86_64&distro=rhel-8.10&package-id=416647ae0ce9a60e&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+      "version": "4.0.9-33.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "libtiff"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "21cdd75b44d4aa017c3df163cad6a932005398e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtiff#21cdd75b44d4aa017c3df163cad6a932005398e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3261047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtiff#21cdd75b44d4aa017c3df163cad6a932005398e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cad80c4d9a1f5dcf&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+      "version": "1.1.4-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "589b33251d858534e86a24b77ac11d2172474e3b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#589b33251d858534e86a24b77ac11d2172474e3b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3028658",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#589b33251d858534e86a24b77ac11d2172474e3b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3cb1aef7db7925a5&upstream=libunistring-0.9.9-3.el8.src.rpm",
+      "version": "0.9.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "10c31f1b7221e427e7ae5925cd95860117eb0ccf",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#10c31f1b7221e427e7ae5925cd95860117eb0ccf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=753876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#10c31f1b7221e427e7ae5925cd95860117eb0ccf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libusbx",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=x86_64&distro=rhel-8.10&package-id=2079bf2de278c73a&upstream=libusbx-1.0.23-4.el8.src.rpm",
+      "version": "1.0.23-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca5dec750fe81d6a60c442ecbffb1bde77a86d94",
+            "url": "git://pkgs.devel.redhat.com/rpms/libusbx#ca5dec750fe81d6a60c442ecbffb1bde77a86d94"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1286148",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libusbx#ca5dec750fe81d6a60c442ecbffb1bde77a86d94",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a6407cda71986b6d&upstream=libuser-0.62-26.el8_10.src.rpm",
+      "version": "0.62-26.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3584103bf5b70ec86c555a98f079ae5129c18a33",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libuser#3584103bf5b70ec86c555a98f079ae5129c18a33"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3196688",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libuser#3584103bf5b70ec86c555a98f079ae5129c18a33",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=ff85e6ae6fbe6897&upstream=libutempter-1.1.6-14.el8.src.rpm",
+      "version": "1.1.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e269bbe32b6035d279754a5ee33a9e017ab337b8",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#e269bbe32b6035d279754a5ee33a9e017ab337b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747310",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#e269bbe32b6035d279754a5ee33a9e017ab337b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=3431e92ffd288b38&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=x86_64&distro=rhel-8.10&package-id=dc73e15bfd2f72a0&upstream=libverto-0.3.2-2.el8.src.rpm",
+      "version": "0.3.2-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "377a16f5e9b26225de899f887687a87349ce6d0b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#377a16f5e9b26225de899f887687a87349ce6d0b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2079503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#377a16f5e9b26225de899f887687a87349ce6d0b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-client",
+      "purl": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=7ad8c4758bb988a6&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-cursor",
+      "purl": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=c906ed32e01195b8&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-egl",
+      "purl": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=545ba41b48d6a5eb&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcb",
+      "purl": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cc84571d169d80d9&upstream=libxcb-1.13.1-1.el8.src.rpm",
+      "version": "1.13.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb253be7a4af9d5f484caa8d05d0065a5c20e172",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcb#eb253be7a4af9d5f484caa8d05d0065a5c20e172"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1014531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcb#eb253be7a4af9d5f484caa8d05d0065a5c20e172",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=fa2892199f269e9b&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "version": "4.1.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt-devel",
+      "purl": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9914b3b870b78700&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "version": "4.1.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxkbcommon",
+      "purl": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=8159aa7df418566b&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+      "version": "0.9.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e3a0fcdea5c0b303ed969d5cef0a04968cd241d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxkbcommon#3e3a0fcdea5c0b303ed969d5cef0a04968cd241d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1001832",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxkbcommon#3e3a0fcdea5c0b303ed969d5cef0a04968cd241d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=x86_64&distro=rhel-8.10&package-id=86561759c46293e9&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+      "version": "2.9.7-18.el8_10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ba13a44374bf525af5006ea36434d7b80a81f486",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#ba13a44374bf525af5006ea36434d7b80a81f486"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3508739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#ba13a44374bf525af5006ea36434d7b80a81f486",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=x86_64&distro=rhel-8.10&package-id=bd0d38eebd665ff4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+      "version": "0.1.7-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23f1a0c7bf8a0013a158d71431038038f95ca6cb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#23f1a0c7bf8a0013a158d71431038038f95ca6cb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747381",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#23f1a0c7bf8a0013a158d71431038038f95ca6cb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5a06b2a5cab1ed24&upstream=zstd-1.4.4-1.el8.src.rpm",
+      "version": "1.4.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "41d137254dabfa495e5585021335d646538846d8",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#41d137254dabfa495e5585021335d646538846d8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1216822",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#41d137254dabfa495e5585021335d646538846d8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lksctp-tools",
+      "purl": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=x86_64&distro=rhel-8.10&package-id=7a77fcd86ba06ecc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+      "version": "1.0.18-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2 and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9771a405772fc12411151a12eebb245a02a8c778",
+            "url": "git://pkgs.devel.redhat.com/rpms/lksctp-tools#9771a405772fc12411151a12eebb245a02a8c778"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=757723",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lksctp-tools#9771a405772fc12411151a12eebb245a02a8c778",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua",
+      "purl": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=24fdcea8a4d24eba&upstream=lua-5.3.4-12.el8.src.rpm",
+      "version": "5.3.4-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0295c1179922370860fe28899e811e9fc663562c",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1701413",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=984a046eed89d84d&upstream=lua-5.3.4-12.el8.src.rpm",
+      "version": "5.3.4-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0295c1179922370860fe28899e811e9fc663562c",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1701413",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=x86_64&distro=rhel-8.10&package-id=747f8d08054bb295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+      "version": "1.8.3-3.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f024e0067da0f2157c0108391673fae4d952d283",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#f024e0067da0f2157c0108391673fae4d952d283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1615115",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#f024e0067da0f2157c0108391673fae4d952d283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=x86_64&distro=rhel-8.10&package-id=51067913349861f2&upstream=mpfr-3.1.6-1.el8.src.rpm",
+      "version": "3.1.6-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ and GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f705032792f282cb684476c9da5bcdbeaca46de",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#7f705032792f282cb684476c9da5bcdbeaca46de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747521",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#7f705032792f282cb684476c9da5bcdbeaca46de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "native-image-base",
+      "purl": "pkg:maven/org.graalvm.nativeimage/native-image-base@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "97dc3b26cbc80d2f46df94f7c9597e86"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f8b1a8870924f535e2e4433f9d243580b6a2f796"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "06af1e144315b25f765b89a5d9c85985b3364d0a9118f153ac06c592d393fb4c"
+        }
+      ],
+      "bom-ref": "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f8b1a8870924f535e2e4433f9d243580b6a2f796"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347892",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "native-image-base-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/native-image-base@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6b44d37da4b7d1ccab75398c1ad84f56"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "574110f086cb10719e28e02ad9720e650835a067"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d59c31a4b85860e8245b1b47f3da66a2dffec41416f85b0ec96fd2351d77604"
+        }
+      ],
+      "bom-ref": "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "574110f086cb10719e28e02ad9720e650835a067"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347903",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "nativeimage",
+      "purl": "pkg:maven/org.graalvm.sdk/nativeimage@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eea890f3986c4e5110dffd7839cb23f4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0249c4b127d2aa81f3592e152545eacfc50a10ae"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7ae03b5689f9a9091f40c4d0392abbd0a74e5182dad0e0b4b7b64cc503734de9"
+        }
+      ],
+      "bom-ref": "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0249c4b127d2aa81f3592e152545eacfc50a10ae"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347860",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "nativeimage-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/nativeimage@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e666c79164441872d394c335825d4b1d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3508f317f62357c1a41c51eef4fdf6c84729cad3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f7f627c7acd040132a163c16c240de6f92d9e3d78409ced544a50dcbb5e0b349"
+        }
+      ],
+      "bom-ref": "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3508f317f62357c1a41c51eef4fdf6c84729cad3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347881",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "version": "6.1-10.20180224.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35d800911ab07907e7b74b1d02b82d88a35d6422",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2638772",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=x86_64&distro=rhel-8.10&package-id=96d91b80e17d2e2d&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "version": "6.1-10.20180224.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35d800911ab07907e7b74b1d02b82d88a35d6422",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2638772",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=x86_64&distro=rhel-8.10&package-id=627574c547a84ac7&upstream=nettle-3.4.1-7.el8.src.rpm",
+      "version": "3.4.1-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e770f0b169737f8c430bd5c68292968f42701c5",
+            "url": "git://pkgs.devel.redhat.com/rpms/nettle#7e770f0b169737f8c430bd5c68292968f42701c5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1663247",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/nettle#7e770f0b169737f8c430bd5c68292968f42701c5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.5-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=9c6455318efa2d7b&upstream=npth-1.5-4.el8.src.rpm",
+      "version": "1.5-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4981bb31f79089dc8b3457db23d090cfec97e2a",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#a4981bb31f79089dc8b3457db23d090cfec97e2a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747600",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#a4981bb31f79089dc8b3457db23d090cfec97e2a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nspr",
+      "purl": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eeec482f0356b353&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+      "version": "4.35.0-1.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "765d8f1920ffbb18661967cade9d52599206d65f",
+            "url": "git://pkgs.devel.redhat.com/rpms/nspr#765d8f1920ffbb18661967cade9d52599206d65f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563709",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/nspr#765d8f1920ffbb18661967cade9d52599206d65f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss",
+      "purl": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eb5a35462c030a1d&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn",
+      "purl": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=c12e3afc80ee2624&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn-freebl",
+      "purl": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=a7a0502be801403c&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-sysinit",
+      "purl": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=3100d9810595d6c0&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-util",
+      "purl": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=8d7f6e696a826a11&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "objectfile",
+      "purl": "pkg:maven/org.graalvm.nativeimage/objectfile@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "30e219aa681c9aebed99076eb85cb40f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5dcc29507faeed2055fe21b11fb4472fde216ab1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ae0cf7576cab09d4c3a3be3704fb9c352933f8bcfb693fe92e8b6d849ba1c161"
+        }
+      ],
+      "bom-ref": "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5dcc29507faeed2055fe21b11fb4472fde216ab1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347889",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "objectfile-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/objectfile@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "15eff2e37b905ec795b8a96971f9e77a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c52abe898512e0cf6b66c597fa8b427424cf2beb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8f62b5c6f9b90936d466951fb5a07edebb349507751b34d81cb574d3dc08b76"
+        }
+      ],
+      "bom-ref": "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c52abe898512e0cf6b66c597fa8b427424cf2beb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347864",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b27e7b2961c600c&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+      "version": "2.4.46-20.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "OpenLDAP"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9820cbeebe81720251c3508f6121a53de5bf4d6f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9820cbeebe81720251c3508f6121a53de5bf4d6f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3342461",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9820cbeebe81720251c3508f6121a53de5bf4d6f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=4c1ab9ead2aef73f&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+      "version": "1:1.1.1k-14.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "OpenSSL and ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e0fe173933c40fcd6e520e696b31568121feb64",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#3e0fe173933c40fcd6e520e696b31568121feb64"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3290749",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#3e0fe173933c40fcd6e520e696b31568121feb64",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=355fe5843a01b570&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "version": "0.23.22-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4533f1a47434a4cb080c56a0f156cb90084fb389",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2799954",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=aa4a466c8c83bfa4&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "version": "0.23.22-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4533f1a47434a4cb080c56a0f156cb90084fb389",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2799954",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=x86_64&distro=rhel-8.10&package-id=faad0cdca7c3ac08&upstream=pam-1.3.1-36.el8_10.src.rpm",
+      "version": "1.3.1-36.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "40c8b8bba685d7f5158d24071def2460453a0d49",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#40c8b8bba685d7f5158d24071def2460453a0d49"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3412546",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#40c8b8bba685d7f5158d24071def2460453a0d49",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pango",
+      "purl": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=x86_64&distro=rhel-8.10&package-id=60fd46064a3ef440&upstream=pango-1.42.4-8.el8.src.rpm",
+      "version": "1.42.4-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a842466da971c3bea09e27dedae7aef1d1cfdcc2",
+            "url": "git://pkgs.devel.redhat.com/rpms/pango#a842466da971c3bea09e27dedae7aef1d1cfdcc2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1627722",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pango#a842466da971c3bea09e27dedae7aef1d1cfdcc2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=x86_64&distro=rhel-8.10&package-id=5d97178827061fdc&upstream=passwd-0.80-4.el8.src.rpm",
+      "version": "0.80-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e779bcdeee3700ff51dfd597064b96368328dc40",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#e779bcdeee3700ff51dfd597064b96368328dc40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1878394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#e779bcdeee3700ff51dfd597064b96368328dc40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=x86_64&distro=rhel-8.10&package-id=689b6a9f1c6e3a4d&upstream=pcre-8.42-6.el8.src.rpm",
+      "version": "8.42-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9985141f5cdf90f176d96f2503bdf60d139d45c6",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#9985141f5cdf90f176d96f2503bdf60d139d45c6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1621568",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#9985141f5cdf90f176d96f2503bdf60d139d45c6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=e986eeba073837bb&upstream=pcre2-10.32-3.el8_6.src.rpm",
+      "version": "10.32-3.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8edb1ebde203287340e48d6cd77f92a013917e84",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre2#8edb1ebde203287340e48d6cd77f92a013917e84"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2016974",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre2#8edb1ebde203287340e48d6cd77f92a013917e84",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pixman",
+      "purl": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=x86_64&distro=rhel-8.10&package-id=87a444578516c6eb&upstream=pixman-0.38.4-4.el8.src.rpm",
+      "version": "0.38.4-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "046693e14b52d91016bb02d9fb449994a787c534",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pixman#046693e14b52d91016bb02d9fb449994a787c534"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2704038",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pixman#046693e14b52d91016bb02d9fb449994a787c534",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf",
+      "purl": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=32b0d48565fb2224&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf-m4",
+      "purl": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf-pkg-config",
+      "purl": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=9d4f75d478573a51&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "platform-python",
+      "purl": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=dfffacd4ee7e7167&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "version": "3.6.8-69.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be2100ec318de201701fcaba16b7663363ee17e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3395467",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "platform-python-setuptools",
+      "purl": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "version": "39.2.0-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ec50811ce8a9855678d3782ff7b88250bbc848",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3195605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pointsto",
+      "purl": "pkg:maven/org.graalvm.nativeimage/pointsto@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79d6b722caf8cee9b2812295bb6c1a5c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f5e0de103e6f85226cbd60246bab2e3d17f963b9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5de7d7e83a5757ab3d91a90db7a604fbfc7732dbff28203921d467ba8a048edf"
+        }
+      ],
+      "bom-ref": "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f5e0de103e6f85226cbd60246bab2e3d17f963b9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347887",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "pointsto-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/pointsto@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5afed6308ee085e7808a48041bec445d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d5868114defdc2f7cc60d2215d77bb67bfaae227"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "339cdb05b609d741906b388d15d478d7c08d3f9ed3b70a45d8bba21e4066dd5d"
+        }
+      ],
+      "bom-ref": "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d5868114defdc2f7cc60d2215d77bb67bfaae227"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347885",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5250f382566aefbe&upstream=popt-1.18-1.el8.src.rpm",
+      "version": "1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "63b1c8ea59d934997b71b3970a8581528a6e40bf",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#63b1c8ea59d934997b71b3970a8581528a6e40bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1447539",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#63b1c8ea59d934997b71b3970a8581528a6e40bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "publicsuffix-list-dafsa",
+      "purl": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+      "version": "20180723-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "33aaa9362fba95857a515475feaff035f59b3384",
+            "url": "git://pkgs.devel.redhat.com/rpms/publicsuffix-list#33aaa9362fba95857a515475feaff035f59b3384"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748188",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/publicsuffix-list#33aaa9362fba95857a515475feaff035f59b3384",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+      "version": "3.0.4-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bc10a725de0ebf632b9cd67735bb46c1c31df1ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#bc10a725de0ebf632b9cd67735bb46c1c31df1ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#bc10a725de0ebf632b9cd67735bb46c1c31df1ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=67f179da5c65c09f&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+      "version": "1:2.6.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e8441401ab6a860bcd370ffde42e9f605bb92e3d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#e8441401ab6a860bcd370ffde42e9f605bb92e3d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747009",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#e8441401ab6a860bcd370ffde42e9f605bb92e3d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=x86_64&distro=rhel-8.10&package-id=4d4f1fee0eb892d3&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+      "version": "1.2.4-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "45e35d535a5cd8f48ab9394b495dbf673eb903cd",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#45e35d535a5cd8f48ab9394b495dbf673eb903cd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=907679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#45e35d535a5cd8f48ab9394b495dbf673eb903cd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+      "version": "4.2.1-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e80551f4e524f020d9b557eed072faba6e1970a8",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#e80551f4e524f020d9b557eed072faba6e1970a8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#e80551f4e524f020d9b557eed072faba6e1970a8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+      "version": "4.0.21-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e8cd35656b141dd5b2617ea383d81c71e6d947",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#89e8cd35656b141dd5b2617ea383d81c71e6d947"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#89e8cd35656b141dd5b2617ea383d81c71e6d947",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-ethtool",
+      "purl": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ba83f3150ddf2a8f&upstream=python-ethtool-0.14-5.el8.src.rpm",
+      "version": "0.14-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "202eebc82b5b3dfa41395f92c09a98d6d0359827",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-ethtool#202eebc82b5b3dfa41395f92c09a98d6d0359827"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1878310",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-ethtool#202eebc82b5b3dfa41395f92c09a98d6d0359827",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=x86_64&distro=rhel-8.10&package-id=f4fe3acddcad7338&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+      "version": "3.28.3-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "53477796225e557d49a99871db8dcf8728f900b6",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#53477796225e557d49a99871db8dcf8728f900b6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1224593",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#53477796225e557d49a99871db8dcf8728f900b6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=d8ed97e00eead113&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "version": "1.13.1-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30ce989734661681faba06ceb0a2573a5c66b85f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2903739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2fcfeb045a4dc845&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+      "version": "2.5-7.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3f661cf6994a1c21eba9801b550a210d8e71f7c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#3f661cf6994a1c21eba9801b550a210d8e71f7c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3026523",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#3f661cf6994a1c21eba9801b550a210d8e71f7c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+      "version": "0.4-31.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747226",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+      "version": "0.9.6-13.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f57fac45551fa077aa273dab9780688212baef3d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#f57fac45551fa077aa273dab9780688212baef3d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=800820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#f57fac45551fa077aa273dab9780688212baef3d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=ec3953fafa801371&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "version": "0.1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4135df9c80076d65c4818b24201054bf2f1be50d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=71e66b4236cdfa73&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=15b8a713ebe85545&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "version": "1.14.2-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc58d5532f28202ecd07557fc2934484fbd0674d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=daeffd8b8a1585b7&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "version": "3.6.8-69.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be2100ec318de201701fcaba16b7663363ee17e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3395467",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+      "version": "9.0.3-24.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2905864",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+      "version": "1.6.8-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7d9d71368d52d8212cee62f3c27e446ec1ef4658",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#7d9d71368d52d8212cee62f3c27e446ec1ef4658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747578",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#7d9d71368d52d8212cee62f3c27e446ec1ef4658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+      "version": "2.20.0-5.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a7ae828b4e21e6c57743ffc05a81005475343a62",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a7ae828b4e21e6c57743ffc05a81005475343a62"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3449388",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a7ae828b4e21e6c57743ffc05a81005475343a62",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f27aea22a4d5de34&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "version": "39.2.0-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ec50811ce8a9855678d3782ff7b88250bbc848",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3195605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+      "version": "1.11.0-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3661c255a5569db674adbb27e1ffa6cd35ba017",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#b3661c255a5569db674adbb27e1ffa6cd35ba017"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747717",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#b3661c255a5569db674adbb27e1ffa6cd35ba017",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cff8e6811247f30a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-syspurpose",
+      "purl": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=960ad18a1caf38a7&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=x86_64&distro=rhel-8.10&package-id=73f0dd5eeadf14f0&upstream=python-systemd-234-8.el8.src.rpm",
+      "version": "234-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ae74ccffe250cc94d1e3ef3478ead327128c0213",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#ae74ccffe250cc94d1e3ef3478ead327128c0213"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747825",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#ae74ccffe250cc94d1e3ef3478ead327128c0213",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+      "version": "1.24.2-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "19a859ea4000236ba954a6b542c428e24c7ec796",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#19a859ea4000236ba954a6b542c428e24c7ec796"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3150813",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#19a859ea4000236ba954a6b542c428e24c7ec796",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-231",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=x86_64&distro=rhel-8.10&package-id=f543af8913e54d7c&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c6cf1ec221cd9836acae449773dca4b746541bbb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel#c6cf1ec221cd9836acae449773dca4b746541bbb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483113",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel#c6cf1ec221cd9836acae449773dca4b746541bbb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-java",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.redhat_00001.1.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483096",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-java-jdk-21-binding",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.redhat_00001.1.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483096",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@7.0-10.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@7.0-10.el8?arch=x86_64&distro=rhel-8.10&package-id=fada24d6082fc020&upstream=readline-7.0-10.el8.src.rpm",
+      "version": "7.0-10.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a73f0afebb2bcab9432598512ed4c166710381a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#a73f0afebb2bcab9432598512ed4c166710381a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748275",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#a73f0afebb2bcab9432598512ed4c166710381a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=x86_64&distro=rhel-8.10&package-id=31b0c2c62bcc343b&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+      "version": "8.10-0.3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rest",
+      "purl": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=x86_64&distro=rhel-8.10&package-id=16f9a10bf6e8d8ff&upstream=rest-0.8.1-2.el8.src.rpm",
+      "version": "0.8.1-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d19e5c77d7dd1627987dcd2ce5561423c56e8572",
+            "url": "git://pkgs.devel.redhat.com/rpms/rest#d19e5c77d7dd1627987dcd2ce5561423c56e8572"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748289",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rest#d19e5c77d7dd1627987dcd2ce5561423c56e8572",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+      "version": "8.1-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5a644f3b114add933d247f8c8f136c41e80dd0b2",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#5a644f3b114add933d247f8c8f136c41e80dd0b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#5a644f3b114add933d247f8c8f136c41e80dd0b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8104254b9f76607b&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7e94ca88aa56ec1d&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=18ff552edc3142bc&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.5-5.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.5-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ac071555714ba21a&upstream=sed-4.5-5.el8.src.rpm",
+      "version": "4.5-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6552e38f557b3990eef296fc79058d20b68c024",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#b6552e38f557b3990eef296fc79058d20b68c024"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1752726",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#b6552e38f557b3990eef296fc79058d20b68c024",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+      "version": "2.12.2-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26",
+            "url": "git://pkgs.devel.redhat.com/rpms/setup#e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2280101",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/setup#e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=04df981948232bdc&upstream=shadow-utils-4.6-22.el8.src.rpm",
+      "version": "2:4.6-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f82d8153c218dc2bebd9a6d7099ea58237088b37",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#f82d8153c218dc2bebd9a6d7099ea58237088b37"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2787584",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#f82d8153c218dc2bebd9a6d7099ea58237088b37",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shared-mime-info",
+      "purl": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ee5abf043dd6b7d6&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+      "version": "1.9-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1047efceb596d22941a5328597673637857886b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shared-mime-info#e1047efceb596d22941a5328597673637857886b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2812019",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shared-mime-info#e1047efceb596d22941a5328597673637857886b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=x86_64&distro=rhel-8.10&package-id=5fba266d57c5b9c9&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+      "version": "3.26.0-19.el8_9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "08fd501b3cc1c5d3b429e85994f0a138064b4df2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#08fd501b3cc1c5d3b429e85994f0a138064b4df2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2837996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#08fd501b3cc1c5d3b429e85994f0a138064b4df2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d3b6159b61b1d2cf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+      "version": "20220623-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5631f07a6720db2f7d8f70e20bd85c12144b56e5",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#5631f07a6720db2f7d8f70e20bd85c12144b56e5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2507619",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#5631f07a6720db2f7d8f70e20bd85c12144b56e5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "svm",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7ade33016ecba96046dfa2ea83418a88"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7bc3285fc33ee1c7db1b0714abe2df8d9daff724"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e0ee3c4678f96c6e857b7b8479b24380c6b47e89ac460bf0ebef138c2fc7f541"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7bc3285fc33ee1c7db1b0714abe2df8d9daff724"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347859",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-agent",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-agent@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "211bb0f3645201b6dde6e4ad7fdeb95f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6665a29599c7834c394f2b9d32e05da2aec3a468"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "453c0229fe2a86c717c01bad09644eb16fa5cb1d7dd5067e48ef7887a096e552"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6665a29599c7834c394f2b9d32e05da2aec3a468"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347879",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-agent-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-agent@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "65cbb9bb9cb7f734ecd4243aef275583"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48a3aae771f2ce450087d997b12088ae621d5c60"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "33e55579c44f5f532982ad744f68400d62a6c9263e51649c8f3634aabdf268bf"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "48a3aae771f2ce450087d997b12088ae621d5c60"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347874",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-configure",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-configure@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b3f8525597d25a79f8eb007e45918a12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "16da989f46ec44e2fa11374ab431d6cc63f1df77"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "24bd1f4f30605a3ea4ae41820ef37bdb40cdf2fc8c10938f0ac804c201ead0a7"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "16da989f46ec44e2fa11374ab431d6cc63f1df77"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347884",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-configure-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-configure@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "21b60a2579e8363b82b7e4e939173d2c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "760dae3c709289404ccf94c531be59726e695c55"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fcabd5cbdf5e5e399c6d346087fec36ec46eec6d2b6cb43f7eb098b318d2ced5"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "760dae3c709289404ccf94c531be59726e695c55"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347906",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-diagnostics-agent",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "614a660fa9cc3e62af68a196e472063b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9a42d2dcf5d4eb6942764a47590e85e693ee6df3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7c41871055f13dc9e0d8d9962f3b1c89306ebccd7c7bccc01858470772d86561"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9a42d2dcf5d4eb6942764a47590e85e693ee6df3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347886",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-diagnostics-agent-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b302f55e82a1f5129885919727a99c55"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "76a5d6fd544395c0c054b8465f97ff2c97f5b44a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aeffd8079fe426107756965d858f1dcf2b7dc91a3c0d1acb6dcc6fe9a8f3dd67"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "76a5d6fd544395c0c054b8465f97ff2c97f5b44a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347870",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-driver",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-driver@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dce52947b4dcb38a36a7a46a122c4449"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57d00f8b24a5af5004c3aa032c5a3c11fac116cd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e521e3d64dea330f9fccd743780932bf1a09d3e44865650e2b7aa2ae268ccd80"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "57d00f8b24a5af5004c3aa032c5a3c11fac116cd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347851",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-driver-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-driver@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9f2af9d85c8dd77ae4f286b40eb910c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "753c3329726a341da7f45dbe0b602b04d68f37bd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "814e3f730fcef73784938be9a43a1a5d6854cdf85b2f839d8d50928704d01c21"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "753c3329726a341da7f45dbe0b602b04d68f37bd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347877",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-foreign",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-foreign@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f0eadec5d5147d809f8e5629cfd43660"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0a61ab48509d780fdecec54ce986e4dfb23df446"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a443dbe1eb2c0b53d08ac26fbc29f6257951e3c3703d989e6439141fad4e019"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0a61ab48509d780fdecec54ce986e4dfb23df446"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347852",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-foreign-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-foreign@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e5621dfcd5e63abda82b9e5fb337b212"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "10b93299a4f24cc155b3afe4e780fb1bdaf9537a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bda6d1f3ebf2d6591212be27ed44c660c36748144531250130321ec593cb5a5c"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "10b93299a4f24cc155b3afe4e780fb1bdaf9537a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347858",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c5ef3cbcdfbc1537150a7a922d5ebf83"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "263ce6b470b0910ed611e6af71b561ff9ac271fb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2494baeaf0ca398f893e1184563aeddef9f9d37f7cb5b41fbb7637ddbec4c7b4"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "263ce6b470b0910ed611e6af71b561ff9ac271fb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347857",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=65f902ab9483fb71&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=b2e6790fad5fa99f&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=45ab67aeec9da32e&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.30-9.el8?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.30-9.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=8095ed048378bfe9&upstream=tar-1.30-9.el8.src.rpm",
+      "version": "2:1.30-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c4fcab8e46b3b03227ec1598aaafd71a0486d42f",
+            "url": "git://pkgs.devel.redhat.com/rpms/tar#c4fcab8e46b3b03227ec1598aaafd71a0486d42f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2373740",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tar#c4fcab8e46b3b03227ec1598aaafd71a0486d42f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=925f06f0270a020a&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+      "version": "2.3.2-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8fdc15508953c0878fe75d6e399ceff961b8164d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tpm2-tss#8fdc15508953c0878fe75d6e399ceff961b8164d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2795188",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tpm2-tss#8fdc15508953c0878fe75d6e399ceff961b8164d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "truffle-compiler",
+      "purl": "pkg:maven/org.graalvm.truffle/truffle-compiler@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c0cf8949a60834b8fee592bb321a7580"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b75c426d6a52ab0df449f9f3914be30dfcfe693"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d1c22f68739a08492f05beb8a61fa55d179e3c4f267553badef030fd69947748"
+        }
+      ],
+      "bom-ref": "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b75c426d6a52ab0df449f9f3914be30dfcfe693"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347901",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "truffle-compiler-sources",
+      "purl": "pkg:maven/org.graalvm.truffle/truffle-compiler@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d4ba41bde228284acdf9702fce45612"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c3742acfd47df34119a64db1797b8503d56caa39"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e4809b741c57238165d71b98661d795a9254a13bb51e96f5dcc5fd58e589ba9"
+        }
+      ],
+      "bom-ref": "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c3742acfd47df34119a64db1797b8503d56caa39"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347897",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "ttmkfdir",
+      "purl": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=x86_64&distro=rhel-8.10&package-id=036174f6bccab119&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+      "version": "3.0.9-54.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb",
+            "url": "git://pkgs.devel.redhat.com/rpms/ttmkfdir#3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748474",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ttmkfdir#3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+      "version": "2025a-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "524d097142d6cf1bd9c98bf1e59817f32314fdac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3480271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata-java",
+      "purl": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+      "version": "2025a-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "524d097142d6cf1bd9c98bf1e59817f32314fdac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3480271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unzip",
+      "purl": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a0abb8bcc3359fe7&upstream=unzip-6.0-47.el8_10.src.rpm",
+      "version": "6.0-47.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca31be59522450f29f7eed5f32cc972130258c15",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#ca31be59522450f29f7eed5f32cc972130258c15"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3354512",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#ca31be59522450f29f7eed5f32cc972130258c15",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=x86_64&distro=rhel-8.10&package-id=db4f73b20c06915b&upstream=usermode-1.113-2.el8.src.rpm",
+      "version": "1.113-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f1102e65b3ae5d34421050b958dbe85c1bc21988",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#f1102e65b3ae5d34421050b958dbe85c1bc21988"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1683221",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#f1102e65b3ae5d34421050b958dbe85c1bc21988",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=ec84218777674d0c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=a5e633f1b5336f31&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+      "version": "2:8.0.1763-19.el8_6.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "20a47258a891a63a9178afb9d69954e4ff123df3",
+            "url": "git://pkgs.devel.redhat.com/rpms/vim#20a47258a891a63a9178afb9d69954e4ff123df3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049552",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/vim#20a47258a891a63a9178afb9d69954e4ff123df3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=x86_64&distro=rhel-8.10&package-id=445adfd4097a0162&upstream=virt-what-1.25-4.el8.src.rpm",
+      "version": "1.25-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-20.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-20.el8?arch=x86_64&distro=rhel-8.10&package-id=1eb75829eed60337&upstream=which-2.21-20.el8.src.rpm",
+      "version": "2.21-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "66aa787e1516e66d79a4d107e3c0441f92e91f59",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#66aa787e1516e66d79a4d107e3c0441f92e91f59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2428391",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#66aa787e1516e66d79a4d107e3c0441f92e91f59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "word",
+      "purl": "pkg:maven/org.graalvm.sdk/word@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "decb3a02e4f637071e7211ec253c68ae"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "605a0780c64fe2a300cff38c56a2c0cdf801087c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ae53c3f185a3627f0b495cfb11217fad96ea8528ce7f1cdcd463d31605432c8d"
+        }
+      ],
+      "bom-ref": "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/word.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/word.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "605a0780c64fe2a300cff38c56a2c0cdf801087c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347854",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "word-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/word@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "356e5fd6981925e983c6bf14997400d7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9471ee87dbb838c92b85a7c687cfc6d6a58b94ef"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c1bddbb237b9ab1f0c358722e3f398b34324e496979b9654b1db364878660819"
+        }
+      ],
+      "bom-ref": "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/word-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/word-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9471ee87dbb838c92b85a7c687cfc6d6a58b94ef"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347902",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "xkeyboard-config",
+      "purl": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+      "version": "2.28-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c4e51af72d9e6c77269af9b2008f35dd6628277b",
+            "url": "git://pkgs.devel.redhat.com/rpms/xkeyboard-config#c4e51af72d9e6c77269af9b2008f35dd6628277b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1000732",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xkeyboard-config#c4e51af72d9e6c77269af9b2008f35dd6628277b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xorg-x11-font-utils",
+      "purl": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=8f583fdc88c7e9f6&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+      "version": "1:7.5-41.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "459ef32286e6d3c633ecb31f33f2d277d63410ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-font-utils#459ef32286e6d3c633ecb31f33f2d277d63410ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1611879",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-font-utils#459ef32286e6d3c633ecb31f33f2d277d63410ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xorg-x11-fonts-Type1",
+      "purl": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+      "version": "7.5-19.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Lucida and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "85df1df15c526b6ec63c8d8f233f1eef5b51d3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-fonts#85df1df15c526b6ec63c8d8f233f1eef5b51d3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748589",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-fonts#85df1df15c526b6ec63c8d8f233f1eef5b51d3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=x86_64&distro=rhel-8.10&package-id=abb6dbdce82086a9&upstream=xz-5.2.4-4.el8_6.src.rpm",
+      "version": "5.2.4-4.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "361386e5dd2092974b32ced26b6ce68aba1913f8",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#361386e5dd2092974b32ced26b6ce68aba1913f8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032511",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#361386e5dd2092974b32ced26b6ce68aba1913f8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=c52632d932de2bdb&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "version": "1.2.11-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2508538",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib-devel",
+      "purl": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=6e33651aa704ce69&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "version": "1.2.11-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2508538",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "1c4abceaa349a8c2",
+      "dependsOn": [
+        "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+        "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=d9a5accf56f24c33&upstream=acl-2.2.53-3.el8.src.rpm",
+        "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+        "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+        "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=x86_64&distro=rhel-8.10&package-id=e687411599c00951&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+        "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6f0e2bd1ba41f221&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=18bf4eca2dcb5d41&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=f90533d328f2b7ef&upstream=atk-2.28.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=3daa175bec117741&upstream=audit-3.1.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=308de131028314a6&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+        "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+        "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=x86_64&distro=rhel-8.10&package-id=4d3216e237d4772a&upstream=bash-4.4.20-5.el8.src.rpm",
+        "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=x86_64&distro=rhel-8.10&package-id=546f5310974cd65f&upstream=binutils-2.30-125.el8_10.src.rpm",
+        "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=x86_64&distro=rhel-8.10&package-id=2fe1dc3826c55b7f&upstream=brotli-1.0.6-3.el8.src.rpm",
+        "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8b61c2a24f04e8f0&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc96ec6647dfc148&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+        "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=f10327d118a11076&upstream=cairo-1.15.12-6.el8.src.rpm",
+        "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6a998977e2992ef1&upstream=cairo-1.15.12-6.el8.src.rpm",
+        "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=331234308ac7a0d9&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+        "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+        "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+        "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=beb3c422d82ba036&upstream=colord-1.4.2-1.el8.src.rpm",
+        "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+        "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+        "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=x86_64&distro=rhel-8.10&package-id=fbfda60c10f25f78&upstream=coreutils-8.30-15.el8.src.rpm",
+        "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc967e75e06e97d5&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=69294411c9a2d835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=6f5a17a48d3922cf&upstream=cracklib-2.9.6-15.el8.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+        "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+        "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a75f80dba0f3a0f7&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+        "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=b3d18b40fd9590f8&upstream=cups-2.2.6-62.el8_10.src.rpm",
+        "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=67c8cdb501d51041&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=x86_64&distro=rhel-8.10&package-id=26a897ee42073d2f&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+        "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=f89b9e929eac9b10&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=18b79fc94c901ed7&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=x86_64&distro=rhel-8.10&package-id=89265388117ac552&upstream=dbus-glib-0.110-2.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=233d3813cd179460&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=6cfefdeb2079d438&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=x86_64&distro=rhel-8.10&package-id=82014b60c2c31aa4&upstream=dconf-0.28.0-4.el8.src.rpm",
+        "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+        "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+        "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=2ca7d48283969523&upstream=lvm2-2.03.14-14.el8.src.rpm",
+        "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=8d450b0b684f93e2&upstream=lvm2-2.03.14-14.el8.src.rpm",
+        "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=74d1497fb48abbfe&upstream=dmidecode-3.5-1.el8.src.rpm",
+        "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=dec2d1d0978e8ff2&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=28b80caf9216b1c1&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=45471cb62ebee70d&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d4395aa9af150f17&upstream=expat-2.2.5-16.el8_10.src.rpm",
+        "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=x86_64&distro=rhel-8.10&package-id=75f1bf4aa9e18cac&upstream=file-5.33-26.el8.src.rpm",
+        "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=x86_64&distro=rhel-8.10&package-id=530cae3194c7bc81&upstream=filesystem-3.8-6.el8.src.rpm",
+        "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=7bdec5ea3b91a11d&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ff91750b39d6154c&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+        "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+        "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=798a1a6ce043b83a&upstream=freetype-2.9.1-9.el8.src.rpm",
+        "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=7fb7501cfb112967&upstream=freetype-2.9.1-9.el8.src.rpm",
+        "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=x86_64&distro=rhel-8.10&package-id=0091172b1339820c&upstream=fribidi-1.0.4-9.el8.src.rpm",
+        "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=0c05100f89a630da&upstream=gawk-4.2.1-4.el8.src.rpm",
+        "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=3d20ce55e2320b78&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2607bc43cf5c2a4b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=x86_64&distro=rhel-8.10&package-id=179000405ec99ff8&upstream=gdb-8.2-20.el8.src.rpm",
+        "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=91b9bcc71236f11e&upstream=gdbm-1.18-2.el8.src.rpm",
+        "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=60ef0563eb70d44e&upstream=gdbm-1.18-2.el8.src.rpm",
+        "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=95a1d7c736d8de13&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=fb3b2b45efc128f2&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=x86_64&distro=rhel-8.10&package-id=096180e123e8406f&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+        "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7a2a1554ab953ced&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+        "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=68a1afa47f2c3b1d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=83e5c3b52d33cd4d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=8c6c06fb42848c8f&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=023f8ce189ff21a6&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=fea1cee95cc1770b&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=24d224b650aa4868&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=682fed2cbd3416af&upstream=gmp-6.1.2-11.el8.src.rpm",
+        "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=389b497b6ede3b42&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+        "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=x86_64&distro=rhel-8.10&package-id=f59dc71cd27c2eef&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+        "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fe6d53a664001f4b&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+        "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=4b9096e1d72fba6c&upstream=gpgme-1.13.1-12.el8.src.rpm",
+        "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+        "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+        "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=x86_64&distro=rhel-8.10&package-id=a4d5e3a755746745&upstream=graphite2-1.3.10-10.el8.src.rpm",
+        "pkg:rpm/redhat/grep@3.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=0d92b5058935e5ce&upstream=grep-3.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=x86_64&distro=rhel-8.10&package-id=efa1ae4e2cc32b52&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+        "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a3990f63e65ca2d4&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f9d2b29b30a6527a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=x86_64&distro=rhel-8.10&package-id=85bfed57331050b8&upstream=gzip-1.9-13.el8_5.src.rpm",
+        "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=a7f512046ee7adb6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+        "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+        "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=x86_64&distro=rhel-8.10&package-id=698a2ee03511ee82&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+        "pkg:rpm/redhat/info@6.5-7.el8?arch=x86_64&distro=rhel-8.10&package-id=de4110a3b17745a9&upstream=texinfo-6.5-7.el8.src.rpm",
+        "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=a754b86118c6038f&upstream=isl-0.16.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=af996aedcac3f597&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=3394ab0ab230be76&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=c3c548a1cf4277b9&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=87d1d39715488da6&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=a8f850dce4001448&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=071410ef311a2c01&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+        "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=x86_64&distro=rhel-8.10&package-id=d8699e1e2662d072&upstream=jbigkit-2.1-14.el8.src.rpm",
+        "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=e4a415a46ed0b08a",
+        "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3be41816d8f28dfc&upstream=json-c-0.13.1-3.el8.src.rpm",
+        "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=1cc0f9bd2e60c960&upstream=json-glib-1.4.4-1.el8.src.rpm",
+        "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+        "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+        "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b87b2a1a83ea5ae&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+        "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=x86_64&distro=rhel-8.10&package-id=9cebf87852c8b719&upstream=keyutils-1.5.10-9.el8.src.rpm",
+        "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=x86_64&distro=rhel-8.10&package-id=5eaf92d12e6e8b83&upstream=kmod-25-20.el8.src.rpm",
+        "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=x86_64&distro=rhel-8.10&package-id=b32043faf4582a8e&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+        "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+        "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=x86_64&distro=rhel-8.10&package-id=5991da020ab31dad&upstream=lcms2-2.9-2.el8.src.rpm",
+        "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=024152497459451d&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d98acce1b0f6dbf&upstream=libXau-1.0.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=2f5c10ae1d5b6ee0&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+        "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3d69163030db7151&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+        "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=4e6d7f19fab9655f&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+        "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=873a3bb46d2b4967&upstream=libXext-1.3.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=9ff054eb2c69e450&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+        "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6da3b9e99fbfd4ec&upstream=libXft-2.3.3-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=x86_64&distro=rhel-8.10&package-id=811246ee1794dc4d&upstream=libXi-1.7.10-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b11e77e7ad718f54&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d7ce0edbccb3de17&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a7872c77d81efdaf&upstream=libXrender-0.9.10-7.el8.src.rpm",
+        "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=1fdf1f9af9334a9c&upstream=libXtst-1.2.3-7.el8.src.rpm",
+        "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4625a584e9b2b6ea&upstream=acl-2.2.53-3.el8.src.rpm",
+        "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cf310560d737d7b0&upstream=libarchive-3.3.3-5.el8.src.rpm",
+        "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3c2c05fa2e65b482&upstream=libassuan-2.5.1-3.el8.src.rpm",
+        "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d9e03bd84141733&upstream=attr-2.4.48-3.el8.src.rpm",
+        "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=16ca121e3b0dacdb&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=x86_64&distro=rhel-8.10&package-id=90ec99a4d3d54a2c&upstream=libcap-2.48-6.el8_9.src.rpm",
+        "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=x86_64&distro=rhel-8.10&package-id=71d6200076770364&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+        "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ef01434b20a692cd&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6004137764ffb113&upstream=libcomps-0.1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=8ba50251b960d097&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=x86_64&distro=rhel-8.10&package-id=4927708ea0661e71&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+        "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=9dcc22fdf0d465d0&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+        "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=33d103636531829f&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+        "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=1b437b219242ccbc&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b2f8dcf273fa3d6e&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+        "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=70487d6e9c60434d&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libffi@3.1-24.el8?arch=x86_64&distro=rhel-8.10&package-id=d12942964336c965&upstream=libffi-3.1-24.el8.src.rpm",
+        "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=x86_64&distro=rhel-8.10&package-id=1291ddc02147059e&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+        "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=0e695a071ee24d8f&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=x86_64&distro=rhel-8.10&package-id=6aad648da8bc9385&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+        "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=aeda3d65f9995507&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=x86_64&distro=rhel-8.10&package-id=33a7fbe1cf5b2659&upstream=libgpg-error-1.31-1.el8.src.rpm",
+        "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fc70f518e05a2e09&upstream=libgusb-0.3.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=139540dbb555a062&upstream=libidn2-2.2.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=x86_64&distro=rhel-8.10&package-id=74007dc1b00bff55&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+        "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=x86_64&distro=rhel-8.10&package-id=4189b45d8b066ed1&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+        "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=x86_64&distro=rhel-8.10&package-id=d38d8a0207f3b579&upstream=libmodman-2.0.1-17.el8.src.rpm",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=99fb83cf0454297f&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=d3d0f503ea9d3051&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=x86_64&distro=rhel-8.10&package-id=ebb3b71859019ae6&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+        "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=0eb3d862523d0548&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+        "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=449118949812d0d2&upstream=libnl3-3.7.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=x86_64&distro=rhel-8.10&package-id=ef43e4d2fbb09d0d&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+        "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e24e2f3bc22ffe13&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=664883aa573607f5&upstream=libpng-1.6.34-5.el8.src.rpm",
+        "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=18dbfd6f3afa0ce4&upstream=libpng-1.6.34-5.el8.src.rpm",
+        "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9e5c394bd88d169f&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+        "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9194b925e7a3bebf&upstream=libpsl-0.20.2-6.el8.src.rpm",
+        "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6085dfcccefaea69&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+        "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+        "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+        "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=9780f211eda573e6&upstream=librepo-1.14.2-5.el8.src.rpm",
+        "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=x86_64&distro=rhel-8.10&package-id=256edfa407c3b660&upstream=libreport-2.9.5-15.el8.src.rpm",
+        "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cd55edd53a4bce8a&upstream=librhsm-0.0.3-5.el8.src.rpm",
+        "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e4eb640ed71d1387&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=40b14020c3a76059&upstream=libselinux-2.9-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d353a56719b280d0&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+        "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=a493c97a5a749b13&upstream=libsepol-2.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=x86_64&distro=rhel-8.10&package-id=c2082e19a7d6e3c1&upstream=libsigsegv-2.11-5.el8.src.rpm",
+        "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=c5c5a2cbb0227d12&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=x86_64&distro=rhel-8.10&package-id=18ed592ae788b75e&upstream=libsolv-0.7.20-6.el8.src.rpm",
+        "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7f51719269909e33&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+        "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=efb80d980b17a2b2&upstream=libssh-0.9.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=53184858d25776ab&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=13fb33eabcbdd348&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=x86_64&distro=rhel-8.10&package-id=635524cc0dab781f&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+        "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=x86_64&distro=rhel-8.10&package-id=348223321fdebdeb&upstream=libthai-0.1.27-2.el8.src.rpm",
+        "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=x86_64&distro=rhel-8.10&package-id=416647ae0ce9a60e&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+        "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cad80c4d9a1f5dcf&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3cb1aef7db7925a5&upstream=libunistring-0.9.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=x86_64&distro=rhel-8.10&package-id=2079bf2de278c73a&upstream=libusbx-1.0.23-4.el8.src.rpm",
+        "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a6407cda71986b6d&upstream=libuser-0.62-26.el8_10.src.rpm",
+        "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=ff85e6ae6fbe6897&upstream=libutempter-1.1.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=3431e92ffd288b38&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=x86_64&distro=rhel-8.10&package-id=dc73e15bfd2f72a0&upstream=libverto-0.3.2-2.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=7ad8c4758bb988a6&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=c906ed32e01195b8&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=545ba41b48d6a5eb&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cc84571d169d80d9&upstream=libxcb-1.13.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=fa2892199f269e9b&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9914b3b870b78700&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=8159aa7df418566b&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=x86_64&distro=rhel-8.10&package-id=86561759c46293e9&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+        "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=x86_64&distro=rhel-8.10&package-id=bd0d38eebd665ff4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5a06b2a5cab1ed24&upstream=zstd-1.4.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=x86_64&distro=rhel-8.10&package-id=7a77fcd86ba06ecc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+        "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=24fdcea8a4d24eba&upstream=lua-5.3.4-12.el8.src.rpm",
+        "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=984a046eed89d84d&upstream=lua-5.3.4-12.el8.src.rpm",
+        "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=x86_64&distro=rhel-8.10&package-id=747f8d08054bb295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+        "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=x86_64&distro=rhel-8.10&package-id=51067913349861f2&upstream=mpfr-3.1.6-1.el8.src.rpm",
+        "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+        "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+        "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+        "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+        "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+        "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=x86_64&distro=rhel-8.10&package-id=96d91b80e17d2e2d&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+        "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=x86_64&distro=rhel-8.10&package-id=627574c547a84ac7&upstream=nettle-3.4.1-7.el8.src.rpm",
+        "pkg:rpm/redhat/npth@1.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=9c6455318efa2d7b&upstream=npth-1.5-4.el8.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eeec482f0356b353&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eb5a35462c030a1d&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=c12e3afc80ee2624&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=a7a0502be801403c&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=3100d9810595d6c0&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=8d7f6e696a826a11&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+        "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+        "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b27e7b2961c600c&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=4c1ab9ead2aef73f&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+        "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=355fe5843a01b570&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+        "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=aa4a466c8c83bfa4&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+        "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=x86_64&distro=rhel-8.10&package-id=faad0cdca7c3ac08&upstream=pam-1.3.1-36.el8_10.src.rpm",
+        "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=x86_64&distro=rhel-8.10&package-id=60fd46064a3ef440&upstream=pango-1.42.4-8.el8.src.rpm",
+        "pkg:rpm/redhat/passwd@0.80-4.el8?arch=x86_64&distro=rhel-8.10&package-id=5d97178827061fdc&upstream=passwd-0.80-4.el8.src.rpm",
+        "pkg:rpm/redhat/pcre@8.42-6.el8?arch=x86_64&distro=rhel-8.10&package-id=689b6a9f1c6e3a4d&upstream=pcre-8.42-6.el8.src.rpm",
+        "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=e986eeba073837bb&upstream=pcre2-10.32-3.el8_6.src.rpm",
+        "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=x86_64&distro=rhel-8.10&package-id=87a444578516c6eb&upstream=pixman-0.38.4-4.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=32b0d48565fb2224&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=9d4f75d478573a51&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=dfffacd4ee7e7167&upstream=python3-3.6.8-69.el8_10.src.rpm",
+        "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+        "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+        "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+        "pkg:rpm/redhat/popt@1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5250f382566aefbe&upstream=popt-1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+        "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=67f179da5c65c09f&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=x86_64&distro=rhel-8.10&package-id=4d4f1fee0eb892d3&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+        "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+        "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ba83f3150ddf2a8f&upstream=python-ethtool-0.14-5.el8.src.rpm",
+        "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=x86_64&distro=rhel-8.10&package-id=f4fe3acddcad7338&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+        "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=d8ed97e00eead113&upstream=gpgme-1.13.1-12.el8.src.rpm",
+        "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2fcfeb045a4dc845&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=ec3953fafa801371&upstream=libcomps-0.1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=71e66b4236cdfa73&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=15b8a713ebe85545&upstream=librepo-1.14.2-5.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=daeffd8b8a1585b7&upstream=python3-3.6.8-69.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+        "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+        "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f27aea22a4d5de34&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cff8e6811247f30a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=960ad18a1caf38a7&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=x86_64&distro=rhel-8.10&package-id=73f0dd5eeadf14f0&upstream=python-systemd-234-8.el8.src.rpm",
+        "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=x86_64&distro=rhel-8.10&package-id=f543af8913e54d7c&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+        "pkg:rpm/redhat/readline@7.0-10.el8?arch=x86_64&distro=rhel-8.10&package-id=fada24d6082fc020&upstream=readline-7.0-10.el8.src.rpm",
+        "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=x86_64&distro=rhel-8.10&package-id=31b0c2c62bcc343b&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+        "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=x86_64&distro=rhel-8.10&package-id=16f9a10bf6e8d8ff&upstream=rest-0.8.1-2.el8.src.rpm",
+        "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+        "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8104254b9f76607b&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7e94ca88aa56ec1d&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=18ff552edc3142bc&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/sed@4.5-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ac071555714ba21a&upstream=sed-4.5-5.el8.src.rpm",
+        "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+        "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=04df981948232bdc&upstream=shadow-utils-4.6-22.el8.src.rpm",
+        "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ee5abf043dd6b7d6&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=x86_64&distro=rhel-8.10&package-id=5fba266d57c5b9c9&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+        "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d3b6159b61b1d2cf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+        "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+        "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+        "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+        "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+        "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+        "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+        "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+        "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+        "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+        "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+        "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+        "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+        "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=65f902ab9483fb71&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=b2e6790fad5fa99f&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=45ab67aeec9da32e&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/tar@1.30-9.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=8095ed048378bfe9&upstream=tar-1.30-9.el8.src.rpm",
+        "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=925f06f0270a020a&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+        "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+        "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+        "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=x86_64&distro=rhel-8.10&package-id=036174f6bccab119&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+        "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+        "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+        "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a0abb8bcc3359fe7&upstream=unzip-6.0-47.el8_10.src.rpm",
+        "pkg:rpm/redhat/usermode@1.113-2.el8?arch=x86_64&distro=rhel-8.10&package-id=db4f73b20c06915b&upstream=usermode-1.113-2.el8.src.rpm",
+        "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=ec84218777674d0c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=a5e633f1b5336f31&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+        "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=x86_64&distro=rhel-8.10&package-id=445adfd4097a0162&upstream=virt-what-1.25-4.el8.src.rpm",
+        "pkg:rpm/redhat/which@2.21-20.el8?arch=x86_64&distro=rhel-8.10&package-id=1eb75829eed60337&upstream=which-2.21-20.el8.src.rpm",
+        "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+        "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+        "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+        "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=8f583fdc88c7e9f6&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+        "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=x86_64&distro=rhel-8.10&package-id=abb6dbdce82086a9&upstream=xz-5.2.4-4.el8_6.src.rpm",
+        "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=c52632d932de2bdb&upstream=zlib-1.2.11-25.el8.src.rpm",
+        "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=6e33651aa704ce69&upstream=zlib-1.2.11-25.el8.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=d9a5accf56f24c33&upstream=acl-2.2.53-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=x86_64&distro=rhel-8.10&package-id=e687411599c00951&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6f0e2bd1ba41f221&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=18bf4eca2dcb5d41&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=f90533d328f2b7ef&upstream=atk-2.28.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=3daa175bec117741&upstream=audit-3.1.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=308de131028314a6&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=x86_64&distro=rhel-8.10&package-id=4d3216e237d4772a&upstream=bash-4.4.20-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=x86_64&distro=rhel-8.10&package-id=546f5310974cd65f&upstream=binutils-2.30-125.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=x86_64&distro=rhel-8.10&package-id=2fe1dc3826c55b7f&upstream=brotli-1.0.6-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8b61c2a24f04e8f0&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc96ec6647dfc148&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=f10327d118a11076&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6a998977e2992ef1&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=331234308ac7a0d9&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=beb3c422d82ba036&upstream=colord-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=x86_64&distro=rhel-8.10&package-id=fbfda60c10f25f78&upstream=coreutils-8.30-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cc967e75e06e97d5&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=69294411c9a2d835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=x86_64&distro=rhel-8.10&package-id=6f5a17a48d3922cf&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a75f80dba0f3a0f7&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=b3d18b40fd9590f8&upstream=cups-2.2.6-62.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=67c8cdb501d51041&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=x86_64&distro=rhel-8.10&package-id=26a897ee42073d2f&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=f89b9e929eac9b10&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=18b79fc94c901ed7&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=x86_64&distro=rhel-8.10&package-id=89265388117ac552&upstream=dbus-glib-0.110-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=233d3813cd179460&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=6cfefdeb2079d438&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=x86_64&distro=rhel-8.10&package-id=82014b60c2c31aa4&upstream=dconf-0.28.0-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=2ca7d48283969523&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=x86_64&distro=rhel-8.10&epoch=8&package-id=8d450b0b684f93e2&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=74d1497fb48abbfe&upstream=dmidecode-3.5-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=dec2d1d0978e8ff2&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=28b80caf9216b1c1&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=x86_64&distro=rhel-8.10&package-id=45471cb62ebee70d&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d4395aa9af150f17&upstream=expat-2.2.5-16.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=x86_64&distro=rhel-8.10&package-id=75f1bf4aa9e18cac&upstream=file-5.33-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=x86_64&distro=rhel-8.10&package-id=530cae3194c7bc81&upstream=filesystem-3.8-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=7bdec5ea3b91a11d&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ff91750b39d6154c&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=798a1a6ce043b83a&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=x86_64&distro=rhel-8.10&package-id=7fb7501cfb112967&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=x86_64&distro=rhel-8.10&package-id=0091172b1339820c&upstream=fribidi-1.0.4-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=x86_64&distro=rhel-8.10&package-id=0c05100f89a630da&upstream=gawk-4.2.1-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=3d20ce55e2320b78&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2607bc43cf5c2a4b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=x86_64&distro=rhel-8.10&package-id=179000405ec99ff8&upstream=gdb-8.2-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=91b9bcc71236f11e&upstream=gdbm-1.18-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=60ef0563eb70d44e&upstream=gdbm-1.18-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=95a1d7c736d8de13&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=fb3b2b45efc128f2&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=x86_64&distro=rhel-8.10&package-id=096180e123e8406f&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7a2a1554ab953ced&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=68a1afa47f2c3b1d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=83e5c3b52d33cd4d&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=8c6c06fb42848c8f&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=023f8ce189ff21a6&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=fea1cee95cc1770b&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=x86_64&distro=rhel-8.10&package-id=24d224b650aa4868&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=682fed2cbd3416af&upstream=gmp-6.1.2-11.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=389b497b6ede3b42&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=x86_64&distro=rhel-8.10&package-id=f59dc71cd27c2eef&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fe6d53a664001f4b&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=4b9096e1d72fba6c&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=x86_64&distro=rhel-8.10&package-id=a4d5e3a755746745&upstream=graphite2-1.3.10-10.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=0d92b5058935e5ce&upstream=grep-3.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=x86_64&distro=rhel-8.10&package-id=efa1ae4e2cc32b52&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a3990f63e65ca2d4&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f9d2b29b30a6527a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=x86_64&distro=rhel-8.10&package-id=85bfed57331050b8&upstream=gzip-1.9-13.el8_5.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=a7f512046ee7adb6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=x86_64&distro=rhel-8.10&package-id=698a2ee03511ee82&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/info@6.5-7.el8?arch=x86_64&distro=rhel-8.10&package-id=de4110a3b17745a9&upstream=texinfo-6.5-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=a754b86118c6038f&upstream=isl-0.16.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=x86_64&distro=rhel-8.10&package-id=af996aedcac3f597&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=3394ab0ab230be76&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=c3c548a1cf4277b9&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=87d1d39715488da6&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=a8f850dce4001448&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=071410ef311a2c01&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=x86_64&distro=rhel-8.10&package-id=d8699e1e2662d072&upstream=jbigkit-2.1-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=e4a415a46ed0b08a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3be41816d8f28dfc&upstream=json-c-0.13.1-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=1cc0f9bd2e60c960&upstream=json-glib-1.4.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b87b2a1a83ea5ae&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=x86_64&distro=rhel-8.10&package-id=9cebf87852c8b719&upstream=keyutils-1.5.10-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=x86_64&distro=rhel-8.10&package-id=5eaf92d12e6e8b83&upstream=kmod-25-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=x86_64&distro=rhel-8.10&package-id=b32043faf4582a8e&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=x86_64&distro=rhel-8.10&package-id=5991da020ab31dad&upstream=lcms2-2.9-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=024152497459451d&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d98acce1b0f6dbf&upstream=libXau-1.0.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=2f5c10ae1d5b6ee0&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3d69163030db7151&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=x86_64&distro=rhel-8.10&package-id=4e6d7f19fab9655f&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=873a3bb46d2b4967&upstream=libXext-1.3.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=9ff054eb2c69e450&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6da3b9e99fbfd4ec&upstream=libXft-2.3.3-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=x86_64&distro=rhel-8.10&package-id=811246ee1794dc4d&upstream=libXi-1.7.10-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b11e77e7ad718f54&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d7ce0edbccb3de17&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=x86_64&distro=rhel-8.10&package-id=a7872c77d81efdaf&upstream=libXrender-0.9.10-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=x86_64&distro=rhel-8.10&package-id=1fdf1f9af9334a9c&upstream=libXtst-1.2.3-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4625a584e9b2b6ea&upstream=acl-2.2.53-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cf310560d737d7b0&upstream=libarchive-3.3.3-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3c2c05fa2e65b482&upstream=libassuan-2.5.1-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=x86_64&distro=rhel-8.10&package-id=4d9e03bd84141733&upstream=attr-2.4.48-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=16ca121e3b0dacdb&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=x86_64&distro=rhel-8.10&package-id=90ec99a4d3d54a2c&upstream=libcap-2.48-6.el8_9.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=x86_64&distro=rhel-8.10&package-id=71d6200076770364&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ef01434b20a692cd&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=6004137764ffb113&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=8ba50251b960d097&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=x86_64&distro=rhel-8.10&package-id=4927708ea0661e71&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=9dcc22fdf0d465d0&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=x86_64&distro=rhel-8.10&package-id=33d103636531829f&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=1b437b219242ccbc&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=x86_64&distro=rhel-8.10&package-id=b2f8dcf273fa3d6e&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=70487d6e9c60434d&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=x86_64&distro=rhel-8.10&package-id=d12942964336c965&upstream=libffi-3.1-24.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=x86_64&distro=rhel-8.10&package-id=1291ddc02147059e&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=0e695a071ee24d8f&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=x86_64&distro=rhel-8.10&package-id=6aad648da8bc9385&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=aeda3d65f9995507&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=x86_64&distro=rhel-8.10&package-id=33a7fbe1cf5b2659&upstream=libgpg-error-1.31-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=fc70f518e05a2e09&upstream=libgusb-0.3.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=139540dbb555a062&upstream=libidn2-2.2.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=x86_64&distro=rhel-8.10&package-id=74007dc1b00bff55&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=x86_64&distro=rhel-8.10&package-id=4189b45d8b066ed1&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=x86_64&distro=rhel-8.10&package-id=d38d8a0207f3b579&upstream=libmodman-2.0.1-17.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=99fb83cf0454297f&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=d3d0f503ea9d3051&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=x86_64&distro=rhel-8.10&package-id=ebb3b71859019ae6&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=x86_64&distro=rhel-8.10&package-id=0eb3d862523d0548&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=449118949812d0d2&upstream=libnl3-3.7.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=x86_64&distro=rhel-8.10&package-id=ef43e4d2fbb09d0d&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e24e2f3bc22ffe13&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=664883aa573607f5&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=18dbfd6f3afa0ce4&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9e5c394bd88d169f&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9194b925e7a3bebf&upstream=libpsl-0.20.2-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=x86_64&distro=rhel-8.10&package-id=6085dfcccefaea69&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=9780f211eda573e6&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=x86_64&distro=rhel-8.10&package-id=256edfa407c3b660&upstream=libreport-2.9.5-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=x86_64&distro=rhel-8.10&package-id=cd55edd53a4bce8a&upstream=librhsm-0.0.3-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=e4eb640ed71d1387&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=x86_64&distro=rhel-8.10&package-id=40b14020c3a76059&upstream=libselinux-2.9-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=x86_64&distro=rhel-8.10&package-id=d353a56719b280d0&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=a493c97a5a749b13&upstream=libsepol-2.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=x86_64&distro=rhel-8.10&package-id=c2082e19a7d6e3c1&upstream=libsigsegv-2.11-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=c5c5a2cbb0227d12&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=x86_64&distro=rhel-8.10&package-id=18ed592ae788b75e&upstream=libsolv-0.7.20-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7f51719269909e33&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=efb80d980b17a2b2&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=53184858d25776ab&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=x86_64&distro=rhel-8.10&package-id=13fb33eabcbdd348&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=x86_64&distro=rhel-8.10&package-id=635524cc0dab781f&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=x86_64&distro=rhel-8.10&package-id=348223321fdebdeb&upstream=libthai-0.1.27-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=x86_64&distro=rhel-8.10&package-id=416647ae0ce9a60e&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=x86_64&distro=rhel-8.10&package-id=cad80c4d9a1f5dcf&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=x86_64&distro=rhel-8.10&package-id=3cb1aef7db7925a5&upstream=libunistring-0.9.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=x86_64&distro=rhel-8.10&package-id=2079bf2de278c73a&upstream=libusbx-1.0.23-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a6407cda71986b6d&upstream=libuser-0.62-26.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=x86_64&distro=rhel-8.10&package-id=ff85e6ae6fbe6897&upstream=libutempter-1.1.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=3431e92ffd288b38&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=x86_64&distro=rhel-8.10&package-id=dc73e15bfd2f72a0&upstream=libverto-0.3.2-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=7ad8c4758bb988a6&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=c906ed32e01195b8&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=x86_64&distro=rhel-8.10&package-id=545ba41b48d6a5eb&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cc84571d169d80d9&upstream=libxcb-1.13.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=fa2892199f269e9b&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=x86_64&distro=rhel-8.10&package-id=9914b3b870b78700&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=x86_64&distro=rhel-8.10&package-id=8159aa7df418566b&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=x86_64&distro=rhel-8.10&package-id=86561759c46293e9&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=x86_64&distro=rhel-8.10&package-id=bd0d38eebd665ff4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5a06b2a5cab1ed24&upstream=zstd-1.4.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=x86_64&distro=rhel-8.10&package-id=7a77fcd86ba06ecc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=24fdcea8a4d24eba&upstream=lua-5.3.4-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=x86_64&distro=rhel-8.10&package-id=984a046eed89d84d&upstream=lua-5.3.4-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=x86_64&distro=rhel-8.10&package-id=747f8d08054bb295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=x86_64&distro=rhel-8.10&package-id=51067913349861f2&upstream=mpfr-3.1.6-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=x86_64&distro=rhel-8.10&package-id=96d91b80e17d2e2d&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=x86_64&distro=rhel-8.10&package-id=627574c547a84ac7&upstream=nettle-3.4.1-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.5-4.el8?arch=x86_64&distro=rhel-8.10&package-id=9c6455318efa2d7b&upstream=npth-1.5-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eeec482f0356b353&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=eb5a35462c030a1d&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=c12e3afc80ee2624&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=a7a0502be801403c&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=3100d9810595d6c0&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=x86_64&distro=rhel-8.10&package-id=8d7f6e696a826a11&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=x86_64&distro=rhel-8.10&package-id=9b27e7b2961c600c&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=4c1ab9ead2aef73f&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=355fe5843a01b570&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=x86_64&distro=rhel-8.10&package-id=aa4a466c8c83bfa4&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=x86_64&distro=rhel-8.10&package-id=faad0cdca7c3ac08&upstream=pam-1.3.1-36.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=x86_64&distro=rhel-8.10&package-id=60fd46064a3ef440&upstream=pango-1.42.4-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=x86_64&distro=rhel-8.10&package-id=5d97178827061fdc&upstream=passwd-0.80-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=x86_64&distro=rhel-8.10&package-id=689b6a9f1c6e3a4d&upstream=pcre-8.42-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=x86_64&distro=rhel-8.10&package-id=e986eeba073837bb&upstream=pcre2-10.32-3.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=x86_64&distro=rhel-8.10&package-id=87a444578516c6eb&upstream=pixman-0.38.4-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=32b0d48565fb2224&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=9d4f75d478573a51&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=dfffacd4ee7e7167&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=5250f382566aefbe&upstream=popt-1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=67f179da5c65c09f&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=x86_64&distro=rhel-8.10&package-id=4d4f1fee0eb892d3&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ba83f3150ddf2a8f&upstream=python-ethtool-0.14-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=x86_64&distro=rhel-8.10&package-id=f4fe3acddcad7338&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=x86_64&distro=rhel-8.10&package-id=d8ed97e00eead113&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=2fcfeb045a4dc845&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=x86_64&distro=rhel-8.10&package-id=ec3953fafa801371&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=x86_64&distro=rhel-8.10&package-id=71e66b4236cdfa73&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=x86_64&distro=rhel-8.10&package-id=15b8a713ebe85545&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=x86_64&distro=rhel-8.10&package-id=daeffd8b8a1585b7&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=f27aea22a4d5de34&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=cff8e6811247f30a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=960ad18a1caf38a7&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=x86_64&distro=rhel-8.10&package-id=73f0dd5eeadf14f0&upstream=python-systemd-234-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=x86_64&distro=rhel-8.10&package-id=f543af8913e54d7c&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@7.0-10.el8?arch=x86_64&distro=rhel-8.10&package-id=fada24d6082fc020&upstream=readline-7.0-10.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=x86_64&distro=rhel-8.10&package-id=31b0c2c62bcc343b&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=x86_64&distro=rhel-8.10&package-id=16f9a10bf6e8d8ff&upstream=rest-0.8.1-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=8104254b9f76607b&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=7e94ca88aa56ec1d&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=x86_64&distro=rhel-8.10&package-id=18ff552edc3142bc&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.5-5.el8?arch=x86_64&distro=rhel-8.10&package-id=ac071555714ba21a&upstream=sed-4.5-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=04df981948232bdc&upstream=shadow-utils-4.6-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=x86_64&distro=rhel-8.10&package-id=ee5abf043dd6b7d6&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=x86_64&distro=rhel-8.10&package-id=5fba266d57c5b9c9&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=x86_64&distro=rhel-8.10&package-id=d3b6159b61b1d2cf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=65f902ab9483fb71&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=b2e6790fad5fa99f&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=x86_64&distro=rhel-8.10&package-id=45ab67aeec9da32e&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.30-9.el8?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=8095ed048378bfe9&upstream=tar-1.30-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=x86_64&distro=rhel-8.10&package-id=925f06f0270a020a&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=x86_64&distro=rhel-8.10&package-id=036174f6bccab119&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=x86_64&distro=rhel-8.10&package-id=a0abb8bcc3359fe7&upstream=unzip-6.0-47.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=x86_64&distro=rhel-8.10&package-id=db4f73b20c06915b&upstream=usermode-1.113-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=x86_64&distro=rhel-8.10&package-id=ec84218777674d0c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=x86_64&distro=rhel-8.10&epoch=2&package-id=a5e633f1b5336f31&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=x86_64&distro=rhel-8.10&package-id=445adfd4097a0162&upstream=virt-what-1.25-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-20.el8?arch=x86_64&distro=rhel-8.10&package-id=1eb75829eed60337&upstream=which-2.21-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=x86_64&distro=rhel-8.10&epoch=1&package-id=8f583fdc88c7e9f6&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=x86_64&distro=rhel-8.10&package-id=abb6dbdce82086a9&upstream=xz-5.2.4-4.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=c52632d932de2bdb&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=x86_64&distro=rhel-8.10&package-id=6e33651aa704ce69&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:ed116532-459f-44dc-a6cc-b4c9ae4c9df9"
+}

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
@@ -1,0 +1,19905 @@
+{
+  "version": 1,
+  "metadata": {
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.16.0"
+        }
+      ]
+    },
+    "component": {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2?arch=arm64&os=linux&tag=23.1-19.1739757566",
+      "type": "container",
+      "properties": [
+        {
+          "name": "errata-tool-product-name",
+          "value": "RHBQ"
+        },
+        {
+          "name": "errata-tool-product-version",
+          "value": "RHEL-8-RHBQ-3.8"
+        },
+        {
+          "name": "errata-tool-product-variant",
+          "value": "8Base-RHBQ-3.8"
+        }
+      ]
+    },
+    "timestamp": "2025-02-17T02:40:27Z"
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "quarkus/mandrel-for-jdk-21-rhel8",
+      "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2?arch=arm64&os=linux&tag=23.1-19.1739757566",
+      "type": "container",
+      "bom-ref": "b2d5dcab2ab572d7",
+      "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "72f7a5ed37f428182ee76cde302ea3300ddc96e9",
+            "url": "https://pkgs.devel.redhat.com/git/containers/quarkus-mandrel#72f7a5ed37f428182ee76cde302ea3300ddc96e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "aarch64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-02-17T02:00:15"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "quarkus-mandrel-231-rhel8-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/en/about/agreements#quarkus"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Quarkus Native builder image (version 23.1) providing the `native-image` executable. JDK 21-based."
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.8"
+        },
+        {
+          "name": "sbomer:image:labels:io.cekit.version",
+          "value": "4.10.0"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Quarkus Native builder image (version 23.1) providing the `native-image` executable. JDK 21-based."
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "Quarkus Native builder image (Version 23.1, GraalVM Native, Mandrel distribution, JDK 21-based)"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "executable,java,quarkus,mandrel,native"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "Red Hat OpenJDK Team <openjdk@redhat.com>"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "quarkus/mandrel-for-jdk-21-rhel8"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "19.1739757566"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Quarkus Native builder (Version 23.1, GraalVM Native, Mandrel distribution, JDK 21-based)"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/quarkus/mandrel-for-jdk-21-rhel8/images/23.1-19.1739757566"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "72f7a5ed37f428182ee76cde302ea3300ddc96e9"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "23.1"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3513101",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/quarkus-mandrel#72f7a5ed37f428182ee76cde302ea3300ddc96e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "abattis-cantarell-fonts",
+      "purl": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+      "version": "0.0.25-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "OFL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe01fbdac570da234c78f809e93cf1a5c72431f3",
+            "url": "git://pkgs.devel.redhat.com/rpms/abattis-cantarell-fonts#fe01fbdac570da234c78f809e93cf1a5c72431f3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1428698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/abattis-cantarell-fonts#fe01fbdac570da234c78f809e93cf1a5c72431f3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "acl",
+      "purl": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=a7917c72826610a9&upstream=acl-2.2.53-3.el8.src.rpm",
+      "version": "2.2.53-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64d42070c251d4b78dc897999b1ff36c5be04002",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2710224",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "adwaita-cursor-theme",
+      "purl": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "version": "3.28.0-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or CC-BY-SA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+            "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1805673",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "adwaita-icon-theme",
+      "purl": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "version": "3.28.0-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or CC-BY-SA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+            "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1805673",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/adwaita-icon-theme#7bea45e2ab3a10ac12dfe9dc23a768eb0491b945",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alsa-lib",
+      "purl": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=aarch64&distro=rhel-8.10&package-id=d5dada97d73f071a&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+      "version": "1.2.10-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1df50921065d04c3409c6d50e45188316530582a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#1df50921065d04c3409c6d50e45188316530582a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2801117",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/alsa-lib#1df50921065d04c3409c6d50e45188316530582a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "at-spi2-atk",
+      "purl": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f3afbc2622bf9a47&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+      "version": "2.26.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a99891d57d7618cff33507cee2205cc6ad464709",
+            "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-atk#a99891d57d7618cff33507cee2205cc6ad464709"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746020",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-atk#a99891d57d7618cff33507cee2205cc6ad464709",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "at-spi2-core",
+      "purl": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4233c2f8efe4e224&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+      "version": "2.28.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "66bd1458234282b1b0f62bb16f89437864dc1067",
+            "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-core#66bd1458234282b1b0f62bb16f89437864dc1067"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746030",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/at-spi2-core#66bd1458234282b1b0f62bb16f89437864dc1067",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "atk",
+      "purl": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9bc23f86b89ffd1e&upstream=atk-2.28.1-1.el8.src.rpm",
+      "version": "2.28.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d8243796680126f5a6991e92d05fbdef1fb363fc",
+            "url": "git://pkgs.devel.redhat.com/rpms/atk#d8243796680126f5a6991e92d05fbdef1fb363fc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746010",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/atk#d8243796680126f5a6991e92d05fbdef1fb363fc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7523ddbf31d32fd5&upstream=audit-3.1.2-1.el8.src.rpm",
+      "version": "3.1.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3b0c2631cd2710642353b96943214221b23a2bf",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#d3b0c2631cd2710642353b96943214221b23a2bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2766534",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#d3b0c2631cd2710642353b96943214221b23a2bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "avahi-libs",
+      "purl": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=06ca8a53d1cc249e&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+      "version": "0.7-27.el8_10.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b34c66d255ae0ac833a85a6b1274b3216fab9e93",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#b34c66d255ae0ac833a85a6b1274b3216fab9e93"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3250821",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/avahi#b34c66d255ae0ac833a85a6b1274b3216fab9e93",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+      "version": "11-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5396e2dfce9e5a71fa15c63cf074f949ea2677c",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#a5396e2dfce9e5a71fa15c63cf074f949ea2677c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746023",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#a5396e2dfce9e5a71fa15c63cf074f949ea2677c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8dca9ae7861a5d31&upstream=bash-4.4.20-5.el8.src.rpm",
+      "version": "4.4.20-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2cd7e4238fbd1aed0611f7227734511b25cfe63f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#2cd7e4238fbd1aed0611f7227734511b25cfe63f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2900299",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#2cd7e4238fbd1aed0611f7227734511b25cfe63f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "binutils",
+      "purl": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=aarch64&distro=rhel-8.10&package-id=357cf8a75af7239c&upstream=binutils-2.30-125.el8_10.src.rpm",
+      "version": "2.30-125.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93ebd35fa24871ad51914892733ba8cb626feed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/binutils#93ebd35fa24871ad51914892733ba8cb626feed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382340",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/binutils#93ebd35fa24871ad51914892733ba8cb626feed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "brotli",
+      "purl": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=aarch64&distro=rhel-8.10&package-id=36c3ab5bddd9f1a3&upstream=brotli-1.0.6-3.el8.src.rpm",
+      "version": "1.0.6-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0ee161fd58068d9081ef1f9825adc72e88500b",
+            "url": "git://pkgs.devel.redhat.com/rpms/brotli#1c0ee161fd58068d9081ef1f9825adc72e88500b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1337704",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/brotli#1c0ee161fd58068d9081ef1f9825adc72e88500b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-devel",
+      "purl": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1f31b47b9494d3cb&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "version": "1.0.6-28.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d3d53396b670f750&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "version": "1.0.6-28.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3465504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#92b7ab78e1a4e02dd3c0204da4b107f70abbb0b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+      "version": "2024.2.69_v8.0.303-80.0.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3189502",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#7e8620eaee0deb41aa5e1ec01bdf016f5fe29e25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cairo",
+      "purl": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=398645343056b831&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "version": "1.15.12-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or MPLv1.1"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+            "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1856752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cairo-gobject",
+      "purl": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=f0a2d94f7a32ee2b&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "version": "1.15.12-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 or MPLv1.1"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+            "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1856752",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cairo#4c3cb0e7fbdbb765cd55a294deeb088b7756ce6e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "chkconfig",
+      "purl": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d9fc13bf2afaafe2&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+      "version": "1.19.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b",
+            "url": "git://pkgs.devel.redhat.com/rpms/chkconfig#82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2503740",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/chkconfig#82ebd39a7ba79350ea9f2e8d5bf298d1bc51274b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "collections",
+      "purl": "pkg:maven/org.graalvm.sdk/collections@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79d666407d73654a38693a2e5cc9bb90"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9aef5575f25f021d7a83928ee6c8244aaa28a4a5"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c85252a2047d75b669c256cc8f36955f311676be11de5160533e41a6b43e1f35"
+        }
+      ],
+      "bom-ref": "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9aef5575f25f021d7a83928ee6c8244aaa28a4a5"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347863",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "collections-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/collections@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3cdb9fb4dfb13ac881806fd4d90636e1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "bf3802eb5026ef9ae4ea258142328a1643c612be"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "960583fdbe25d8ea594dbd1573c6e1d43bbb00fbb6584eaea63c7e0ca8cc42f5"
+        }
+      ],
+      "bom-ref": "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/collections-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "bf3802eb5026ef9ae4ea258142328a1643c612be"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347888",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "colord-libs",
+      "purl": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5ec10e2b6c6075b1&upstream=colord-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b8b9b530a28c8ab42471284d434afe9ee3c47299",
+            "url": "git://pkgs.devel.redhat.com/rpms/colord#b8b9b530a28c8ab42471284d434afe9ee3c47299"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746106",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/colord#b8b9b530a28c8ab42471284d434afe9ee3c47299",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "compiler",
+      "purl": "pkg:maven/org.graalvm.compiler/compiler@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "72225170e7fcf6bc7351ef3b45b3a86e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5b92e665aae823e6f9ae0ce4a1dfc212702c5129"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aa1cf4a7eeb6d35d6120979404e3a53a44bdf6ae759a2d8e6dba7a09a5c2fffe"
+        }
+      ],
+      "bom-ref": "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5b92e665aae823e6f9ae0ce4a1dfc212702c5129"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347856",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "compiler-sources",
+      "purl": "pkg:maven/org.graalvm.compiler/compiler@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "3932562b61c626758d8cd45e89821a5e"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "4e7b48a5ece076047a23c499efe610b0167792ff"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ec7a7feee3e54849473c48d1b97920c659f6780aa29f2e79a71fb8968779637a"
+        }
+      ],
+      "bom-ref": "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/compiler-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "4e7b48a5ece076047a23c499efe610b0167792ff"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347883",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "copy-jdk-configs",
+      "purl": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+      "version": "4.0-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0f065c185b51f47d2d3a825f33c5fb2dfda5657d",
+            "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#0f065c185b51f47d2d3a825f33c5fb2dfda5657d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1638485",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/copy-jdk-configs#0f065c185b51f47d2d3a825f33c5fb2dfda5657d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=aarch64&distro=rhel-8.10&package-id=1539837d2471018e&upstream=coreutils-8.30-15.el8.src.rpm",
+      "version": "8.30-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0",
+            "url": "git://pkgs.devel.redhat.com/rpms/coreutils#a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2324367",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/coreutils#a81d1be4dffedb85f0a05b39bc86cbe2b0ac48b0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cpp",
+      "purl": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=caa963f8079ff764&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib",
+      "purl": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=71b432d3c9a36835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "version": "2.9.6-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=804625",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cracklib-dicts",
+      "purl": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=25517b5ff2550b18&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "version": "2.9.6-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+            "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=804625",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cracklib#89e354f1cbadcb79257a8d0dbe802b3aa76196b5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "version": "20230731-1.git3177e06.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c698dc49e0972391ac247a342789e3a021af69d",
+            "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2621975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies-scripts",
+      "purl": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "version": "20230731-1.git3177e06.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c698dc49e0972391ac247a342789e3a021af69d",
+            "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2621975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/crypto-policies#1c698dc49e0972391ac247a342789e3a021af69d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cryptsetup-libs",
+      "purl": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=aarch64&distro=rhel-8.10&package-id=312286ce82a76c5e&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+      "version": "2.3.7-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25",
+            "url": "git://pkgs.devel.redhat.com/rpms/cryptsetup#b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2588613",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cryptsetup#b6a1e6c2c187d1dde565bfcf35005ecbc05d8d25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cups-libs",
+      "purl": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=937da8bd05964a01&upstream=cups-2.2.6-62.el8_10.src.rpm",
+      "version": "1:2.2.6-62.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2 and zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "83b5a019975a2e63167d471e33535cbe43f8523e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#83b5a019975a2e63167d471e33535cbe43f8523e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3415903",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/cups#83b5a019975a2e63167d471e33535cbe43f8523e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl",
+      "purl": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7642b1c80cb7a881&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "version": "7.61.1-34.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3375089",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=aarch64&distro=rhel-8.10&package-id=ee9fc9e06878cf18&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+      "version": "2.1.27-6.el8_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "03d2c0663f4a25fe455b867d0c2b28501b3f28c2",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#03d2c0663f4a25fe455b867d0c2b28501b3f28c2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892190",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#03d2c0663f4a25fe455b867d0c2b28501b3f28c2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus",
+      "purl": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=416bf5a232fc918a&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-common",
+      "purl": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-daemon",
+      "purl": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6c36a0a0a6da83ac&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-glib",
+      "purl": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=aarch64&distro=rhel-8.10&package-id=1ea0d23cbf2b48a3&upstream=dbus-glib-0.110-2.el8.src.rpm",
+      "version": "0.110-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "AFL and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5eb05e6c24dd7ccebca79678a8bcc876ada6db0f",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-glib#5eb05e6c24dd7ccebca79678a8bcc876ada6db0f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746151",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-glib#5eb05e6c24dd7ccebca79678a8bcc876ada6db0f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-libs",
+      "purl": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7c9a1c226a677c28&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dbus-tools",
+      "purl": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7909e99adecf0e0d&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "version": "1:1.12.8-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or AFL) and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2557482",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus#8a53b7020e5dc6213eeb00753bb60a3c88a0d912",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dconf",
+      "purl": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=aarch64&distro=rhel-8.10&package-id=557caf7d0d4b3d91&upstream=dconf-0.28.0-4.el8.src.rpm",
+      "version": "0.28.0-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b9117cee6006bec458091955949dffb128aa0ec",
+            "url": "git://pkgs.devel.redhat.com/rpms/dconf#7b9117cee6006bec458091955949dffb128aa0ec"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1390833",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dconf#7b9117cee6006bec458091955949dffb128aa0ec",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-fonts-common",
+      "purl": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "version": "2.35-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1410980",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-mono-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "version": "2.35-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1410980",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#c8d4b0d08ba8911bf235d216f9994382f2ee8fa2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "device-mapper",
+      "purl": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=aarch64&epoch=8",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b4e8dd7f72ca970a&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "version": "8:1.02.181-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09f895338878b2481897562d4c478c596609167c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2886869",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "device-mapper-libs",
+      "purl": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=aarch64&epoch=8",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b55e2c322e77f3bd&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "version": "8:1.02.181-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "09f895338878b2481897562d4c478c596609167c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2886869",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/lvm2#09f895338878b2481897562d4c478c596609167c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dmidecode",
+      "purl": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=2439b3294fa7d3cb&upstream=dmidecode-3.5-1.el8.src.rpm",
+      "version": "1:3.5-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "715b44b5163c3ead4fa58113a72745c57dc5fa2b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#715b44b5163c3ead4fa58113a72745c57dc5fa2b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2828442",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dmidecode#715b44b5163c3ead4fa58113a72745c57dc5fa2b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf",
+      "purl": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-plugin-subscription-manager",
+      "purl": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7bad0774a686c567&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-default-yama-scope",
+      "purl": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libelf",
+      "purl": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=2dba7c7dd2b6a358&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "elfutils-libs",
+      "purl": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=34a7605a88bd6b7e&upstream=elfutils-0.190-2.el8.src.rpm",
+      "version": "0.190-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94bfd0c0875502d871bd4042e693669fb277979b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2818997",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/elfutils#94bfd0c0875502d871bd4042e693669fb277979b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "expat",
+      "purl": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5ea6ff40602a8457&upstream=expat-2.2.5-16.el8_10.src.rpm",
+      "version": "2.2.5-16.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00ef654fce79bdb84c4d96eef8e781913506ae1c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#00ef654fce79bdb84c4d96eef8e781913506ae1c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3383793",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/expat#00ef654fce79bdb84c4d96eef8e781913506ae1c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=aarch64&distro=rhel-8.10&package-id=6afff6bb9732e06d&upstream=file-5.33-26.el8.src.rpm",
+      "version": "5.33-26.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2751139",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#c79a8583c5a4b49aa2e1bb2a59b1ce4dbf0cc6b3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=aarch64&distro=rhel-8.10&package-id=346ab4ee189eb6a5&upstream=filesystem-3.8-6.el8.src.rpm",
+      "version": "3.8-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0888a057be6b19d775e219b22aaadaa6825a4493",
+            "url": "git://pkgs.devel.redhat.com/rpms/filesystem#0888a057be6b19d775e219b22aaadaa6825a4493"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1640139",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/filesystem#0888a057be6b19d775e219b22aaadaa6825a4493",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "findutils",
+      "purl": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=f58a85f97aa1c211&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+      "version": "1:4.6.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be0c981099552be94b8e759c8113f70f30ffa574",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#be0c981099552be94b8e759c8113f70f30ffa574"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3166029",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/findutils#be0c981099552be94b8e759c8113f70f30ffa574",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fontconfig",
+      "purl": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=03111bf8e0b4a329&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+      "version": "2.13.1-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Public Domain and UCD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9b8add415a851e8c83851cbf497ab36a379dc1c9",
+            "url": "git://pkgs.devel.redhat.com/rpms/fontconfig#9b8add415a851e8c83851cbf497ab36a379dc1c9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1699029",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fontconfig#9b8add415a851e8c83851cbf497ab36a379dc1c9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fontpackages-filesystem",
+      "purl": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+      "version": "1.44-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "67e7529185d4a64eb77c1c383ea479b704e3f6fe",
+            "url": "git://pkgs.devel.redhat.com/rpms/fontpackages#67e7529185d4a64eb77c1c383ea479b704e3f6fe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746265",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fontpackages#67e7529185d4a64eb77c1c383ea479b704e3f6fe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "freetype",
+      "purl": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=03eb320bcf25d556&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "version": "2.9.1-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "352ceda9b7b8521f5812faea931314e480e15430",
+            "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2029792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "freetype-devel",
+      "purl": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=54313f0a53ced35f&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "version": "2.9.1-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "352ceda9b7b8521f5812faea931314e480e15430",
+            "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2029792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/freetype#352ceda9b7b8521f5812faea931314e480e15430",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fribidi",
+      "purl": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=aarch64&distro=rhel-8.10&package-id=8bc6eeb43471fec4&upstream=fribidi-1.0.4-9.el8.src.rpm",
+      "version": "1.0.4-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and UCD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25",
+            "url": "git://pkgs.devel.redhat.com/rpms/fribidi#8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1972637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fribidi#8c53fc31ac6e6a1fa282aa6c6686c38e17cbbf25",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d81ed4895e302f1f&upstream=gawk-4.2.1-4.el8.src.rpm",
+      "version": "4.2.1-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2894f879f91f263ecb702981bdcaf8012ac299bc",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#2894f879f91f263ecb702981bdcaf8012ac299bc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1884677",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#2894f879f91f263ecb702981bdcaf8012ac299bc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gcc",
+      "purl": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b799b76678b8854&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gcc-c++",
+      "purl": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7dce2b0519a3160b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdb-gdbserver",
+      "purl": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=aarch64&distro=rhel-8.10&package-id=92529bc1ca6eba4e&upstream=gdb-8.2-20.el8.src.rpm",
+      "version": "8.2-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6c06900a0891d6807b46dad7f0b06d0114ff5fe3",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdb#6c06900a0891d6807b46dad7f0b06d0114ff5fe3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2447068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdb#6c06900a0891d6807b46dad7f0b06d0114ff5fe3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm",
+      "purl": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6a4e5ba47778a597&upstream=gdbm-1.18-2.el8.src.rpm",
+      "version": "1:1.18-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92ca20d1833e263d5990060445e6516c018dfb26",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2078608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=8002d63f7648f7e3&upstream=gdbm-1.18-2.el8.src.rpm",
+      "version": "1:1.18-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "92ca20d1833e263d5990060445e6516c018dfb26",
+            "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2078608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gdbm#92ca20d1833e263d5990060445e6516c018dfb26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdk-pixbuf2",
+      "purl": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e518ee39ae8eae1e&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "version": "2.36.12-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51c11c568980903a55d65d0e709bd37b9a54affa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3059697",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdk-pixbuf2-modules",
+      "purl": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=131cc75f16f084ac&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "version": "2.36.12-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "51c11c568980903a55d65d0e709bd37b9a54affa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3059697",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdk-pixbuf2#51c11c568980903a55d65d0e709bd37b9a54affa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib-networking",
+      "purl": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=aarch64&distro=rhel-8.10&package-id=26067cb38279ca47&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+      "version": "2.56.1-1.1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "022e922bfd62720b931cbb917c5f25392bc8ccb4",
+            "url": "git://pkgs.devel.redhat.com/rpms/glib-networking#022e922bfd62720b931cbb917c5f25392bc8ccb4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=808537",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/glib-networking#022e922bfd62720b931cbb917c5f25392bc8ccb4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ed2d632e2160f1a3&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+      "version": "2.56.4-165.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5c5396905d7c0632c3d4dffee21553cdb3587773",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#5c5396905d7c0632c3d4dffee21553cdb3587773"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3310831",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#5c5396905d7c0632c3d4dffee21553cdb3587773",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=7f13f1b80f7976ee&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=3e03d903fd884090&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-devel",
+      "purl": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=95e14bede372995c&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-headers",
+      "purl": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=844597ed5cee4103&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-langpack-en",
+      "purl": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=49ecf57c502bbd37&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=9dcc1af340590fef&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "version": "2.28-251.el8_10.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5338b4b056de52f670558d3153c52e0ce93ab5",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3435914",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#8b5338b4b056de52f670558d3153c52e0ce93ab5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=afd99c8be86b75c7&upstream=gmp-6.1.2-11.el8.src.rpm",
+      "version": "1:6.1.2-11.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad3d169c431b4fab7675c90887dd3528605f17eb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gmp#ad3d169c431b4fab7675c90887dd3528605f17eb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2888918",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gmp#ad3d169c431b4fab7675c90887dd3528605f17eb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=3225fc9cf5a4a100&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+      "version": "2.2.20-3.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "de234834ad4638434c686e1073ede1add35add72",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#de234834ad4638434c686e1073ede1add35add72"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2114977",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#de234834ad4638434c686e1073ede1add35add72",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=aarch64&distro=rhel-8.10&package-id=c68e2e13c86ee2b5&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+      "version": "3.6.16-8.el8_9.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dd3e410bdeb6d4126b24d0d24347dc8d4758207b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#dd3e410bdeb6d4126b24d0d24347dc8d4758207b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2973710",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#dd3e410bdeb6d4126b24d0d24347dc8d4758207b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=eb56ef0cc23ffb3c&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+      "version": "1.56.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+, LGPLv2+, MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36eb0ce62a6550943166ca0fc6ad5819ad12acd1",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#36eb0ce62a6550943166ca0fc6ad5819ad12acd1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746526",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#36eb0ce62a6550943166ca0fc6ad5819ad12acd1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+      "version": "d4082792-5b32db75",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=c896e2652a3c6566&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "version": "1.13.1-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30ce989734661681faba06ceb0a2573a5c66b85f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2903739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "graal-sdk",
+      "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "154e55e710ff408baee7ecfd0466fa30"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d41619a29cd775e1b75f2a406b7a0d4658bde1e0"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e33844b38bbebb7fee75138b2260c2eb574351006111c4e669d63766fbab5166"
+        }
+      ],
+      "bom-ref": "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d41619a29cd775e1b75f2a406b7a0d4658bde1e0"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347890",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "graal-sdk-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6689c7ce9b7450afcc1a55ee91894617"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "11f213da066f81db16d9d699df47f81baaec8b60"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bb5d2cf660498c1d5d7ec1ea5b4cfb4ad5902ee3b4bda9e3e66fc2f621d4b18f"
+        }
+      ],
+      "bom-ref": "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/graal-sdk-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "11f213da066f81db16d9d699df47f81baaec8b60"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347880",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "graphite2",
+      "purl": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=aarch64&distro=rhel-8.10&package-id=fea0c5371ec8a84b&upstream=graphite2-1.3.10-10.el8.src.rpm",
+      "version": "1.3.10-10.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv2+ or GPLv2+ or MPL) and (Netscape or GPLv2+ or LGPLv2+)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b71ee5b21e8f2c2247d0f547e60ccea7030db7dd",
+            "url": "git://pkgs.devel.redhat.com/rpms/graphite2#b71ee5b21e8f2c2247d0f547e60ccea7030db7dd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=762158",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/graphite2#b71ee5b21e8f2c2247d0f547e60ccea7030db7dd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.1-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=32e755f3d822d08b&upstream=grep-3.1-6.el8.src.rpm",
+      "version": "3.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c300a00f9d91514feb8a5eef8d06800c4be6a03b",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#c300a00f9d91514feb8a5eef8d06800c4be6a03b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=745934",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#c300a00f9d91514feb8a5eef8d06800c4be6a03b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gsettings-desktop-schemas",
+      "purl": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=aarch64&distro=rhel-8.10&package-id=95356035cafc7374&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+      "version": "3.32.0-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "934b1f14fd093e9073ab3091507f45d5a6406a8c",
+            "url": "git://pkgs.devel.redhat.com/rpms/gsettings-desktop-schemas#934b1f14fd093e9073ab3091507f45d5a6406a8c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1668107",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gsettings-desktop-schemas#934b1f14fd093e9073ab3091507f45d5a6406a8c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gtk-update-icon-cache",
+      "purl": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=2bb2cfcbf653e8aa&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "version": "3.22.30-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3215246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gtk3",
+      "purl": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c684c884397ed31a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "version": "3.22.30-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3215246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gtk3#7f2cdaf4e08111b17f7a02e8fe1aaa8dc77ddf0c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=aarch64&distro=rhel-8.10&package-id=a2dc59575b8c7aa0&upstream=gzip-1.9-13.el8_5.src.rpm",
+      "version": "1.9-13.el8_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3",
+            "url": "git://pkgs.devel.redhat.com/rpms/gzip#4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1978968",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gzip#4e7115a1ddebb04f264fe8b6c4ea77f4c66bcfa3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "harfbuzz",
+      "purl": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ded3edd0418bf4e6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+      "version": "1.7.5-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/harfbuzz#a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2691402",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/harfbuzz#a08ce5b9c01ae635d5d01bbc8f4175c07b1dd52f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "hicolor-icon-theme",
+      "purl": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+      "version": "0.17-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e299e4a26c78c50f595c6929681fe66f3c6fef4",
+            "url": "git://pkgs.devel.redhat.com/rpms/hicolor-icon-theme#3e299e4a26c78c50f595c6929681fe66f3c6fef4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746592",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/hicolor-icon-theme#3e299e4a26c78c50f595c6929681fe66f3c6fef4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ima-evm-utils",
+      "purl": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=aarch64&distro=rhel-8.10&package-id=da527f08de208fb5&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+      "version": "1.3.2-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14ff723c10237225d71585ee05524248b63a05e2",
+            "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#14ff723c10237225d71585ee05524248b63a05e2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1509562",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ima-evm-utils#14ff723c10237225d71585ee05524248b63a05e2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "info",
+      "purl": "pkg:rpm/redhat/info@6.5-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/info@6.5-7.el8?arch=aarch64&distro=rhel-8.10&package-id=28e3049964db8aa8&upstream=texinfo-6.5-7.el8.src.rpm",
+      "version": "6.5-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fcd588440f00fc27457e5c31cd05f3ac06799982",
+            "url": "git://pkgs.devel.redhat.com/rpms/texinfo#fcd588440f00fc27457e5c31cd05f3ac06799982"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852265",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/texinfo#fcd588440f00fc27457e5c31cd05f3ac06799982",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "isl",
+      "purl": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=6d388e5321da4719&upstream=isl-0.16.1-6.el8.src.rpm",
+      "version": "0.16.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0e53516c24774dd2377f56e2e8e52cb5cbeeab84",
+            "url": "git://pkgs.devel.redhat.com/rpms/isl#0e53516c24774dd2377f56e2e8e52cb5cbeeab84"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746861",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/isl#0e53516c24774dd2377f56e2e8e52cb5cbeeab84",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jasper-libs",
+      "purl": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=a2a242cd24594853&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+      "version": "2.0.14-6.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "JasPer"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/jasper#0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3463584",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/jasper#0b66f8b438d8fc8b7d1fae96c2d8b2e12fc4b91a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk",
+      "purl": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=04a7eebb68f41981&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-devel",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=143aa9bdff3f3006&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-headless",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=792c5489088f88f4&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-src",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=c3f1c48159e68929&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "java-21-openjdk-static-libs",
+      "purl": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=4cb76261f61797f0&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "version": "1:21.0.6.0.7-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3473655",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/java-21-openjdk#a6330a35c6a86cd646eef7b9ccf50590a11b7f12",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "javapackages-filesystem",
+      "purl": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+      "version": "5.3.0-1.module+el8+2447+6f56d9a6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b5321498d8cb1dbcd241e8eee0523661a16a9e4",
+            "url": "git://pkgs.devel.redhat.com/rpms/javapackages-tools#8b5321498d8cb1dbcd241e8eee0523661a16a9e4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=815001",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/javapackages-tools#8b5321498d8cb1dbcd241e8eee0523661a16a9e4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jbigkit-libs",
+      "purl": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=aarch64&distro=rhel-8.10&package-id=a3af83ca4128b274&upstream=jbigkit-2.1-14.el8.src.rpm",
+      "version": "2.1-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8effde482b7c059bb265dd1e05ead891c29ecfae",
+            "url": "git://pkgs.devel.redhat.com/rpms/jbigkit#8effde482b7c059bb265dd1e05ead891c29ecfae"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=788163",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/jbigkit#8effde482b7c059bb265dd1e05ead891c29ecfae",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jrt-fs",
+      "purl": "pkg:maven/jrt-fs/jrt-fs@21.0.6?type=jar",
+      "type": "library",
+      "bom-ref": "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=a17644094896e7e9",
+      "version": "21.0.6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.6.0.7-1.el8.aarch64/lib/jrt-fs.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/lib/jvm/java-21-openjdk-21.0.6.0.7-1.el8.aarch64/lib/jrt-fs.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "8fd24c77c3f670e9ddc1dce502528e781d0a12be"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=310651df6a321631&upstream=json-c-0.13.1-3.el8.src.rpm",
+      "version": "0.13.1-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c499538bdd7ee11647cb04770c55e720d9850a89",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#c499538bdd7ee11647cb04770c55e720d9850a89"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787596",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#c499538bdd7ee11647cb04770c55e720d9850a89",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9fa05295c0bef29e&upstream=json-glib-1.4.4-1.el8.src.rpm",
+      "version": "1.4.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9c5843980e980d2c8163e684ff2b81a7acf49bad",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#9c5843980e980d2c8163e684ff2b81a7acf49bad"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#9c5843980e980d2c8163e684ff2b81a7acf49bad",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "jvmti-agent-base",
+      "purl": "pkg:maven/org.graalvm.nativeimage/jvmti-agent-base@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "d1a5ae5f4c1b3a365e79bb01a082098f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c663280e87e9f895b9541a2939386c46e66c0789"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e4058939634248a37da3f6f052d08ac5eb5bbbb7b06db2b4e3a28697d0c47835"
+        }
+      ],
+      "bom-ref": "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c663280e87e9f895b9541a2939386c46e66c0789"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347893",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "jvmti-agent-base-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/jvmti-agent-base@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "1de883a52eb34899fa29030240cb6477"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "feee00388852d1f248cc78b9ac6e171d204c993e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1bb579589e3b6281032694a3b913855ed826ab59f99c046cd6b3657608c595ac"
+        }
+      ],
+      "bom-ref": "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/jvmti-agent-base-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "feee00388852d1f248cc78b9ac6e171d204c993e"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347904",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "kernel-headers",
+      "purl": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=aarch64&distro=rhel-8.10&package-id=b0c79f4a399c4534&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+      "version": "4.18.0-553.40.1.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and Redistributable, no modification permitted"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e322ab635fa43c1980ceb05d3ff83fc762569917",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/kernel#e322ab635fa43c1980ceb05d3ff83fc762569917"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3497910",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/kernel#e322ab635fa43c1980ceb05d3ff83fc762569917",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=aarch64&distro=rhel-8.10&package-id=06362f3f4f15eaa6&upstream=keyutils-1.5.10-9.el8.src.rpm",
+      "version": "1.5.10-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6d9d9e2016a2bbdf84034cd72c77532044537588",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#6d9d9e2016a2bbdf84034cd72c77532044537588"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1636344",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#6d9d9e2016a2bbdf84034cd72c77532044537588",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "kmod-libs",
+      "purl": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=aarch64&distro=rhel-8.10&package-id=72b84a74877d2816&upstream=kmod-25-20.el8.src.rpm",
+      "version": "25-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e909931d9fb6b40c76dee1369a11fe5098ebd0f9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/kmod#e909931d9fb6b40c76dee1369a11fe5098ebd0f9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2747988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/kmod#e909931d9fb6b40c76dee1369a11fe5098ebd0f9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c6c83e80d0d08980&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+      "version": "1.18.2-30.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1b992ccc4e31bcd32004d00be03e0c01a308a7ff",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#1b992ccc4e31bcd32004d00be03e0c01a308a7ff"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3348161",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#1b992ccc4e31bcd32004d00be03e0c01a308a7ff",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+      "version": "1.0-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746975",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#3d878a90e1c0a1d62fcea7b63aa1fc389991ab4d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lcms2",
+      "purl": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=aarch64&distro=rhel-8.10&package-id=9ecf73e25e8d8d57&upstream=lcms2-2.9-2.el8.src.rpm",
+      "version": "2.9-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc4d80a58b7e391730c79700239bbfd9d7fa4946",
+            "url": "git://pkgs.devel.redhat.com/rpms/lcms2#dc4d80a58b7e391730c79700239bbfd9d7fa4946"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746989",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lcms2#dc4d80a58b7e391730c79700239bbfd9d7fa4946",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libX11",
+      "purl": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ae4b374f69775e20&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "version": "1.6.8-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "15a649f949df2a70afb109ea64293dd7c9036e16",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3285753",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libX11-common",
+      "purl": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "version": "1.6.8-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "15a649f949df2a70afb109ea64293dd7c9036e16",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3285753",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libX11#15a649f949df2a70afb109ea64293dd7c9036e16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXau",
+      "purl": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=80d20e5c5c3a91c7&upstream=libXau-1.0.9-3.el8.src.rpm",
+      "version": "1.0.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXau#b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214033",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXau#b55c5e5f02c562abcb9f0883c6dd008f5d4b9d7b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXcomposite",
+      "purl": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=533f1ee8546d8a20&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+      "version": "0.4.4-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "11a091cf8f79e28c16a6400926448949a472d2b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXcomposite#11a091cf8f79e28c16a6400926448949a472d2b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747373",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXcomposite#11a091cf8f79e28c16a6400926448949a472d2b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXcursor",
+      "purl": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=aarch64&distro=rhel-8.10&package-id=806bc00cec3c7a10&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+      "version": "1.1.15-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9a2bd659d4620bfd1f1c382cdf90ef14002e99e2",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXcursor#9a2bd659d4620bfd1f1c382cdf90ef14002e99e2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747355",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXcursor#9a2bd659d4620bfd1f1c382cdf90ef14002e99e2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXdamage",
+      "purl": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=1459c8808ab02a53&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+      "version": "1.1.4-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c51981e69e3a27b3d3e792f81937fc6c74a205a7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXdamage#c51981e69e3a27b3d3e792f81937fc6c74a205a7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747346",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXdamage#c51981e69e3a27b3d3e792f81937fc6c74a205a7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXext",
+      "purl": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4944c89b44fc2a09&upstream=libXext-1.3.4-1.el8.src.rpm",
+      "version": "1.3.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "76c0aa859ddcdeaacee677f583d437540e819d46",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXext#76c0aa859ddcdeaacee677f583d437540e819d46"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214999",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXext#76c0aa859ddcdeaacee677f583d437540e819d46",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXfixes",
+      "purl": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=f263842319069d86&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+      "version": "5.0.3-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1da8edf4ed249a235d0e9a09dc0e06003be57498",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXfixes#1da8edf4ed249a235d0e9a09dc0e06003be57498"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747353",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXfixes#1da8edf4ed249a235d0e9a09dc0e06003be57498",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXft",
+      "purl": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=aarch64&distro=rhel-8.10&package-id=dfd465c8f0ce1eb0&upstream=libXft-2.3.3-1.el8.src.rpm",
+      "version": "2.3.3-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed837265cedf0f5e61e8d6f668e931e3bb58f7d1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXft#ed837265cedf0f5e61e8d6f668e931e3bb58f7d1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1214061",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXft#ed837265cedf0f5e61e8d6f668e931e3bb58f7d1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXi",
+      "purl": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=aarch64&distro=rhel-8.10&package-id=82d20a689d5e8ca6&upstream=libXi-1.7.10-1.el8.src.rpm",
+      "version": "1.7.10-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "072476f025ad1ecdd0e6d6ceb5cd1139fac31d55",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXi#072476f025ad1ecdd0e6d6ceb5cd1139fac31d55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215343",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXi#072476f025ad1ecdd0e6d6ceb5cd1139fac31d55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXinerama",
+      "purl": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44225303775ea551&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+      "version": "1.1.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "568c3db2a300d250c0e83a43be5c40117593774d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXinerama#568c3db2a300d250c0e83a43be5c40117593774d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747354",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXinerama#568c3db2a300d250c0e83a43be5c40117593774d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXrandr",
+      "purl": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=15db644a30c76424&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+      "version": "1.5.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXrandr#c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215377",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXrandr#c3e0a8af9e405c91b0ea55e6dafb1bfb62bfe453",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXrender",
+      "purl": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=aarch64&distro=rhel-8.10&package-id=2622b49eaaf4c1db&upstream=libXrender-0.9.10-7.el8.src.rpm",
+      "version": "0.9.10-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "90e38e62624a34867ee066a19ddecda68ce49dfd",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXrender#90e38e62624a34867ee066a19ddecda68ce49dfd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747368",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXrender#90e38e62624a34867ee066a19ddecda68ce49dfd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libXtst",
+      "purl": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=3e3c5ad2962a85d9&upstream=libXtst-1.2.3-7.el8.src.rpm",
+      "version": "1.2.3-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "88da2182682f3d6f76b225ec07bff26eb0068868",
+            "url": "git://pkgs.devel.redhat.com/rpms/libXtst#88da2182682f3d6f76b225ec07bff26eb0068868"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747385",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libXtst#88da2182682f3d6f76b225ec07bff26eb0068868",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=9d27b98fe63ca3cd&upstream=acl-2.2.53-3.el8.src.rpm",
+      "version": "2.2.53-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "64d42070c251d4b78dc897999b1ff36c5be04002",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2710224",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#64d42070c251d4b78dc897999b1ff36c5be04002",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=f7634661bd463385&upstream=libarchive-3.3.3-5.el8.src.rpm",
+      "version": "3.3.3-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "104b7b68bae0f2bc8cdda1220b675cb93ab7250a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libarchive#104b7b68bae0f2bc8cdda1220b675cb93ab7250a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2293131",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libarchive#104b7b68bae0f2bc8cdda1220b675cb93ab7250a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libasan",
+      "purl": "pkg:rpm/redhat/libasan@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libasan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=564c33037dacb889&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=1719abfe14071591&upstream=libassuan-2.5.1-3.el8.src.rpm",
+      "version": "2.5.1-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3de5b0bcfc1ed6c812fd4bb6e171584655be414a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#3de5b0bcfc1ed6c812fd4bb6e171584655be414a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747020",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#3de5b0bcfc1ed6c812fd4bb6e171584655be414a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libatomic",
+      "purl": "pkg:rpm/redhat/libatomic@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libatomic@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5fbe3e4bf494d51b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=aarch64&distro=rhel-8.10&package-id=d3409f4e6605d5b3&upstream=attr-2.4.48-3.el8.src.rpm",
+      "version": "2.4.48-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fdfcc6e99dda82ee784f779aea1e6583d6a9114f",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#fdfcc6e99dda82ee784f779aea1e6583d6a9114f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746019",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#fdfcc6e99dda82ee784f779aea1e6583d6a9114f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=b646f22ca3348666&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=aarch64&distro=rhel-8.10&package-id=df47f6b7146547f5&upstream=libcap-2.48-6.el8_9.src.rpm",
+      "version": "2.48-6.el8_9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820182",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libcap#739ee7058ca1e1e6cf688eb11733a89ae1a3ff6a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e3cd1e52de35fc54&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+      "version": "0.7.11-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "81596f2d86a07a87e7114728f34610a4efe7e67b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#81596f2d86a07a87e7114728f34610a4efe7e67b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1621556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#81596f2d86a07a87e7114728f34610a4efe7e67b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8b389f14c0a79044&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+      "version": "1.45.6-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "56bb7dc240dbaa63a9b44a865b6167d34f484128",
+            "url": "git://pkgs.devel.redhat.com/rpms/e2fsprogs#56bb7dc240dbaa63a9b44a865b6167d34f484128"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2014246",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/e2fsprogs#56bb7dc240dbaa63a9b44a865b6167d34f484128",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcomps",
+      "purl": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44d5ca3b8ff1766a&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "version": "0.1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4135df9c80076d65c4818b24201054bf2f1be50d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcurl",
+      "purl": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7fb4d069cf9c95ea&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "version": "7.61.1-34.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3375089",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#a29ff5a08ef0faee28a7c7470b3a8684763c79c7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdatrie",
+      "purl": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=aarch64&distro=rhel-8.10&package-id=c4c7e4b3981d0cf9&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+      "version": "0.2.9-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9f635f110e56b9d5bf47821f7012ce5266ea9831",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdatrie#9f635f110e56b9d5bf47821f7012ce5266ea9831"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdatrie#9f635f110e56b9d5bf47821f7012ce5266ea9831",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdb",
+      "purl": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=a4bfbcf6f3d5862d&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "version": "5.3.28-42.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1724416",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdb-utils",
+      "purl": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=2933aca3c206dd07&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "version": "5.3.28-42.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2 and Sleepycat"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+            "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1724416",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libdb#c86108edeb77e2c664b3cb0cf031b1ab460a17d3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=112492897e160bc3&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libepoxy",
+      "purl": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=aarch64&distro=rhel-8.10&package-id=6c53c63bbf11aba5&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+      "version": "1.5.8-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cd28d1e02402539789c4f28b0eb7ea1f33503e88",
+            "url": "git://pkgs.devel.redhat.com/rpms/libepoxy#cd28d1e02402539789c4f28b0eb7ea1f33503e88"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1647414",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libepoxy#cd28d1e02402539789c4f28b0eb7ea1f33503e88",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libfdisk",
+      "purl": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=df0e828929783e77&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=aarch64&distro=rhel-8.10&package-id=5b6bad9d2758a421&upstream=libffi-3.1-24.el8.src.rpm",
+      "version": "3.1-24.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c565b3a03c15455f315d054f69da5f9dc5c648fb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#c565b3a03c15455f315d054f69da5f9dc5c648fb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2281599",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#c565b3a03c15455f315d054f69da5f9dc5c648fb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libfontenc",
+      "purl": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=aarch64&distro=rhel-8.10&package-id=a097a18165dd8f25&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+      "version": "1.1.3-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf2feb55c26033eaeb9e151cb7ec701cf55fc62b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libfontenc#bf2feb55c26033eaeb9e151cb7ec701cf55fc62b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747099",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libfontenc#bf2feb55c26033eaeb9e151cb7ec701cf55fc62b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8f41c8c3ebe3564a&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=aarch64&distro=rhel-8.10&package-id=a9661a521abcf435&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+      "version": "1.8.5-7.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgcrypt#fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1987493",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgcrypt#fce8ed7d6abd6f02b118c98babc13c7b8e4e6b95",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgomp",
+      "purl": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c47afa9dbb1716c7&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=aarch64&distro=rhel-8.10&package-id=8b91a1557a32d7b4&upstream=libgpg-error-1.31-1.el8.src.rpm",
+      "version": "1.31-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac00f435a46e5609f4a4504a87fed9edcd51f374",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#ac00f435a46e5609f4a4504a87fed9edcd51f374"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747111",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#ac00f435a46e5609f4a4504a87fed9edcd51f374",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgusb",
+      "purl": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5d88f0893502fb4f&upstream=libgusb-0.3.0-1.el8.src.rpm",
+      "version": "0.3.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14d7241bc2a77370fd275cf1c65664259f0464fb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgusb#14d7241bc2a77370fd275cf1c65664259f0464fb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgusb#14d7241bc2a77370fd275cf1c65664259f0464fb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e5b83aa2b874524b&upstream=libidn2-2.2.0-1.el8.src.rpm",
+      "version": "2.2.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "844711723d62e709fb16cc01b988468b226e9659",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#844711723d62e709fb16cc01b988468b226e9659"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=909244",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#844711723d62e709fb16cc01b988468b226e9659",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libjpeg-turbo",
+      "purl": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=aarch64&distro=rhel-8.10&package-id=7e3e9be87e629c89&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+      "version": "1.5.3-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "IJG"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6c3165c96e35faab383b164294460eccba517907",
+            "url": "git://pkgs.devel.redhat.com/rpms/libjpeg-turbo#6c3165c96e35faab383b164294460eccba517907"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1663830",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libjpeg-turbo#6c3165c96e35faab383b164294460eccba517907",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=aarch64&distro=rhel-8.10&package-id=b6e8357e7e1b8c14&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+      "version": "1.3.5-9.el8_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7a641d587945a523e806d95a5873327bd5bbee07",
+            "url": "git://pkgs.devel.redhat.com/rpms/libksba#7a641d587945a523e806d95a5873327bd5bbee07"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2345799",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libksba#7a641d587945a523e806d95a5873327bd5bbee07",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodman",
+      "purl": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=aarch64&distro=rhel-8.10&package-id=0fcc2edf750b9023&upstream=libmodman-2.0.1-17.el8.src.rpm",
+      "version": "2.0.1-17.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodman#f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747175",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodman#f8b6b8f0adf2ea626ac3b294b4bbdeea3c0da8f7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5a20854f17566631&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+      "version": "2.13.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "93951985e28c28d784bbb8b084bae6e428148e35",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#93951985e28c28d784bbb8b084bae6e428148e35"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695734",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#93951985e28c28d784bbb8b084bae6e428148e35",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=f90aaec48b37e8f0&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmpc",
+      "purl": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=aarch64&distro=rhel-8.10&package-id=a07abfdc3a969678&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+      "version": "1.1.0-9.1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6b1a2d5892f12e777e1ef3a29bc1d0c83e499317",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmpc#6b1a2d5892f12e777e1ef3a29bc1d0c83e499317"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1345966",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmpc#6b1a2d5892f12e777e1ef3a29bc1d0c83e499317",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=58a27f2921004797&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+      "version": "1.33.0-6.el8_10.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eab77a0da66f15bc5084a2fd0ea1514636cbfe69",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#eab77a0da66f15bc5084a2fd0ea1514636cbfe69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996504",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#eab77a0da66f15bc5084a2fd0ea1514636cbfe69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnl3",
+      "purl": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=26fea9dd5e53dd90&upstream=libnl3-3.7.0-1.el8.src.rpm",
+      "version": "3.7.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e4cb0e98768f5184b2ca03d07a0c7a1d074f230",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnl3#3e4cb0e98768f5184b2ca03d07a0c7a1d074f230"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2077667",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnl3#3e4cb0e98768f5184b2ca03d07a0c7a1d074f230",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnsl2",
+      "purl": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=aarch64&distro=rhel-8.10&package-id=b359853f9043e5e1&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+      "version": "1.2.0-2.20180605git4a062cf.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3aaef48927091509dfedb2a21bf8b81f460f89e1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libnsl2#3aaef48927091509dfedb2a21bf8b81f460f89e1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747205",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libnsl2#3aaef48927091509dfedb2a21bf8b81f460f89e1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpkgconf",
+      "purl": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=a437d21cd0275150&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpng",
+      "purl": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=e2255200ffe21353&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "version": "2:1.6.34-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "Zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31d64ebe86bf6eaec320369f80bea745379bab83",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpng-devel",
+      "purl": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=a692f7f04c49ba27&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "version": "2:1.6.34-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "Zlib"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31d64ebe86bf6eaec320369f80bea745379bab83",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=782820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpng#31d64ebe86bf6eaec320369f80bea745379bab83",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libproxy",
+      "purl": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8d90fd9fe1e9b528&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+      "version": "0.4.15-5.5.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9beb82f2dfe210e349fe719f94034e6169dbccf9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libproxy#9beb82f2dfe210e349fe719f94034e6169dbccf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3227237",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libproxy#9beb82f2dfe210e349fe719f94034e6169dbccf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpsl",
+      "purl": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=e0a9a0a10b80450f&upstream=libpsl-0.20.2-6.el8.src.rpm",
+      "version": "0.20.2-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "752b285122bce7c00a05be51e81f253d6ee8c00a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpsl#752b285122bce7c00a05be51e81f253d6ee8c00a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1215600",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpsl#752b285122bce7c00a05be51e81f253d6ee8c00a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpwquality",
+      "purl": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=aarch64&distro=rhel-8.10&package-id=325ab1835d1c6d46&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+      "version": "1.4.4-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79b7f02763a3c4be9121d767959588b8068acf32",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#79b7f02763a3c4be9121d767959588b8068acf32"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2375421",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpwquality#79b7f02763a3c4be9121d767959588b8068acf32",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "library-support",
+      "purl": "pkg:maven/org.graalvm.nativeimage/library-support@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7005288c99795d06f9d1c7a9f6bd83d1"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "86eb2169e2efb24c036c779e53e2ebbe8dc9bf5b"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bdc8f42bdfd63453e843571ba9fe67c6e6a5e8a2ac88fcf3a0c30d4b3ae7bcad"
+        }
+      ],
+      "bom-ref": "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "86eb2169e2efb24c036c779e53e2ebbe8dc9bf5b"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347866",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "library-support-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/library-support@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "81189f47b7f0f3d951395c393fd6bee9"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0ef34f03d7098887b1ea5a364a5cf3077ce4a7fe"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a2cefec3c90bdb846d331703368b22c91fb3d3ee3addbf9d330129a6066f8c1"
+        }
+      ],
+      "bom-ref": "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/library-support-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0ef34f03d7098887b1ea5a364a5cf3077ce4a7fe"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347867",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=7846f7a24b808647&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "version": "1.14.2-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc58d5532f28202ecd07557fc2934484fbd0674d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=aarch64&distro=rhel-8.10&package-id=6ca06be0281cde55&upstream=libreport-2.9.5-15.el8.src.rpm",
+      "version": "2.9.5-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cd702428f310bfec7ef6fb24f959a8ba3d1e7a99",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#cd702428f310bfec7ef6fb24f959a8ba3d1e7a99"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1290417",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#cd702428f310bfec7ef6fb24f959a8ba3d1e7a99",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=4d2f9eaf4eac1d2b&upstream=librhsm-0.0.3-5.el8.src.rpm",
+      "version": "0.0.3-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2772e1aa2d7193707e72eb2d1c727d06a16c9989",
+            "url": "git://pkgs.devel.redhat.com/rpms/librhsm#2772e1aa2d7193707e72eb2d1c727d06a16c9989"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2323402",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/librhsm#2772e1aa2d7193707e72eb2d1c727d06a16c9989",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libseccomp",
+      "purl": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=183140ebe5efae19&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+      "version": "2.5.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2e3a0fd6837173bb76b091d65e591a1ce7311378",
+            "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#2e3a0fd6837173bb76b091d65e591a1ce7311378"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1786669",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libseccomp#2e3a0fd6837173bb76b091d65e591a1ce7311378",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1dcab03ec8d5a657&upstream=libselinux-2.9-9.el8_10.src.rpm",
+      "version": "2.9-9.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ed8e2baba154118c35626186ed3e654c10b5f491",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#ed8e2baba154118c35626186ed3e654c10b5f491"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3239387",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#ed8e2baba154118c35626186ed3e654c10b5f491",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=aarch64&distro=rhel-8.10&package-id=adbe6cf578398b6c&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+      "version": "2.9-10.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "997cbe2630d6429ee45f6cfef84ff7509a4ea058",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#997cbe2630d6429ee45f6cfef84ff7509a4ea058"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3239522",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#997cbe2630d6429ee45f6cfef84ff7509a4ea058",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=14a7d099f9556a9a&upstream=libsepol-2.9-3.el8.src.rpm",
+      "version": "2.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad6a367f763be53b4d0e436a21b280b69c8597c9",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsepol#ad6a367f763be53b4d0e436a21b280b69c8597c9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707351",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsepol#ad6a367f763be53b4d0e436a21b280b69c8597c9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=aarch64&distro=rhel-8.10&package-id=91079b2774b8b040&upstream=libsigsegv-2.11-5.el8.src.rpm",
+      "version": "2.11-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "67798a99164bf6a86104365323cdd1e96aa481ac",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#67798a99164bf6a86104365323cdd1e96aa481ac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747270",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#67798a99164bf6a86104365323cdd1e96aa481ac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=e60e475fd320494f&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=aarch64&distro=rhel-8.10&package-id=872a30e171b05c4a&upstream=libsolv-0.7.20-6.el8.src.rpm",
+      "version": "0.7.20-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3591046e11dc93a168b2746adc2cea187517125b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsolv#3591046e11dc93a168b2746adc2cea187517125b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563470",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsolv#3591046e11dc93a168b2746adc2cea187517125b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsoup",
+      "purl": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1b02aca03537bb7a&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+      "version": "2.62.3-7.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5c427b629b65ec0bbc9ac68c202782c460d99ea0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsoup#5c427b629b65ec0bbc9ac68c202782c460d99ea0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3487919",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsoup#5c427b629b65ec0bbc9ac68c202782c460d99ea0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh",
+      "purl": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=ab82e216500e0485&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "version": "0.9.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2928407",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libssh-config",
+      "purl": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "version": "0.9.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2928407",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libssh#e1bdcfcf505d73cf406baa1043430c0ac7e481af",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e971c74752b284e8&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++-devel",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d547be5b6d90f20c&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=aarch64&distro=rhel-8.10&package-id=fe46eeefc65cc0ab&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+      "version": "4.13-4.el8_7",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8353f7abddd9a5fdad86a0f8a1aa00059190fff1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#8353f7abddd9a5fdad86a0f8a1aa00059190fff1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2288152",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#8353f7abddd9a5fdad86a0f8a1aa00059190fff1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libthai",
+      "purl": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=aarch64&distro=rhel-8.10&package-id=de48710f0e2c7520&upstream=libthai-0.1.27-2.el8.src.rpm",
+      "version": "0.1.27-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "86c327f4c74fe5d4b41929bafb1c4ab9088f48ce",
+            "url": "git://pkgs.devel.redhat.com/rpms/libthai#86c327f4c74fe5d4b41929bafb1c4ab9088f48ce"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747296",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libthai#86c327f4c74fe5d4b41929bafb1c4ab9088f48ce",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtiff",
+      "purl": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5cbce553517738e9&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+      "version": "4.0.9-33.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "libtiff"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "21cdd75b44d4aa017c3df163cad6a932005398e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtiff#21cdd75b44d4aa017c3df163cad6a932005398e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3261047",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtiff#21cdd75b44d4aa017c3df163cad6a932005398e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtirpc",
+      "purl": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c05d1d0844912efe&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+      "version": "1.1.4-12.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "SISSL and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "589b33251d858534e86a24b77ac11d2172474e3b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#589b33251d858534e86a24b77ac11d2172474e3b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3028658",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libtirpc#589b33251d858534e86a24b77ac11d2172474e3b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libubsan",
+      "purl": "pkg:rpm/redhat/libubsan@8.5.0-23.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libubsan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=eee6fc3ea6845423&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "version": "8.5.0-23.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3498786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#60866efe8f9b6e29f26613b8521e67a0370f0dfe",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=ff6a6a152a60cd30&upstream=libunistring-0.9.9-3.el8.src.rpm",
+      "version": "0.9.9-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "10c31f1b7221e427e7ae5925cd95860117eb0ccf",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#10c31f1b7221e427e7ae5925cd95860117eb0ccf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=753876",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#10c31f1b7221e427e7ae5925cd95860117eb0ccf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libusbx",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=aarch64&distro=rhel-8.10&package-id=97ea5d360e069ab2&upstream=libusbx-1.0.23-4.el8.src.rpm",
+      "version": "1.0.23-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca5dec750fe81d6a60c442ecbffb1bde77a86d94",
+            "url": "git://pkgs.devel.redhat.com/rpms/libusbx#ca5dec750fe81d6a60c442ecbffb1bde77a86d94"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1286148",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libusbx#ca5dec750fe81d6a60c442ecbffb1bde77a86d94",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuser",
+      "purl": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=aarch64&distro=rhel-8.10&package-id=685367a93f076d65&upstream=libuser-0.62-26.el8_10.src.rpm",
+      "version": "0.62-26.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3584103bf5b70ec86c555a98f079ae5129c18a33",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libuser#3584103bf5b70ec86c555a98f079ae5129c18a33"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3196688",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libuser#3584103bf5b70ec86c555a98f079ae5129c18a33",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libutempter",
+      "purl": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=f8fd78979cb56b53&upstream=libutempter-1.1.6-14.el8.src.rpm",
+      "version": "1.1.6-14.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e269bbe32b6035d279754a5ee33a9e017ab337b8",
+            "url": "git://pkgs.devel.redhat.com/rpms/libutempter#e269bbe32b6035d279754a5ee33a9e017ab337b8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747310",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libutempter#e269bbe32b6035d279754a5ee33a9e017ab337b8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=827034366e893e61&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=aarch64&distro=rhel-8.10&package-id=0915d8364816bf23&upstream=libverto-0.3.2-2.el8.src.rpm",
+      "version": "0.3.2-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "377a16f5e9b26225de899f887687a87349ce6d0b",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#377a16f5e9b26225de899f887687a87349ce6d0b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2079503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#377a16f5e9b26225de899f887687a87349ce6d0b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-client",
+      "purl": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d4f9c25c8368ffc0&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-cursor",
+      "purl": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7c63ae3d9327dfc9&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libwayland-egl",
+      "purl": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=3857c70756c26179&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "version": "1.21.0-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e38cc752bf85d72246864988a0a49b25a18e7375",
+            "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2242434",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/wayland#e38cc752bf85d72246864988a0a49b25a18e7375",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcb",
+      "purl": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=66014f616ce4b606&upstream=libxcb-1.13.1-1.el8.src.rpm",
+      "version": "1.13.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb253be7a4af9d5f484caa8d05d0065a5c20e172",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcb#eb253be7a4af9d5f484caa8d05d0065a5c20e172"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1014531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcb#eb253be7a4af9d5f484caa8d05d0065a5c20e172",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3a14124d7f3621bc&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "version": "4.1.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt-devel",
+      "purl": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=339e20c0716cc640&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "version": "4.1.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592637",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#65b86f94ba2c061290f3e4d3f4bca4007ecb6549",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxkbcommon",
+      "purl": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=2a174bf5209cf6e2&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+      "version": "0.9.1-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e3a0fcdea5c0b303ed969d5cef0a04968cd241d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxkbcommon#3e3a0fcdea5c0b303ed969d5cef0a04968cd241d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1001832",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxkbcommon#3e3a0fcdea5c0b303ed969d5cef0a04968cd241d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=aarch64&distro=rhel-8.10&package-id=116d6f5d9908ee8e&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+      "version": "2.9.7-18.el8_10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ba13a44374bf525af5006ea36434d7b80a81f486",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#ba13a44374bf525af5006ea36434d7b80a81f486"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3508739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#ba13a44374bf525af5006ea36434d7b80a81f486",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=aarch64&distro=rhel-8.10&package-id=607c59ebfbcc98b4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+      "version": "0.1.7-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "23f1a0c7bf8a0013a158d71431038038f95ca6cb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#23f1a0c7bf8a0013a158d71431038038f95ca6cb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747381",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#23f1a0c7bf8a0013a158d71431038038f95ca6cb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7a1760d46e6068b4&upstream=zstd-1.4.4-1.el8.src.rpm",
+      "version": "1.4.4-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "41d137254dabfa495e5585021335d646538846d8",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#41d137254dabfa495e5585021335d646538846d8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1216822",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#41d137254dabfa495e5585021335d646538846d8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lksctp-tools",
+      "purl": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=aarch64&distro=rhel-8.10&package-id=3698d052477430fc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+      "version": "1.0.18-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2 and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9771a405772fc12411151a12eebb245a02a8c778",
+            "url": "git://pkgs.devel.redhat.com/rpms/lksctp-tools#9771a405772fc12411151a12eebb245a02a8c778"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=757723",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lksctp-tools#9771a405772fc12411151a12eebb245a02a8c778",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua",
+      "purl": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=b0c8afe45df6f5be&upstream=lua-5.3.4-12.el8.src.rpm",
+      "version": "5.3.4-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0295c1179922370860fe28899e811e9fc663562c",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1701413",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6d18d92559bad86c&upstream=lua-5.3.4-12.el8.src.rpm",
+      "version": "5.3.4-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0295c1179922370860fe28899e811e9fc663562c",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1701413",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#0295c1179922370860fe28899e811e9fc663562c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=aarch64&distro=rhel-8.10&package-id=5f623653b82e2295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+      "version": "1.8.3-3.el8_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f024e0067da0f2157c0108391673fae4d952d283",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#f024e0067da0f2157c0108391673fae4d952d283"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1615115",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#f024e0067da0f2157c0108391673fae4d952d283",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b39be4aa3230f5fc&upstream=mpfr-3.1.6-1.el8.src.rpm",
+      "version": "3.1.6-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ and GPLv3+ and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7f705032792f282cb684476c9da5bcdbeaca46de",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#7f705032792f282cb684476c9da5bcdbeaca46de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747521",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#7f705032792f282cb684476c9da5bcdbeaca46de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "native-image-base",
+      "purl": "pkg:maven/org.graalvm.nativeimage/native-image-base@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "97dc3b26cbc80d2f46df94f7c9597e86"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f8b1a8870924f535e2e4433f9d243580b6a2f796"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "06af1e144315b25f765b89a5d9c85985b3364d0a9118f153ac06c592d393fb4c"
+        }
+      ],
+      "bom-ref": "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f8b1a8870924f535e2e4433f9d243580b6a2f796"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347892",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "native-image-base-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/native-image-base@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "6b44d37da4b7d1ccab75398c1ad84f56"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "574110f086cb10719e28e02ad9720e650835a067"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d59c31a4b85860e8245b1b47f3da66a2dffec41416f85b0ec96fd2351d77604"
+        }
+      ],
+      "bom-ref": "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/native-image-base-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "574110f086cb10719e28e02ad9720e650835a067"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347903",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "nativeimage",
+      "purl": "pkg:maven/org.graalvm.sdk/nativeimage@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "eea890f3986c4e5110dffd7839cb23f4"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0249c4b127d2aa81f3592e152545eacfc50a10ae"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7ae03b5689f9a9091f40c4d0392abbd0a74e5182dad0e0b4b7b64cc503734de9"
+        }
+      ],
+      "bom-ref": "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0249c4b127d2aa81f3592e152545eacfc50a10ae"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347860",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "nativeimage-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/nativeimage@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e666c79164441872d394c335825d4b1d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "3508f317f62357c1a41c51eef4fdf6c84729cad3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f7f627c7acd040132a163c16c240de6f92d9e3d78409ced544a50dcbb5e0b349"
+        }
+      ],
+      "bom-ref": "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/nativeimage-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "3508f317f62357c1a41c51eef4fdf6c84729cad3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347881",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "version": "6.1-10.20180224.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35d800911ab07907e7b74b1d02b82d88a35d6422",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2638772",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=aarch64&distro=rhel-8.10&package-id=d5d54f710fc30c6c&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "version": "6.1-10.20180224.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35d800911ab07907e7b74b1d02b82d88a35d6422",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2638772",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#35d800911ab07907e7b74b1d02b82d88a35d6422",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=aarch64&distro=rhel-8.10&package-id=85f82b06d08c07da&upstream=nettle-3.4.1-7.el8.src.rpm",
+      "version": "3.4.1-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e770f0b169737f8c430bd5c68292968f42701c5",
+            "url": "git://pkgs.devel.redhat.com/rpms/nettle#7e770f0b169737f8c430bd5c68292968f42701c5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1663247",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/nettle#7e770f0b169737f8c430bd5c68292968f42701c5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.5-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=6e32855431e0b2f1&upstream=npth-1.5-4.el8.src.rpm",
+      "version": "1.5-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4981bb31f79089dc8b3457db23d090cfec97e2a",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#a4981bb31f79089dc8b3457db23d090cfec97e2a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747600",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#a4981bb31f79089dc8b3457db23d090cfec97e2a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nspr",
+      "purl": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f49c22ca630d6fac&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+      "version": "4.35.0-1.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "765d8f1920ffbb18661967cade9d52599206d65f",
+            "url": "git://pkgs.devel.redhat.com/rpms/nspr#765d8f1920ffbb18661967cade9d52599206d65f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2563709",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/nspr#765d8f1920ffbb18661967cade9d52599206d65f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss",
+      "purl": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a1b42013319200fc&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn",
+      "purl": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f35d76f713c9d5de&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-softokn-freebl",
+      "purl": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=630795f4ee0f59ae&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-sysinit",
+      "purl": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=414018215681a712&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nss-util",
+      "purl": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a6c23e9089421845&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "version": "3.101.0-11.el8_8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fe3c378c7dd1f082af1a7a163200f94357821343",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3399988",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nss#fe3c378c7dd1f082af1a7a163200f94357821343",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "objectfile",
+      "purl": "pkg:maven/org.graalvm.nativeimage/objectfile@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "30e219aa681c9aebed99076eb85cb40f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "5dcc29507faeed2055fe21b11fb4472fde216ab1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ae0cf7576cab09d4c3a3be3704fb9c352933f8bcfb693fe92e8b6d849ba1c161"
+        }
+      ],
+      "bom-ref": "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "5dcc29507faeed2055fe21b11fb4472fde216ab1"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347889",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "objectfile-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/objectfile@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "15eff2e37b905ec795b8a96971f9e77a"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c52abe898512e0cf6b66c597fa8b427424cf2beb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e8f62b5c6f9b90936d466951fb5a07edebb349507751b34d81cb574d3dc08b76"
+        }
+      ],
+      "bom-ref": "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/objectfile-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c52abe898512e0cf6b66c597fa8b427424cf2beb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347864",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e3a7f8b669b15c6e&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+      "version": "2.4.46-20.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "OpenLDAP"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9820cbeebe81720251c3508f6121a53de5bf4d6f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9820cbeebe81720251c3508f6121a53de5bf4d6f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3342461",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#9820cbeebe81720251c3508f6121a53de5bf4d6f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=19322cfbb726e69d&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+      "version": "1:1.1.1k-14.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "OpenSSL and ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3e0fe173933c40fcd6e520e696b31568121feb64",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#3e0fe173933c40fcd6e520e696b31568121feb64"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3290749",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#3e0fe173933c40fcd6e520e696b31568121feb64",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=8ab00611a5262639&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "version": "0.23.22-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4533f1a47434a4cb080c56a0f156cb90084fb389",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2799954",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=bef8eded2f067ea1&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "version": "0.23.22-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4533f1a47434a4cb080c56a0f156cb90084fb389",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2799954",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#4533f1a47434a4cb080c56a0f156cb90084fb389",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pam",
+      "purl": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=aarch64&distro=rhel-8.10&package-id=328b8af675ba36d1&upstream=pam-1.3.1-36.el8_10.src.rpm",
+      "version": "1.3.1-36.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "40c8b8bba685d7f5158d24071def2460453a0d49",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#40c8b8bba685d7f5158d24071def2460453a0d49"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3412546",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pam#40c8b8bba685d7f5158d24071def2460453a0d49",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pango",
+      "purl": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=aarch64&distro=rhel-8.10&package-id=3f02b6b82bebe2bb&upstream=pango-1.42.4-8.el8.src.rpm",
+      "version": "1.42.4-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a842466da971c3bea09e27dedae7aef1d1cfdcc2",
+            "url": "git://pkgs.devel.redhat.com/rpms/pango#a842466da971c3bea09e27dedae7aef1d1cfdcc2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1627722",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pango#a842466da971c3bea09e27dedae7aef1d1cfdcc2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "passwd",
+      "purl": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d32eb1b1193179b2&upstream=passwd-0.80-4.el8.src.rpm",
+      "version": "0.80-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPL+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e779bcdeee3700ff51dfd597064b96368328dc40",
+            "url": "git://pkgs.devel.redhat.com/rpms/passwd#e779bcdeee3700ff51dfd597064b96368328dc40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1878394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/passwd#e779bcdeee3700ff51dfd597064b96368328dc40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3e4a953d06b3e762&upstream=pcre-8.42-6.el8.src.rpm",
+      "version": "8.42-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9985141f5cdf90f176d96f2503bdf60d139d45c6",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre#9985141f5cdf90f176d96f2503bdf60d139d45c6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1621568",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre#9985141f5cdf90f176d96f2503bdf60d139d45c6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=0efed7b24272dfb6&upstream=pcre2-10.32-3.el8_6.src.rpm",
+      "version": "10.32-3.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8edb1ebde203287340e48d6cd77f92a013917e84",
+            "url": "git://pkgs.devel.redhat.com/rpms/pcre2#8edb1ebde203287340e48d6cd77f92a013917e84"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2016974",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pcre2#8edb1ebde203287340e48d6cd77f92a013917e84",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pixman",
+      "purl": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=aarch64&distro=rhel-8.10&package-id=3d9eb892a2be9298&upstream=pixman-0.38.4-4.el8.src.rpm",
+      "version": "0.38.4-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "046693e14b52d91016bb02d9fb449994a787c534",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pixman#046693e14b52d91016bb02d9fb449994a787c534"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2704038",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pixman#046693e14b52d91016bb02d9fb449994a787c534",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf",
+      "purl": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=96aa135add7867ca&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf-m4",
+      "purl": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pkgconf-pkg-config",
+      "purl": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b061dd442c817159&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "version": "1.4.2-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "baaf7998f97184941e3b6e8a10bc58d036b22b28",
+            "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748183",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pkgconf#baaf7998f97184941e3b6e8a10bc58d036b22b28",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "platform-python",
+      "purl": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=04040e71b6a01e44&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "version": "3.6.8-69.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be2100ec318de201701fcaba16b7663363ee17e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3395467",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "platform-python-setuptools",
+      "purl": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "version": "39.2.0-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ec50811ce8a9855678d3782ff7b88250bbc848",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3195605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pointsto",
+      "purl": "pkg:maven/org.graalvm.nativeimage/pointsto@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "79d6b722caf8cee9b2812295bb6c1a5c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "f5e0de103e6f85226cbd60246bab2e3d17f963b9"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "5de7d7e83a5757ab3d91a90db7a604fbfc7732dbff28203921d467ba8a048edf"
+        }
+      ],
+      "bom-ref": "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "f5e0de103e6f85226cbd60246bab2e3d17f963b9"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347887",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "pointsto-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/pointsto@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5afed6308ee085e7808a48041bec445d"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "d5868114defdc2f7cc60d2215d77bb67bfaae227"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "339cdb05b609d741906b388d15d478d7c08d3f9ed3b70a45d8bba21e4066dd5d"
+        }
+      ],
+      "bom-ref": "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/pointsto-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "d5868114defdc2f7cc60d2215d77bb67bfaae227"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347885",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=db3651f8dfe4fe78&upstream=popt-1.18-1.el8.src.rpm",
+      "version": "1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "63b1c8ea59d934997b71b3970a8581528a6e40bf",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#63b1c8ea59d934997b71b3970a8581528a6e40bf"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1447539",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#63b1c8ea59d934997b71b3970a8581528a6e40bf",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "publicsuffix-list-dafsa",
+      "purl": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+      "version": "20180723-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MPLv2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "33aaa9362fba95857a515475feaff035f59b3384",
+            "url": "git://pkgs.devel.redhat.com/rpms/publicsuffix-list#33aaa9362fba95857a515475feaff035f59b3384"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748188",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/publicsuffix-list#33aaa9362fba95857a515475feaff035f59b3384",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-chardet",
+      "purl": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+      "version": "3.0.4-7.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bc10a725de0ebf632b9cd67735bb46c1c31df1ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#bc10a725de0ebf632b9cd67735bb46c1c31df1ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-chardet#bc10a725de0ebf632b9cd67735bb46c1c31df1ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-cloud-what",
+      "purl": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=fa3bdd3c94948edf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dateutil",
+      "purl": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+      "version": "1:2.6.1-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e8441401ab6a860bcd370ffde42e9f605bb92e3d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#e8441401ab6a860bcd370ffde42e9f605bb92e3d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747009",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-dateutil#e8441401ab6a860bcd370ffde42e9f605bb92e3d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dbus",
+      "purl": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=aarch64&distro=rhel-8.10&package-id=7641f38d8fdd67b0&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+      "version": "1.2.4-15.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "45e35d535a5cd8f48ab9394b495dbf673eb903cd",
+            "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#45e35d535a5cd8f48ab9394b495dbf673eb903cd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=907679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dbus-python#45e35d535a5cd8f48ab9394b495dbf673eb903cd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-decorator",
+      "purl": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+      "version": "4.2.1-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e80551f4e524f020d9b557eed072faba6e1970a8",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#e80551f4e524f020d9b557eed072faba6e1970a8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=746941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-decorator#e80551f4e524f020d9b557eed072faba6e1970a8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf",
+      "purl": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-dnf-plugins-core",
+      "purl": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+      "version": "4.0.21-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "89e8cd35656b141dd5b2617ea383d81c71e6d947",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#89e8cd35656b141dd5b2617ea383d81c71e6d947"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2850556",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf-plugins-core#89e8cd35656b141dd5b2617ea383d81c71e6d947",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-ethtool",
+      "purl": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=aarch64&distro=rhel-8.10&package-id=5934b23038107776&upstream=python-ethtool-0.14-5.el8.src.rpm",
+      "version": "0.14-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "202eebc82b5b3dfa41395f92c09a98d6d0359827",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-ethtool#202eebc82b5b3dfa41395f92c09a98d6d0359827"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1878310",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-ethtool#202eebc82b5b3dfa41395f92c09a98d6d0359827",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gobject-base",
+      "purl": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=aarch64&distro=rhel-8.10&package-id=fe4447ebb9031347&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+      "version": "3.28.3-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "53477796225e557d49a99871db8dcf8728f900b6",
+            "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#53477796225e557d49a99871db8dcf8728f900b6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1224593",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/pygobject3#53477796225e557d49a99871db8dcf8728f900b6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-gpg",
+      "purl": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6664419428cfad79&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "version": "1.13.1-12.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30ce989734661681faba06ceb0a2573a5c66b85f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2903739",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gpgme#30ce989734661681faba06ceb0a2573a5c66b85f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-hawkey",
+      "purl": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=0a805fdf275ab160&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-idna",
+      "purl": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+      "version": "2.5-7.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and Python and Unicode"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3f661cf6994a1c21eba9801b550a210d8e71f7c3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#3f661cf6994a1c21eba9801b550a210d8e71f7c3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3026523",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-idna#3f661cf6994a1c21eba9801b550a210d8e71f7c3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-iniparse",
+      "purl": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+      "version": "0.4-31.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747226",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-iniparse#a34eb76c56747a185d15c5fb7dd44ae5a66bfcf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-inotify",
+      "purl": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+      "version": "0.9.6-13.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f57fac45551fa077aa273dab9780688212baef3d",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#f57fac45551fa077aa273dab9780688212baef3d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=800820",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-inotify#f57fac45551fa077aa273dab9780688212baef3d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libcomps",
+      "purl": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f0aa16ee3d997f13&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "version": "0.1.18-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4135df9c80076d65c4818b24201054bf2f1be50d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1787698",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcomps#4135df9c80076d65c4818b24201054bf2f1be50d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libdnf",
+      "purl": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b64bc837fa3b3b7&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "version": "0.63.0-21.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3431475",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#b59c452d0827d3954db02cab24f8a2f7d7483f9f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-librepo",
+      "purl": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=2bbd773b962f3af8&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "version": "1.14.2-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dc58d5532f28202ecd07557fc2934484fbd0674d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797250",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#dc58d5532f28202ecd07557fc2934484fbd0674d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-libs",
+      "purl": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=dc6170657118ed50&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "version": "3.6.8-69.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "Python"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be2100ec318de201701fcaba16b7663363ee17e9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3395467",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python3#be2100ec318de201701fcaba16b7663363ee17e9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pip-wheel",
+      "purl": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+      "version": "9.0.3-24.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Python and ASL 2.0 and BSD and ISC and LGPLv2 and MPLv2.0 and (ASL 2.0 or BSD)"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2905864",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-pip#13be3bc23d6c6cbb1fa2a4d4a4faa8368a5f4607",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-pysocks",
+      "purl": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+      "version": "1.6.8-3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7d9d71368d52d8212cee62f3c27e446ec1ef4658",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#7d9d71368d52d8212cee62f3c27e446ec1ef4658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747578",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-pysocks#7d9d71368d52d8212cee62f3c27e446ec1ef4658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-requests",
+      "purl": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+      "version": "2.20.0-5.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a7ae828b4e21e6c57743ffc05a81005475343a62",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a7ae828b4e21e6c57743ffc05a81005475343a62"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3449388",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-requests#a7ae828b4e21e6c57743ffc05a81005475343a62",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-rpm",
+      "purl": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c86eb92ca7a45d5f&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-setuptools-wheel",
+      "purl": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "version": "39.2.0-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c7ec50811ce8a9855678d3782ff7b88250bbc848",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3195605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-setuptools#c7ec50811ce8a9855678d3782ff7b88250bbc848",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-six",
+      "purl": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+      "version": "1.11.0-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3661c255a5569db674adbb27e1ffa6cd35ba017",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-six#b3661c255a5569db674adbb27e1ffa6cd35ba017"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747717",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-six#b3661c255a5569db674adbb27e1ffa6cd35ba017",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-subscription-manager-rhsm",
+      "purl": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=288586619e04710e&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-syspurpose",
+      "purl": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f38d22810e2efbb0&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-systemd",
+      "purl": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=aarch64&distro=rhel-8.10&package-id=bc2f0e1e5e72128d&upstream=python-systemd-234-8.el8.src.rpm",
+      "version": "234-8.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ae74ccffe250cc94d1e3ef3478ead327128c0213",
+            "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#ae74ccffe250cc94d1e3ef3478ead327128c0213"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=747825",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/python-systemd#ae74ccffe250cc94d1e3ef3478ead327128c0213",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "python3-urllib3",
+      "purl": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+      "version": "1.24.2-8.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "19a859ea4000236ba954a6b542c428e24c7ec796",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#19a859ea4000236ba954a6b542c428e24c7ec796"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3150813",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/python-urllib3#19a859ea4000236ba954a6b542c428e24c7ec796",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-231",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=aarch64&distro=rhel-8.10&package-id=6e3e79ac0fd369d4&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c6cf1ec221cd9836acae449773dca4b746541bbb",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel#c6cf1ec221cd9836acae449773dca4b746541bbb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483113",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel#c6cf1ec221cd9836acae449773dca4b746541bbb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-java",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.redhat_00001.1.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483096",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "quarkus-mandrel-java-jdk-21-binding",
+      "purl": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "version": "23.1.6.0_1-3.redhat_00001.1.el8qks",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3483096",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/quarkus-mandrel-java#4eabbc03b7bd16cd855cd78b7980c91ee1754871",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@7.0-10.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@7.0-10.el8?arch=aarch64&distro=rhel-8.10&package-id=bde5d37d5ddc9ec3&upstream=readline-7.0-10.el8.src.rpm",
+      "version": "7.0-10.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a73f0afebb2bcab9432598512ed4c166710381a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#a73f0afebb2bcab9432598512ed4c166710381a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748275",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#a73f0afebb2bcab9432598512ed4c166710381a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=aarch64&distro=rhel-8.10&package-id=6abfcad7344c4852&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+      "version": "8.10-0.3.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3021597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#e50cf9c2f1e0a2b6d2951ae1b1c3dbb6907a19c8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rest",
+      "purl": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=aarch64&distro=rhel-8.10&package-id=eb4ecd147aa27fcf&upstream=rest-0.8.1-2.el8.src.rpm",
+      "version": "0.8.1-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d19e5c77d7dd1627987dcd2ce5561423c56e8572",
+            "url": "git://pkgs.devel.redhat.com/rpms/rest#d19e5c77d7dd1627987dcd2ce5561423c56e8572"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748289",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rest#d19e5c77d7dd1627987dcd2ce5561423c56e8572",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+      "version": "8.1-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5a644f3b114add933d247f8c8f136c41e80dd0b2",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#5a644f3b114add933d247f8c8f136c41e80dd0b2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#5a644f3b114add933d247f8c8f136c41e80dd0b2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=cf2bd2d917d5d6ae&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-build-libs",
+      "purl": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ba960029a8447681&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8ddd5df4d1b6e342&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "version": "4.14.3-32.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3353068",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#b4c5b237426b5c9c9ad3abecc2a4b96e8d9ebefa",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.5-5.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.5-5.el8?arch=aarch64&distro=rhel-8.10&package-id=e9a6ef8cd84ecd36&upstream=sed-4.5-5.el8.src.rpm",
+      "version": "4.5-5.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b6552e38f557b3990eef296fc79058d20b68c024",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#b6552e38f557b3990eef296fc79058d20b68c024"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1752726",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#b6552e38f557b3990eef296fc79058d20b68c024",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+      "version": "2.12.2-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26",
+            "url": "git://pkgs.devel.redhat.com/rpms/setup#e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2280101",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/setup#e2bd6fc0ee3e00afe0cfeab2b119d08ce2c2ad26",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=07ad7309f6757172&upstream=shadow-utils-4.6-22.el8.src.rpm",
+      "version": "2:4.6-22.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f82d8153c218dc2bebd9a6d7099ea58237088b37",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#f82d8153c218dc2bebd9a6d7099ea58237088b37"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2787584",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#f82d8153c218dc2bebd9a6d7099ea58237088b37",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shared-mime-info",
+      "purl": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ed24a806ed7a13d9&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+      "version": "1.9-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e1047efceb596d22941a5328597673637857886b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shared-mime-info#e1047efceb596d22941a5328597673637857886b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2812019",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shared-mime-info#e1047efceb596d22941a5328597673637857886b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=aarch64&distro=rhel-8.10&package-id=ce027089a651fb5f&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+      "version": "3.26.0-19.el8_9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "08fd501b3cc1c5d3b429e85994f0a138064b4df2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#08fd501b3cc1c5d3b429e85994f0a138064b4df2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2837996",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#08fd501b3cc1c5d3b429e85994f0a138064b4df2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager",
+      "purl": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=479b0650a812678a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "version": "1.28.42-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2870444",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/subscription-manager#a3af0de3890bc4fa3fc0df2bffe198a0f666f19a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "subscription-manager-rhsm-certificates",
+      "purl": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+      "version": "20220623-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5631f07a6720db2f7d8f70e20bd85c12144b56e5",
+            "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#5631f07a6720db2f7d8f70e20bd85c12144b56e5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2507619",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/subscription-manager-rhsm-certificates#5631f07a6720db2f7d8f70e20bd85c12144b56e5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "svm",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "7ade33016ecba96046dfa2ea83418a88"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "7bc3285fc33ee1c7db1b0714abe2df8d9daff724"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e0ee3c4678f96c6e857b7b8479b24380c6b47e89ac460bf0ebef138c2fc7f541"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "7bc3285fc33ee1c7db1b0714abe2df8d9daff724"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347859",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-agent",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-agent@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "211bb0f3645201b6dde6e4ad7fdeb95f"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "6665a29599c7834c394f2b9d32e05da2aec3a468"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "453c0229fe2a86c717c01bad09644eb16fa5cb1d7dd5067e48ef7887a096e552"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "6665a29599c7834c394f2b9d32e05da2aec3a468"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347879",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-agent-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-agent@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "65cbb9bb9cb7f734ecd4243aef275583"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "48a3aae771f2ce450087d997b12088ae621d5c60"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "33e55579c44f5f532982ad744f68400d62a6c9263e51649c8f3634aabdf268bf"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-agent-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "48a3aae771f2ce450087d997b12088ae621d5c60"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347874",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-configure",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-configure@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b3f8525597d25a79f8eb007e45918a12"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "16da989f46ec44e2fa11374ab431d6cc63f1df77"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "24bd1f4f30605a3ea4ae41820ef37bdb40cdf2fc8c10938f0ac804c201ead0a7"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "16da989f46ec44e2fa11374ab431d6cc63f1df77"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347884",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-configure-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-configure@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "21b60a2579e8363b82b7e4e939173d2c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "760dae3c709289404ccf94c531be59726e695c55"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "fcabd5cbdf5e5e399c6d346087fec36ec46eec6d2b6cb43f7eb098b318d2ced5"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-configure-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "760dae3c709289404ccf94c531be59726e695c55"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347906",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-diagnostics-agent",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "614a660fa9cc3e62af68a196e472063b"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9a42d2dcf5d4eb6942764a47590e85e693ee6df3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7c41871055f13dc9e0d8d9962f3b1c89306ebccd7c7bccc01858470772d86561"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9a42d2dcf5d4eb6942764a47590e85e693ee6df3"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347886",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-diagnostics-agent-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "b302f55e82a1f5129885919727a99c55"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "76a5d6fd544395c0c054b8465f97ff2c97f5b44a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "aeffd8079fe426107756965d858f1dcf2b7dc91a3c0d1acb6dcc6fe9a8f3dd67"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-diagnostics-agent-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "76a5d6fd544395c0c054b8465f97ff2c97f5b44a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347870",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-driver",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-driver@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "dce52947b4dcb38a36a7a46a122c4449"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "57d00f8b24a5af5004c3aa032c5a3c11fac116cd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e521e3d64dea330f9fccd743780932bf1a09d3e44865650e2b7aa2ae268ccd80"
+        }
+      ],
+      "bom-ref": "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "57d00f8b24a5af5004c3aa032c5a3c11fac116cd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347851",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-driver-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-driver@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "a9f2af9d85c8dd77ae4f286b40eb910c"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "753c3329726a341da7f45dbe0b602b04d68f37bd"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "814e3f730fcef73784938be9a43a1a5d6854cdf85b2f839d8d50928704d01c21"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-driver-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "753c3329726a341da7f45dbe0b602b04d68f37bd"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347877",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-foreign",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-foreign@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "f0eadec5d5147d809f8e5629cfd43660"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0a61ab48509d780fdecec54ce986e4dfb23df446"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "6a443dbe1eb2c0b53d08ac26fbc29f6257951e3c3703d989e6439141fad4e019"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0a61ab48509d780fdecec54ce986e4dfb23df446"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347852",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-foreign-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm-foreign@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "e5621dfcd5e63abda82b9e5fb337b212"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "10b93299a4f24cc155b3afe4e780fb1bdaf9537a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "bda6d1f3ebf2d6591212be27ed44c660c36748144531250130321ec593cb5a5c"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-foreign-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "10b93299a4f24cc155b3afe4e780fb1bdaf9537a"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347858",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "svm-sources",
+      "purl": "pkg:maven/org.graalvm.nativeimage/svm@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c5ef3cbcdfbc1537150a7a922d5ebf83"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "263ce6b470b0910ed611e6af71b561ff9ac271fb"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2494baeaf0ca398f893e1184563aeddef9f9d37f7cb5b41fbb7637ddbec4c7b4"
+        }
+      ],
+      "bom-ref": "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/svm-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "263ce6b470b0910ed611e6af71b561ff9ac271fb"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347857",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "systemd",
+      "purl": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=4bc16f8c8e456bba&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=d1c980b4175dd44a&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "systemd-pam",
+      "purl": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=368cb220a0e33613&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "version": "239-82.el8_10.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e977df4f004e814f699165f7988b6c1f0203c1ef",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3382271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#e977df4f004e814f699165f7988b6c1f0203c1ef",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tar",
+      "purl": "pkg:rpm/redhat/tar@1.30-9.el8?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tar@1.30-9.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=ed275a36c3211937&upstream=tar-1.30-9.el8.src.rpm",
+      "version": "2:1.30-9.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c4fcab8e46b3b03227ec1598aaafd71a0486d42f",
+            "url": "git://pkgs.devel.redhat.com/rpms/tar#c4fcab8e46b3b03227ec1598aaafd71a0486d42f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2373740",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/tar#c4fcab8e46b3b03227ec1598aaafd71a0486d42f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tpm2-tss",
+      "purl": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=b4f3e8d3fae5e8ef&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+      "version": "2.3.2-6.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8fdc15508953c0878fe75d6e399ceff961b8164d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tpm2-tss#8fdc15508953c0878fe75d6e399ceff961b8164d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2795188",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tpm2-tss#8fdc15508953c0878fe75d6e399ceff961b8164d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "truffle-compiler",
+      "purl": "pkg:maven/org.graalvm.truffle/truffle-compiler@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "c0cf8949a60834b8fee592bb321a7580"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "0b75c426d6a52ab0df449f9f3914be30dfcfe693"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d1c22f68739a08492f05beb8a61fa55d179e3c4f267553badef030fd69947748"
+        }
+      ],
+      "bom-ref": "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "0b75c426d6a52ab0df449f9f3914be30dfcfe693"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347901",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "truffle-compiler-sources",
+      "purl": "pkg:maven/org.graalvm.truffle/truffle-compiler@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "5d4ba41bde228284acdf9702fce45612"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "c3742acfd47df34119a64db1797b8503d56caa39"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "1e4809b741c57238165d71b98661d795a9254a13bb51e96f5dcc5fd58e589ba9"
+        }
+      ],
+      "bom-ref": "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/truffle-compiler-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "c3742acfd47df34119a64db1797b8503d56caa39"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347897",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "ttmkfdir",
+      "purl": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=aarch64&distro=rhel-8.10&package-id=f4fe390f647ec4fc&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+      "version": "3.0.9-54.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb",
+            "url": "git://pkgs.devel.redhat.com/rpms/ttmkfdir#3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748474",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ttmkfdir#3be6f16ab8c44cb145aff0c37d40c7cbdf7f9beb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+      "version": "2025a-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "524d097142d6cf1bd9c98bf1e59817f32314fdac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3480271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata-java",
+      "purl": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+      "version": "2025a-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "524d097142d6cf1bd9c98bf1e59817f32314fdac",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3480271",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#524d097142d6cf1bd9c98bf1e59817f32314fdac",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "unzip",
+      "purl": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ff9f8c1cfaa30998&upstream=unzip-6.0-47.el8_10.src.rpm",
+      "version": "6.0-47.el8_10",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ca31be59522450f29f7eed5f32cc972130258c15",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#ca31be59522450f29f7eed5f32cc972130258c15"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3354512",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/unzip#ca31be59522450f29f7eed5f32cc972130258c15",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "usermode",
+      "purl": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=aarch64&distro=rhel-8.10&package-id=6aa56f9dac275080&upstream=usermode-1.113-2.el8.src.rpm",
+      "version": "1.113-2.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "f1102e65b3ae5d34421050b958dbe85c1bc21988",
+            "url": "git://pkgs.devel.redhat.com/rpms/usermode#f1102e65b3ae5d34421050b958dbe85c1bc21988"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1683221",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/usermode#f1102e65b3ae5d34421050b958dbe85c1bc21988",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "util-linux",
+      "purl": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=3159a38905502c6c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "version": "2.32.1-46.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2895941",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#0aa41c2c341e25a7c7f45d7df81cfb5c78f41520",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "vim-minimal",
+      "purl": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=aarch64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=278bd89e6fb3bee6&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+      "version": "2:8.0.1763-19.el8_6.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "Vim and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "20a47258a891a63a9178afb9d69954e4ff123df3",
+            "url": "git://pkgs.devel.redhat.com/rpms/vim#20a47258a891a63a9178afb9d69954e4ff123df3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2049552",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/vim#20a47258a891a63a9178afb9d69954e4ff123df3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "virt-what",
+      "purl": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=aarch64&distro=rhel-8.10&package-id=df8ed92798abe304&upstream=virt-what-1.25-4.el8.src.rpm",
+      "version": "1.25-4.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c",
+            "url": "git://pkgs.devel.redhat.com/rpms/virt-what#5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2574067",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/virt-what#5ae52eb3372d7eb3c4b782f7ad384d1bbee9e10c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "purl": "pkg:rpm/redhat/which@2.21-20.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/which@2.21-20.el8?arch=aarch64&distro=rhel-8.10&package-id=8bfe881f7e7b316d&upstream=which-2.21-20.el8.src.rpm",
+      "version": "2.21-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "66aa787e1516e66d79a4d107e3c0441f92e91f59",
+            "url": "git://pkgs.devel.redhat.com/rpms/which#66aa787e1516e66d79a4d107e3c0441f92e91f59"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2428391",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/which#66aa787e1516e66d79a4d107e3c0441f92e91f59",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "word",
+      "purl": "pkg:maven/org.graalvm.sdk/word@23.1.6.0-1-redhat-00001?type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "decb3a02e4f637071e7211ec253c68ae"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "605a0780c64fe2a300cff38c56a2c0cdf801087c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ae53c3f185a3627f0b495cfb11217fad96ea8528ce7f1cdcd463d31605432c8d"
+        }
+      ],
+      "bom-ref": "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/word.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/word.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "605a0780c64fe2a300cff38c56a2c0cdf801087c"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347854",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "word-sources",
+      "purl": "pkg:maven/org.graalvm.sdk/word@23.1.6.0-1-redhat-00001?classifier=sources&type=jar",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "MD5",
+          "content": "356e5fd6981925e983c6bf14997400d7"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9471ee87dbb838c92b85a7c687cfc6d6a58b94ef"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c1bddbb237b9ab1f0c358722e3f398b34324e496979b9654b1db364878660819"
+        }
+      ],
+      "bom-ref": "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+      "version": "23.1.6.0-1-redhat-00001",
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "31fbd201983ee2ff99986ee3b9e7e2559bd153bc",
+            "url": "https://gitlab.cee.redhat.com/mandrel/mandrel.git#23.1.6.0-1-redhat-00001"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "java"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "java-archive"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/usr/share/java/quarkus-mandrel-java/word-sources.jar"
+        },
+        {
+          "name": "sbomer:metadata:virtualPath",
+          "value": "/usr/share/java/quarkus-mandrel-java/word-sources.jar"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "9471ee87dbb838c92b85a7c687cfc6d6a58b94ef"
+            }
+          ]
+        },
+        {
+          "url": "https://maven.repository.redhat.com/ga/",
+          "type": "distribution"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/artifacts/13347902",
+          "type": "build-system",
+          "comment": "pnc-artifact-id"
+        },
+        {
+          "url": "https://orch.pnc.engineering.redhat.com/pnc-rest/v2/builds/BFGUXXROUKYAA",
+          "type": "build-system",
+          "comment": "pnc-build-id"
+        },
+        {
+          "url": "quay.io/rh-newcastle/builder-rhel-8-j21.0.6-7-mx6.46.1-mvn3.9.6:1.0.0",
+          "type": "build-meta",
+          "comment": "pnc-environment-image"
+        }
+      ]
+    },
+    {
+      "name": "xkeyboard-config",
+      "purl": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+      "version": "2.28-1.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c4e51af72d9e6c77269af9b2008f35dd6628277b",
+            "url": "git://pkgs.devel.redhat.com/rpms/xkeyboard-config#c4e51af72d9e6c77269af9b2008f35dd6628277b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1000732",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xkeyboard-config#c4e51af72d9e6c77269af9b2008f35dd6628277b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xorg-x11-font-utils",
+      "purl": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=aarch64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=b690bb6c551e092b&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+      "version": "1:7.5-41.el8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "459ef32286e6d3c633ecb31f33f2d277d63410ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-font-utils#459ef32286e6d3c633ecb31f33f2d277d63410ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1611879",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-font-utils#459ef32286e6d3c633ecb31f33f2d277d63410ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xorg-x11-fonts-Type1",
+      "purl": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+      "version": "7.5-19.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT and Lucida and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "85df1df15c526b6ec63c8d8f233f1eef5b51d3ed",
+            "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-fonts#85df1df15c526b6ec63c8d8f233f1eef5b51d3ed"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=748589",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xorg-x11-fonts#85df1df15c526b6ec63c8d8f233f1eef5b51d3ed",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=aarch64&distro=rhel-8.10&package-id=09b524062e30517a&upstream=xz-5.2.4-4.el8_6.src.rpm",
+      "version": "5.2.4-4.el8_6",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "361386e5dd2092974b32ced26b6ce68aba1913f8",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#361386e5dd2092974b32ced26b6ce68aba1913f8"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032511",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#361386e5dd2092974b32ced26b6ce68aba1913f8",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "yum",
+      "purl": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "version": "4.7.0-20.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2726408",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#54457bbf8a3bf87e7ede78299bf8a46fa35e4a1f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=f7e9ed0da4bb72af&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "version": "1.2.11-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2508538",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib-devel",
+      "purl": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=aarch64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=a7258f3c94d69023&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "version": "1.2.11-25.el8",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/Packages"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2508538",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#5fb24ceb2975f8d9ae166341de9dc9599b8ff154",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "b2d5dcab2ab572d7",
+      "dependsOn": [
+        "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+        "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=a7917c72826610a9&upstream=acl-2.2.53-3.el8.src.rpm",
+        "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+        "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+        "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=aarch64&distro=rhel-8.10&package-id=d5dada97d73f071a&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+        "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f3afbc2622bf9a47&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4233c2f8efe4e224&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9bc23f86b89ffd1e&upstream=atk-2.28.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7523ddbf31d32fd5&upstream=audit-3.1.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=06ca8a53d1cc249e&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+        "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+        "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8dca9ae7861a5d31&upstream=bash-4.4.20-5.el8.src.rpm",
+        "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=aarch64&distro=rhel-8.10&package-id=357cf8a75af7239c&upstream=binutils-2.30-125.el8_10.src.rpm",
+        "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=aarch64&distro=rhel-8.10&package-id=36c3ab5bddd9f1a3&upstream=brotli-1.0.6-3.el8.src.rpm",
+        "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1f31b47b9494d3cb&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+        "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d3d53396b670f750&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+        "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=398645343056b831&upstream=cairo-1.15.12-6.el8.src.rpm",
+        "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=f0a2d94f7a32ee2b&upstream=cairo-1.15.12-6.el8.src.rpm",
+        "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d9fc13bf2afaafe2&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+        "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+        "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+        "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5ec10e2b6c6075b1&upstream=colord-1.4.2-1.el8.src.rpm",
+        "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+        "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+        "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+        "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=aarch64&distro=rhel-8.10&package-id=1539837d2471018e&upstream=coreutils-8.30-15.el8.src.rpm",
+        "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=caa963f8079ff764&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=71b432d3c9a36835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+        "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=25517b5ff2550b18&upstream=cracklib-2.9.6-15.el8.src.rpm",
+        "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+        "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+        "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=aarch64&distro=rhel-8.10&package-id=312286ce82a76c5e&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+        "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=937da8bd05964a01&upstream=cups-2.2.6-62.el8_10.src.rpm",
+        "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7642b1c80cb7a881&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=aarch64&distro=rhel-8.10&package-id=ee9fc9e06878cf18&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+        "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=416bf5a232fc918a&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6c36a0a0a6da83ac&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=aarch64&distro=rhel-8.10&package-id=1ea0d23cbf2b48a3&upstream=dbus-glib-0.110-2.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7c9a1c226a677c28&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7909e99adecf0e0d&upstream=dbus-1.12.8-26.el8.src.rpm",
+        "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=aarch64&distro=rhel-8.10&package-id=557caf7d0d4b3d91&upstream=dconf-0.28.0-4.el8.src.rpm",
+        "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+        "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+        "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b4e8dd7f72ca970a&upstream=lvm2-2.03.14-14.el8.src.rpm",
+        "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b55e2c322e77f3bd&upstream=lvm2-2.03.14-14.el8.src.rpm",
+        "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=2439b3294fa7d3cb&upstream=dmidecode-3.5-1.el8.src.rpm",
+        "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7bad0774a686c567&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=2dba7c7dd2b6a358&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=34a7605a88bd6b7e&upstream=elfutils-0.190-2.el8.src.rpm",
+        "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5ea6ff40602a8457&upstream=expat-2.2.5-16.el8_10.src.rpm",
+        "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=aarch64&distro=rhel-8.10&package-id=6afff6bb9732e06d&upstream=file-5.33-26.el8.src.rpm",
+        "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=aarch64&distro=rhel-8.10&package-id=346ab4ee189eb6a5&upstream=filesystem-3.8-6.el8.src.rpm",
+        "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=f58a85f97aa1c211&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=03111bf8e0b4a329&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+        "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+        "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=03eb320bcf25d556&upstream=freetype-2.9.1-9.el8.src.rpm",
+        "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=54313f0a53ced35f&upstream=freetype-2.9.1-9.el8.src.rpm",
+        "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=aarch64&distro=rhel-8.10&package-id=8bc6eeb43471fec4&upstream=fribidi-1.0.4-9.el8.src.rpm",
+        "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d81ed4895e302f1f&upstream=gawk-4.2.1-4.el8.src.rpm",
+        "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b799b76678b8854&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7dce2b0519a3160b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=aarch64&distro=rhel-8.10&package-id=92529bc1ca6eba4e&upstream=gdb-8.2-20.el8.src.rpm",
+        "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6a4e5ba47778a597&upstream=gdbm-1.18-2.el8.src.rpm",
+        "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=8002d63f7648f7e3&upstream=gdbm-1.18-2.el8.src.rpm",
+        "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e518ee39ae8eae1e&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=131cc75f16f084ac&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=aarch64&distro=rhel-8.10&package-id=26067cb38279ca47&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+        "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ed2d632e2160f1a3&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+        "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=7f13f1b80f7976ee&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=3e03d903fd884090&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=95e14bede372995c&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=844597ed5cee4103&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=49ecf57c502bbd37&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=9dcc1af340590fef&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+        "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=afd99c8be86b75c7&upstream=gmp-6.1.2-11.el8.src.rpm",
+        "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=3225fc9cf5a4a100&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+        "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=aarch64&distro=rhel-8.10&package-id=c68e2e13c86ee2b5&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+        "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=eb56ef0cc23ffb3c&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+        "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=c896e2652a3c6566&upstream=gpgme-1.13.1-12.el8.src.rpm",
+        "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+        "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+        "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=aarch64&distro=rhel-8.10&package-id=fea0c5371ec8a84b&upstream=graphite2-1.3.10-10.el8.src.rpm",
+        "pkg:rpm/redhat/grep@3.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=32e755f3d822d08b&upstream=grep-3.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=aarch64&distro=rhel-8.10&package-id=95356035cafc7374&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+        "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=2bb2cfcbf653e8aa&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c684c884397ed31a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=aarch64&distro=rhel-8.10&package-id=a2dc59575b8c7aa0&upstream=gzip-1.9-13.el8_5.src.rpm",
+        "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ded3edd0418bf4e6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+        "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+        "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=aarch64&distro=rhel-8.10&package-id=da527f08de208fb5&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+        "pkg:rpm/redhat/info@6.5-7.el8?arch=aarch64&distro=rhel-8.10&package-id=28e3049964db8aa8&upstream=texinfo-6.5-7.el8.src.rpm",
+        "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=6d388e5321da4719&upstream=isl-0.16.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=a2a242cd24594853&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=04a7eebb68f41981&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=143aa9bdff3f3006&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=792c5489088f88f4&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=c3f1c48159e68929&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=4cb76261f61797f0&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+        "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+        "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=aarch64&distro=rhel-8.10&package-id=a3af83ca4128b274&upstream=jbigkit-2.1-14.el8.src.rpm",
+        "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=a17644094896e7e9",
+        "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=310651df6a321631&upstream=json-c-0.13.1-3.el8.src.rpm",
+        "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9fa05295c0bef29e&upstream=json-glib-1.4.4-1.el8.src.rpm",
+        "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+        "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+        "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=aarch64&distro=rhel-8.10&package-id=b0c79f4a399c4534&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+        "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=aarch64&distro=rhel-8.10&package-id=06362f3f4f15eaa6&upstream=keyutils-1.5.10-9.el8.src.rpm",
+        "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=aarch64&distro=rhel-8.10&package-id=72b84a74877d2816&upstream=kmod-25-20.el8.src.rpm",
+        "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c6c83e80d0d08980&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+        "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+        "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=aarch64&distro=rhel-8.10&package-id=9ecf73e25e8d8d57&upstream=lcms2-2.9-2.el8.src.rpm",
+        "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ae4b374f69775e20&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=80d20e5c5c3a91c7&upstream=libXau-1.0.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=533f1ee8546d8a20&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+        "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=aarch64&distro=rhel-8.10&package-id=806bc00cec3c7a10&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+        "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=1459c8808ab02a53&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+        "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4944c89b44fc2a09&upstream=libXext-1.3.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=f263842319069d86&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+        "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=aarch64&distro=rhel-8.10&package-id=dfd465c8f0ce1eb0&upstream=libXft-2.3.3-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=aarch64&distro=rhel-8.10&package-id=82d20a689d5e8ca6&upstream=libXi-1.7.10-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44225303775ea551&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=15db644a30c76424&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=aarch64&distro=rhel-8.10&package-id=2622b49eaaf4c1db&upstream=libXrender-0.9.10-7.el8.src.rpm",
+        "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=3e3c5ad2962a85d9&upstream=libXtst-1.2.3-7.el8.src.rpm",
+        "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=9d27b98fe63ca3cd&upstream=acl-2.2.53-3.el8.src.rpm",
+        "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=f7634661bd463385&upstream=libarchive-3.3.3-5.el8.src.rpm",
+        "pkg:rpm/redhat/libasan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=564c33037dacb889&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=1719abfe14071591&upstream=libassuan-2.5.1-3.el8.src.rpm",
+        "pkg:rpm/redhat/libatomic@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5fbe3e4bf494d51b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=aarch64&distro=rhel-8.10&package-id=d3409f4e6605d5b3&upstream=attr-2.4.48-3.el8.src.rpm",
+        "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=b646f22ca3348666&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=aarch64&distro=rhel-8.10&package-id=df47f6b7146547f5&upstream=libcap-2.48-6.el8_9.src.rpm",
+        "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e3cd1e52de35fc54&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+        "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8b389f14c0a79044&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+        "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44d5ca3b8ff1766a&upstream=libcomps-0.1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7fb4d069cf9c95ea&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=aarch64&distro=rhel-8.10&package-id=c4c7e4b3981d0cf9&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+        "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=a4bfbcf6f3d5862d&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+        "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=2933aca3c206dd07&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+        "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=112492897e160bc3&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=aarch64&distro=rhel-8.10&package-id=6c53c63bbf11aba5&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+        "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=df0e828929783e77&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libffi@3.1-24.el8?arch=aarch64&distro=rhel-8.10&package-id=5b6bad9d2758a421&upstream=libffi-3.1-24.el8.src.rpm",
+        "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=aarch64&distro=rhel-8.10&package-id=a097a18165dd8f25&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+        "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8f41c8c3ebe3564a&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=aarch64&distro=rhel-8.10&package-id=a9661a521abcf435&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+        "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c47afa9dbb1716c7&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=aarch64&distro=rhel-8.10&package-id=8b91a1557a32d7b4&upstream=libgpg-error-1.31-1.el8.src.rpm",
+        "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5d88f0893502fb4f&upstream=libgusb-0.3.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e5b83aa2b874524b&upstream=libidn2-2.2.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=aarch64&distro=rhel-8.10&package-id=7e3e9be87e629c89&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+        "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=aarch64&distro=rhel-8.10&package-id=b6e8357e7e1b8c14&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+        "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=aarch64&distro=rhel-8.10&package-id=0fcc2edf750b9023&upstream=libmodman-2.0.1-17.el8.src.rpm",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5a20854f17566631&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=f90aaec48b37e8f0&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=aarch64&distro=rhel-8.10&package-id=a07abfdc3a969678&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+        "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=58a27f2921004797&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+        "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=26fea9dd5e53dd90&upstream=libnl3-3.7.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=aarch64&distro=rhel-8.10&package-id=b359853f9043e5e1&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+        "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=a437d21cd0275150&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=e2255200ffe21353&upstream=libpng-1.6.34-5.el8.src.rpm",
+        "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=a692f7f04c49ba27&upstream=libpng-1.6.34-5.el8.src.rpm",
+        "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8d90fd9fe1e9b528&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+        "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=e0a9a0a10b80450f&upstream=libpsl-0.20.2-6.el8.src.rpm",
+        "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=aarch64&distro=rhel-8.10&package-id=325ab1835d1c6d46&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+        "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+        "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+        "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=7846f7a24b808647&upstream=librepo-1.14.2-5.el8.src.rpm",
+        "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=aarch64&distro=rhel-8.10&package-id=6ca06be0281cde55&upstream=libreport-2.9.5-15.el8.src.rpm",
+        "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=4d2f9eaf4eac1d2b&upstream=librhsm-0.0.3-5.el8.src.rpm",
+        "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=183140ebe5efae19&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1dcab03ec8d5a657&upstream=libselinux-2.9-9.el8_10.src.rpm",
+        "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=aarch64&distro=rhel-8.10&package-id=adbe6cf578398b6c&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+        "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=14a7d099f9556a9a&upstream=libsepol-2.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=aarch64&distro=rhel-8.10&package-id=91079b2774b8b040&upstream=libsigsegv-2.11-5.el8.src.rpm",
+        "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=e60e475fd320494f&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=aarch64&distro=rhel-8.10&package-id=872a30e171b05c4a&upstream=libsolv-0.7.20-6.el8.src.rpm",
+        "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1b02aca03537bb7a&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+        "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=ab82e216500e0485&upstream=libssh-0.9.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e971c74752b284e8&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d547be5b6d90f20c&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=aarch64&distro=rhel-8.10&package-id=fe46eeefc65cc0ab&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+        "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=aarch64&distro=rhel-8.10&package-id=de48710f0e2c7520&upstream=libthai-0.1.27-2.el8.src.rpm",
+        "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5cbce553517738e9&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+        "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c05d1d0844912efe&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+        "pkg:rpm/redhat/libubsan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=eee6fc3ea6845423&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+        "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=ff6a6a152a60cd30&upstream=libunistring-0.9.9-3.el8.src.rpm",
+        "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=aarch64&distro=rhel-8.10&package-id=97ea5d360e069ab2&upstream=libusbx-1.0.23-4.el8.src.rpm",
+        "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=aarch64&distro=rhel-8.10&package-id=685367a93f076d65&upstream=libuser-0.62-26.el8_10.src.rpm",
+        "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=f8fd78979cb56b53&upstream=libutempter-1.1.6-14.el8.src.rpm",
+        "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=827034366e893e61&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=aarch64&distro=rhel-8.10&package-id=0915d8364816bf23&upstream=libverto-0.3.2-2.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d4f9c25c8368ffc0&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7c63ae3d9327dfc9&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=3857c70756c26179&upstream=wayland-1.21.0-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=66014f616ce4b606&upstream=libxcb-1.13.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3a14124d7f3621bc&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=339e20c0716cc640&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=2a174bf5209cf6e2&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+        "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=aarch64&distro=rhel-8.10&package-id=116d6f5d9908ee8e&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+        "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=aarch64&distro=rhel-8.10&package-id=607c59ebfbcc98b4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+        "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7a1760d46e6068b4&upstream=zstd-1.4.4-1.el8.src.rpm",
+        "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=aarch64&distro=rhel-8.10&package-id=3698d052477430fc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+        "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=b0c8afe45df6f5be&upstream=lua-5.3.4-12.el8.src.rpm",
+        "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6d18d92559bad86c&upstream=lua-5.3.4-12.el8.src.rpm",
+        "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=aarch64&distro=rhel-8.10&package-id=5f623653b82e2295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+        "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b39be4aa3230f5fc&upstream=mpfr-3.1.6-1.el8.src.rpm",
+        "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+        "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+        "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+        "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+        "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+        "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=aarch64&distro=rhel-8.10&package-id=d5d54f710fc30c6c&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+        "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=aarch64&distro=rhel-8.10&package-id=85f82b06d08c07da&upstream=nettle-3.4.1-7.el8.src.rpm",
+        "pkg:rpm/redhat/npth@1.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=6e32855431e0b2f1&upstream=npth-1.5-4.el8.src.rpm",
+        "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f49c22ca630d6fac&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a1b42013319200fc&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f35d76f713c9d5de&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=630795f4ee0f59ae&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=414018215681a712&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a6c23e9089421845&upstream=nss-3.101.0-11.el8_8.src.rpm",
+        "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+        "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+        "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e3a7f8b669b15c6e&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+        "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=19322cfbb726e69d&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+        "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=8ab00611a5262639&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+        "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=bef8eded2f067ea1&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+        "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=aarch64&distro=rhel-8.10&package-id=328b8af675ba36d1&upstream=pam-1.3.1-36.el8_10.src.rpm",
+        "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=aarch64&distro=rhel-8.10&package-id=3f02b6b82bebe2bb&upstream=pango-1.42.4-8.el8.src.rpm",
+        "pkg:rpm/redhat/passwd@0.80-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d32eb1b1193179b2&upstream=passwd-0.80-4.el8.src.rpm",
+        "pkg:rpm/redhat/pcre@8.42-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3e4a953d06b3e762&upstream=pcre-8.42-6.el8.src.rpm",
+        "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=0efed7b24272dfb6&upstream=pcre2-10.32-3.el8_6.src.rpm",
+        "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=aarch64&distro=rhel-8.10&package-id=3d9eb892a2be9298&upstream=pixman-0.38.4-4.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=96aa135add7867ca&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b061dd442c817159&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+        "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=04040e71b6a01e44&upstream=python3-3.6.8-69.el8_10.src.rpm",
+        "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+        "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+        "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+        "pkg:rpm/redhat/popt@1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=db3651f8dfe4fe78&upstream=popt-1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+        "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=fa3bdd3c94948edf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=aarch64&distro=rhel-8.10&package-id=7641f38d8fdd67b0&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+        "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+        "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=aarch64&distro=rhel-8.10&package-id=5934b23038107776&upstream=python-ethtool-0.14-5.el8.src.rpm",
+        "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=aarch64&distro=rhel-8.10&package-id=fe4447ebb9031347&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+        "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6664419428cfad79&upstream=gpgme-1.13.1-12.el8.src.rpm",
+        "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=0a805fdf275ab160&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+        "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f0aa16ee3d997f13&upstream=libcomps-0.1.18-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b64bc837fa3b3b7&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=2bbd773b962f3af8&upstream=librepo-1.14.2-5.el8.src.rpm",
+        "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=dc6170657118ed50&upstream=python3-3.6.8-69.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+        "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+        "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c86eb92ca7a45d5f&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+        "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+        "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=288586619e04710e&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f38d22810e2efbb0&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=aarch64&distro=rhel-8.10&package-id=bc2f0e1e5e72128d&upstream=python-systemd-234-8.el8.src.rpm",
+        "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=aarch64&distro=rhel-8.10&package-id=6e3e79ac0fd369d4&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+        "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+        "pkg:rpm/redhat/readline@7.0-10.el8?arch=aarch64&distro=rhel-8.10&package-id=bde5d37d5ddc9ec3&upstream=readline-7.0-10.el8.src.rpm",
+        "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=aarch64&distro=rhel-8.10&package-id=6abfcad7344c4852&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+        "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=aarch64&distro=rhel-8.10&package-id=eb4ecd147aa27fcf&upstream=rest-0.8.1-2.el8.src.rpm",
+        "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+        "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=cf2bd2d917d5d6ae&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ba960029a8447681&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8ddd5df4d1b6e342&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+        "pkg:rpm/redhat/sed@4.5-5.el8?arch=aarch64&distro=rhel-8.10&package-id=e9a6ef8cd84ecd36&upstream=sed-4.5-5.el8.src.rpm",
+        "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+        "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=07ad7309f6757172&upstream=shadow-utils-4.6-22.el8.src.rpm",
+        "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ed24a806ed7a13d9&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+        "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=aarch64&distro=rhel-8.10&package-id=ce027089a651fb5f&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+        "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=479b0650a812678a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+        "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+        "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+        "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+        "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+        "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+        "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+        "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+        "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+        "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+        "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+        "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+        "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+        "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+        "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=4bc16f8c8e456bba&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=d1c980b4175dd44a&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=368cb220a0e33613&upstream=systemd-239-82.el8_10.3.src.rpm",
+        "pkg:rpm/redhat/tar@1.30-9.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=ed275a36c3211937&upstream=tar-1.30-9.el8.src.rpm",
+        "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=b4f3e8d3fae5e8ef&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+        "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+        "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+        "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=aarch64&distro=rhel-8.10&package-id=f4fe390f647ec4fc&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+        "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+        "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+        "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ff9f8c1cfaa30998&upstream=unzip-6.0-47.el8_10.src.rpm",
+        "pkg:rpm/redhat/usermode@1.113-2.el8?arch=aarch64&distro=rhel-8.10&package-id=6aa56f9dac275080&upstream=usermode-1.113-2.el8.src.rpm",
+        "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=3159a38905502c6c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+        "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=278bd89e6fb3bee6&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+        "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=aarch64&distro=rhel-8.10&package-id=df8ed92798abe304&upstream=virt-what-1.25-4.el8.src.rpm",
+        "pkg:rpm/redhat/which@2.21-20.el8?arch=aarch64&distro=rhel-8.10&package-id=8bfe881f7e7b316d&upstream=which-2.21-20.el8.src.rpm",
+        "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+        "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+        "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+        "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=b690bb6c551e092b&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+        "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+        "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=aarch64&distro=rhel-8.10&package-id=09b524062e30517a&upstream=xz-5.2.4-4.el8_6.src.rpm",
+        "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+        "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=f7e9ed0da4bb72af&upstream=zlib-1.2.11-25.el8.src.rpm",
+        "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=a7258f3c94d69023&upstream=zlib-1.2.11-25.el8.src.rpm"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=a7917c72826610a9&upstream=acl-2.2.53-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/adwaita-cursor-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=5d3ca07c88861a4f&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/adwaita-icon-theme@3.28.0-3.el8?arch=noarch&distro=rhel-8.10&package-id=1c8a36f4ad660ae4&upstream=adwaita-icon-theme-3.28.0-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/alsa-lib@1.2.10-2.el8?arch=aarch64&distro=rhel-8.10&package-id=d5dada97d73f071a&upstream=alsa-lib-1.2.10-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/at-spi2-atk@2.26.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f3afbc2622bf9a47&upstream=at-spi2-atk-2.26.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/at-spi2-core@2.28.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4233c2f8efe4e224&upstream=at-spi2-core-2.28.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/atk@2.28.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9bc23f86b89ffd1e&upstream=atk-2.28.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7523ddbf31d32fd5&upstream=audit-3.1.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/avahi-libs@0.7-27.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=06ca8a53d1cc249e&upstream=avahi-0.7-27.el8_10.1.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=rhel-8.10&package-id=01de6e846ac46933&upstream=basesystem-11-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@4.4.20-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8dca9ae7861a5d31&upstream=bash-4.4.20-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/binutils@2.30-125.el8_10?arch=aarch64&distro=rhel-8.10&package-id=357cf8a75af7239c&upstream=binutils-2.30-125.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/brotli@1.0.6-3.el8?arch=aarch64&distro=rhel-8.10&package-id=36c3ab5bddd9f1a3&upstream=brotli-1.0.6-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-devel@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1f31b47b9494d3cb&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.6-28.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d3d53396b670f750&upstream=bzip2-1.0.6-28.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-80.0.el8_10?arch=noarch&distro=rhel-8.10&package-id=97d4c77a9470921b&upstream=ca-certificates-2024.2.69_v8.0.303-80.0.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cairo@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=398645343056b831&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cairo-gobject@1.15.12-6.el8?arch=aarch64&distro=rhel-8.10&package-id=f0a2d94f7a32ee2b&upstream=cairo-1.15.12-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/chkconfig@1.19.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d9fc13bf2afaafe2&upstream=chkconfig-1.19.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/collections/collections@23.1.6.0-1-redhat-00001?package-id=7341ff8a7c9f06b4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/collections-sources/collections-sources@23.1.6.0-1-redhat-00001?package-id=f83569129973c4b3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/colord-libs@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5ec10e2b6c6075b1&upstream=colord-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler/compiler@23.1.6.0-1-redhat-00001?package-id=eca0222da19da374",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/compiler-sources/compiler-sources@23.1.6.0-1-redhat-00001?package-id=5a3b3f268a3f3de2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/copy-jdk-configs@4.0-2.el8?arch=noarch&distro=rhel-8.10&package-id=df9156c54838ec1e&upstream=copy-jdk-configs-4.0-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.30-15.el8?arch=aarch64&distro=rhel-8.10&package-id=1539837d2471018e&upstream=coreutils-8.30-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cpp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=caa963f8079ff764&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=71b432d3c9a36835&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=aarch64&distro=rhel-8.10&package-id=25517b5ff2550b18&upstream=cracklib-2.9.6-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=5479a3f44d600b40&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies-scripts@20230731-1.git3177e06.el8?arch=noarch&distro=rhel-8.10&package-id=79429e78cd469cd2&upstream=crypto-policies-20230731-1.git3177e06.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cryptsetup-libs@2.3.7-7.el8?arch=aarch64&distro=rhel-8.10&package-id=312286ce82a76c5e&upstream=cryptsetup-2.3.7-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cups-libs@2.2.6-62.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=937da8bd05964a01&upstream=cups-2.2.6-62.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7642b1c80cb7a881&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-6.el8_5?arch=aarch64&distro=rhel-8.10&package-id=ee9fc9e06878cf18&upstream=cyrus-sasl-2.1.27-6.el8_5.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=416bf5a232fc918a&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-common@1.12.8-26.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=276ce3e74816389f&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-daemon@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6c36a0a0a6da83ac&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-glib@0.110-2.el8?arch=aarch64&distro=rhel-8.10&package-id=1ea0d23cbf2b48a3&upstream=dbus-glib-0.110-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-libs@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7c9a1c226a677c28&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dbus-tools@1.12.8-26.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=7909e99adecf0e0d&upstream=dbus-1.12.8-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dconf@0.28.0-4.el8?arch=aarch64&distro=rhel-8.10&package-id=557caf7d0d4b3d91&upstream=dconf-0.28.0-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-fonts-common@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=7814ed3944b1e470&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-mono-fonts@2.35-7.el8?arch=noarch&distro=rhel-8.10&package-id=a31ef1073e795330&upstream=dejavu-fonts-2.35-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/device-mapper@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b4e8dd7f72ca970a&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/device-mapper-libs@1.02.181-14.el8?arch=aarch64&distro=rhel-8.10&epoch=8&package-id=b55e2c322e77f3bd&upstream=lvm2-2.03.14-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dmidecode@3.5-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=2439b3294fa7d3cb&upstream=dmidecode-3.5-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=28dc259f8d3de849&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=11d2f13b5477c98f&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-plugin-subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7bad0774a686c567&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-default-yama-scope@0.190-2.el8?arch=noarch&distro=rhel-8.10&package-id=e8e49d82ad089267&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libelf@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=2dba7c7dd2b6a358&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/elfutils-libs@0.190-2.el8?arch=aarch64&distro=rhel-8.10&package-id=34a7605a88bd6b7e&upstream=elfutils-0.190-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/expat@2.2.5-16.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5ea6ff40602a8457&upstream=expat-2.2.5-16.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.33-26.el8?arch=aarch64&distro=rhel-8.10&package-id=6afff6bb9732e06d&upstream=file-5.33-26.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.8-6.el8?arch=aarch64&distro=rhel-8.10&package-id=346ab4ee189eb6a5&upstream=filesystem-3.8-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/findutils@4.6.0-23.el8_10?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=f58a85f97aa1c211&upstream=findutils-4.6.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fontconfig@2.13.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=03111bf8e0b4a329&upstream=fontconfig-2.13.1-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fontpackages-filesystem@1.44-22.el8?arch=noarch&distro=rhel-8.10&package-id=ae4b7808a0c336f2&upstream=fontpackages-1.44-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/freetype@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=03eb320bcf25d556&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/freetype-devel@2.9.1-9.el8?arch=aarch64&distro=rhel-8.10&package-id=54313f0a53ced35f&upstream=freetype-2.9.1-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fribidi@1.0.4-9.el8?arch=aarch64&distro=rhel-8.10&package-id=8bc6eeb43471fec4&upstream=fribidi-1.0.4-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@4.2.1-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d81ed4895e302f1f&upstream=gawk-4.2.1-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b799b76678b8854&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gcc-c%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7dce2b0519a3160b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdb-gdbserver@8.2-20.el8?arch=aarch64&distro=rhel-8.10&package-id=92529bc1ca6eba4e&upstream=gdb-8.2-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=6a4e5ba47778a597&upstream=gdbm-1.18-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.18-2.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=8002d63f7648f7e3&upstream=gdbm-1.18-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdk-pixbuf2@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e518ee39ae8eae1e&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdk-pixbuf2-modules@2.36.12-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=131cc75f16f084ac&upstream=gdk-pixbuf2-2.36.12-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib-networking@2.56.1-1.1.el8?arch=aarch64&distro=rhel-8.10&package-id=26067cb38279ca47&upstream=glib-networking-2.56.1-1.1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.56.4-165.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ed2d632e2160f1a3&upstream=glib2-2.56.4-165.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=7f13f1b80f7976ee&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=3e03d903fd884090&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-devel@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=95e14bede372995c&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-headers@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=844597ed5cee4103&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-langpack-en@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=49ecf57c502bbd37&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.28-251.el8_10.11?arch=aarch64&distro=rhel-8.10&package-id=9dcc1af340590fef&upstream=glibc-2.28-251.el8_10.11.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.1.2-11.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=afd99c8be86b75c7&upstream=gmp-6.1.2-11.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.2.20-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=3225fc9cf5a4a100&upstream=gnupg2-2.2.20-3.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.6.16-8.el8_9.3?arch=aarch64&distro=rhel-8.10&package-id=c68e2e13c86ee2b5&upstream=gnutls-3.6.16-8.el8_9.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.56.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=eb56ef0cc23ffb3c&upstream=gobject-introspection-1.56.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.10&package-id=ba0df8f903e7efba",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b?distro=rhel-8.10&package-id=b19a1359d4b69014",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=c896e2652a3c6566&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/graal-sdk/graal-sdk@23.1.6.0-1-redhat-00001?package-id=b3bb318c8655326d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/graal-sdk-sources/graal-sdk-sources@23.1.6.0-1-redhat-00001?package-id=190265fa5ac883d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/graphite2@1.3.10-10.el8?arch=aarch64&distro=rhel-8.10&package-id=fea0c5371ec8a84b&upstream=graphite2-1.3.10-10.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=32e755f3d822d08b&upstream=grep-3.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gsettings-desktop-schemas@3.32.0-6.el8?arch=aarch64&distro=rhel-8.10&package-id=95356035cafc7374&upstream=gsettings-desktop-schemas-3.32.0-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gtk-update-icon-cache@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=2bb2cfcbf653e8aa&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gtk3@3.22.30-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c684c884397ed31a&upstream=gtk3-3.22.30-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gzip@1.9-13.el8_5?arch=aarch64&distro=rhel-8.10&package-id=a2dc59575b8c7aa0&upstream=gzip-1.9-13.el8_5.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/harfbuzz@1.7.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ded3edd0418bf4e6&upstream=harfbuzz-1.7.5-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/hicolor-icon-theme@0.17-2.el8?arch=noarch&distro=rhel-8.10&package-id=ee33215d8ac6be45&upstream=hicolor-icon-theme-0.17-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ima-evm-utils@1.3.2-12.el8?arch=aarch64&distro=rhel-8.10&package-id=da527f08de208fb5&upstream=ima-evm-utils-1.3.2-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/info@6.5-7.el8?arch=aarch64&distro=rhel-8.10&package-id=28e3049964db8aa8&upstream=texinfo-6.5-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/isl@0.16.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=6d388e5321da4719&upstream=isl-0.16.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jasper-libs@2.0.14-6.el8_10?arch=aarch64&distro=rhel-8.10&package-id=a2a242cd24594853&upstream=jasper-2.0.14-6.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=04a7eebb68f41981&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-devel@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=143aa9bdff3f3006&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-headless@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=792c5489088f88f4&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-src@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=c3f1c48159e68929&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/java-21-openjdk-static-libs@21.0.6.0.7-1.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=4cb76261f61797f0&upstream=java-21-openjdk-21.0.6.0.7-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/javapackages-filesystem@5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6?arch=noarch&distro=rhel-8.10&package-id=b6d4b49434368c0a&upstream=javapackages-tools-5.3.0-1.module%2Bel8%2B2447%2B6f56d9a6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/jbigkit-libs@2.1-14.el8?arch=aarch64&distro=rhel-8.10&package-id=a3af83ca4128b274&upstream=jbigkit-2.1-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jrt-fs/jrt-fs@21.0.6?package-id=a17644094896e7e9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.13.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=310651df6a321631&upstream=json-c-0.13.1-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=9fa05295c0bef29e&upstream=json-glib-1.4.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jvmti-agent-base/jvmti-agent-base@23.1.6.0-1-redhat-00001?package-id=60af06ff29bf6960",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/jvmti-agent-base-sources/jvmti-agent-base-sources@23.1.6.0-1-redhat-00001?package-id=3a900af2ae464923",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kernel-headers@4.18.0-553.40.1.el8_10?arch=aarch64&distro=rhel-8.10&package-id=b0c79f4a399c4534&upstream=kernel-4.18.0-553.40.1.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.5.10-9.el8?arch=aarch64&distro=rhel-8.10&package-id=06362f3f4f15eaa6&upstream=keyutils-1.5.10-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/kmod-libs@25-20.el8?arch=aarch64&distro=rhel-8.10&package-id=72b84a74877d2816&upstream=kmod-25-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.18.2-30.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c6c83e80d0d08980&upstream=krb5-1.18.2-30.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@1.0-12.el8?arch=noarch&distro=rhel-8.10&package-id=c7fb78a8091dd557&upstream=langpacks-1.0-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lcms2@2.9-2.el8?arch=aarch64&distro=rhel-8.10&package-id=9ecf73e25e8d8d57&upstream=lcms2-2.9-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libX11@1.6.8-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ae4b374f69775e20&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libX11-common@1.6.8-9.el8_10?arch=noarch&distro=rhel-8.10&package-id=714b840541a214a5&upstream=libX11-1.6.8-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXau@1.0.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=80d20e5c5c3a91c7&upstream=libXau-1.0.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXcomposite@0.4.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=533f1ee8546d8a20&upstream=libXcomposite-0.4.4-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXcursor@1.1.15-3.el8?arch=aarch64&distro=rhel-8.10&package-id=806bc00cec3c7a10&upstream=libXcursor-1.1.15-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXdamage@1.1.4-14.el8?arch=aarch64&distro=rhel-8.10&package-id=1459c8808ab02a53&upstream=libXdamage-1.1.4-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXext@1.3.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=4944c89b44fc2a09&upstream=libXext-1.3.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXfixes@5.0.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=f263842319069d86&upstream=libXfixes-5.0.3-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXft@2.3.3-1.el8?arch=aarch64&distro=rhel-8.10&package-id=dfd465c8f0ce1eb0&upstream=libXft-2.3.3-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXi@1.7.10-1.el8?arch=aarch64&distro=rhel-8.10&package-id=82d20a689d5e8ca6&upstream=libXi-1.7.10-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXinerama@1.1.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44225303775ea551&upstream=libXinerama-1.1.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXrandr@1.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=15db644a30c76424&upstream=libXrandr-1.5.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXrender@0.9.10-7.el8?arch=aarch64&distro=rhel-8.10&package-id=2622b49eaaf4c1db&upstream=libXrender-0.9.10-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libXtst@1.2.3-7.el8?arch=aarch64&distro=rhel-8.10&package-id=3e3c5ad2962a85d9&upstream=libXtst-1.2.3-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=9d27b98fe63ca3cd&upstream=acl-2.2.53-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.3.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=f7634661bd463385&upstream=libarchive-3.3.3-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libasan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=564c33037dacb889&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.1-3.el8?arch=aarch64&distro=rhel-8.10&package-id=1719abfe14071591&upstream=libassuan-2.5.1-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libatomic@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5fbe3e4bf494d51b&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.4.48-3.el8?arch=aarch64&distro=rhel-8.10&package-id=d3409f4e6605d5b3&upstream=attr-2.4.48-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=b646f22ca3348666&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-6.el8_9?arch=aarch64&distro=rhel-8.10&package-id=df47f6b7146547f5&upstream=libcap-2.48-6.el8_9.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.7.11-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e3cd1e52de35fc54&upstream=libcap-ng-0.7.11-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.45.6-5.el8?arch=aarch64&distro=rhel-8.10&package-id=8b389f14c0a79044&upstream=e2fsprogs-1.45.6-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=44d5ca3b8ff1766a&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl@7.61.1-34.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=7fb4d069cf9c95ea&upstream=curl-7.61.1-34.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdatrie@0.2.9-7.el8?arch=aarch64&distro=rhel-8.10&package-id=c4c7e4b3981d0cf9&upstream=libdatrie-0.2.9-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=a4bfbcf6f3d5862d&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdb-utils@5.3.28-42.el8_4?arch=aarch64&distro=rhel-8.10&package-id=2933aca3c206dd07&upstream=libdb-5.3.28-42.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=112492897e160bc3&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libepoxy@1.5.8-1.el8?arch=aarch64&distro=rhel-8.10&package-id=6c53c63bbf11aba5&upstream=libepoxy-1.5.8-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfdisk@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=df0e828929783e77&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.1-24.el8?arch=aarch64&distro=rhel-8.10&package-id=5b6bad9d2758a421&upstream=libffi-3.1-24.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libfontenc@1.1.3-8.el8?arch=aarch64&distro=rhel-8.10&package-id=a097a18165dd8f25&upstream=libfontenc-1.1.3-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8f41c8c3ebe3564a&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.8.5-7.el8_6?arch=aarch64&distro=rhel-8.10&package-id=a9661a521abcf435&upstream=libgcrypt-1.8.5-7.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgomp@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c47afa9dbb1716c7&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=aarch64&distro=rhel-8.10&package-id=8b91a1557a32d7b4&upstream=libgpg-error-1.31-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgusb@0.3.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5d88f0893502fb4f&upstream=libgusb-0.3.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.2.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=e5b83aa2b874524b&upstream=libidn2-2.2.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libjpeg-turbo@1.5.3-12.el8?arch=aarch64&distro=rhel-8.10&package-id=7e3e9be87e629c89&upstream=libjpeg-turbo-1.5.3-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.3.5-9.el8_7?arch=aarch64&distro=rhel-8.10&package-id=b6e8357e7e1b8c14&upstream=libksba-1.3.5-9.el8_7.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodman@2.0.1-17.el8?arch=aarch64&distro=rhel-8.10&package-id=0fcc2edf750b9023&upstream=libmodman-2.0.1-17.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=5a20854f17566631&upstream=libmodulemd-2.13.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=f90aaec48b37e8f0&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmpc@1.1.0-9.1.el8?arch=aarch64&distro=rhel-8.10&package-id=a07abfdc3a969678&upstream=libmpc-1.1.0-9.1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.33.0-6.el8_10.1?arch=aarch64&distro=rhel-8.10&package-id=58a27f2921004797&upstream=nghttp2-1.33.0-6.el8_10.1.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnl3@3.7.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=26fea9dd5e53dd90&upstream=libnl3-3.7.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnsl2@1.2.0-2.20180605git4a062cf.el8?arch=aarch64&distro=rhel-8.10&package-id=b359853f9043e5e1&upstream=libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=a437d21cd0275150&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpng@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=e2255200ffe21353&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpng-devel@1.6.34-5.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=a692f7f04c49ba27&upstream=libpng-1.6.34-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libproxy@0.4.15-5.5.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8d90fd9fe1e9b528&upstream=libproxy-0.4.15-5.5.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpsl@0.20.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=e0a9a0a10b80450f&upstream=libpsl-0.20.2-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpwquality@1.4.4-6.el8?arch=aarch64&distro=rhel-8.10&package-id=325ab1835d1c6d46&upstream=libpwquality-1.4.4-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/library-support/library-support@23.1.6.0-1-redhat-00001?package-id=aa27735321f47af3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/library-support-sources/library-support-sources@23.1.6.0-1-redhat-00001?package-id=b94fb17c82e310f5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=7846f7a24b808647&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.9.5-15.el8?arch=aarch64&distro=rhel-8.10&package-id=6ca06be0281cde55&upstream=libreport-2.9.5-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-5.el8?arch=aarch64&distro=rhel-8.10&package-id=4d2f9eaf4eac1d2b&upstream=librhsm-0.0.3-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libseccomp@2.5.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=183140ebe5efae19&upstream=libseccomp-2.5.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@2.9-9.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1dcab03ec8d5a657&upstream=libselinux-2.9-9.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@2.9-10.el8_10?arch=aarch64&distro=rhel-8.10&package-id=adbe6cf578398b6c&upstream=libsemanage-2.9-10.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@2.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=14a7d099f9556a9a&upstream=libsepol-2.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.11-5.el8?arch=aarch64&distro=rhel-8.10&package-id=91079b2774b8b040&upstream=libsigsegv-2.11-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=e60e475fd320494f&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.20-6.el8?arch=aarch64&distro=rhel-8.10&package-id=872a30e171b05c4a&upstream=libsolv-0.7.20-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsoup@2.62.3-7.el8_10?arch=aarch64&distro=rhel-8.10&package-id=1b02aca03537bb7a&upstream=libsoup-2.62.3-7.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh@0.9.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=ab82e216500e0485&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libssh-config@0.9.6-14.el8?arch=noarch&distro=rhel-8.10&package-id=fceaaf800266582c&upstream=libssh-0.9.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e971c74752b284e8&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B-devel@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=d547be5b6d90f20c&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.13-4.el8_7?arch=aarch64&distro=rhel-8.10&package-id=fe46eeefc65cc0ab&upstream=libtasn1-4.13-4.el8_7.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libthai@0.1.27-2.el8?arch=aarch64&distro=rhel-8.10&package-id=de48710f0e2c7520&upstream=libthai-0.1.27-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtiff@4.0.9-33.el8_10?arch=aarch64&distro=rhel-8.10&package-id=5cbce553517738e9&upstream=libtiff-4.0.9-33.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtirpc@1.1.4-12.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c05d1d0844912efe&upstream=libtirpc-1.1.4-12.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libubsan@8.5.0-23.el8_10?arch=aarch64&distro=rhel-8.10&package-id=eee6fc3ea6845423&upstream=gcc-8.5.0-23.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.9-3.el8?arch=aarch64&distro=rhel-8.10&package-id=ff6a6a152a60cd30&upstream=libunistring-0.9.9-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.23-4.el8?arch=aarch64&distro=rhel-8.10&package-id=97ea5d360e069ab2&upstream=libusbx-1.0.23-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuser@0.62-26.el8_10?arch=aarch64&distro=rhel-8.10&package-id=685367a93f076d65&upstream=libuser-0.62-26.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libutempter@1.1.6-14.el8?arch=aarch64&distro=rhel-8.10&package-id=f8fd78979cb56b53&upstream=libutempter-1.1.6-14.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=827034366e893e61&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-2.el8?arch=aarch64&distro=rhel-8.10&package-id=0915d8364816bf23&upstream=libverto-0.3.2-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-client@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=d4f9c25c8368ffc0&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-cursor@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7c63ae3d9327dfc9&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libwayland-egl@1.21.0-1.el8?arch=aarch64&distro=rhel-8.10&package-id=3857c70756c26179&upstream=wayland-1.21.0-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcb@1.13.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=66014f616ce4b606&upstream=libxcb-1.13.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3a14124d7f3621bc&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt-devel@4.1.1-6.el8?arch=aarch64&distro=rhel-8.10&package-id=339e20c0716cc640&upstream=libxcrypt-4.1.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxkbcommon@0.9.1-1.el8?arch=aarch64&distro=rhel-8.10&package-id=2a174bf5209cf6e2&upstream=libxkbcommon-0.9.1-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.7-18.el8_10.2?arch=aarch64&distro=rhel-8.10&package-id=116d6f5d9908ee8e&upstream=libxml2-2.9.7-18.el8_10.2.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.1.7-5.el8?arch=aarch64&distro=rhel-8.10&package-id=607c59ebfbcc98b4&upstream=libyaml-0.1.7-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.4.4-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7a1760d46e6068b4&upstream=zstd-1.4.4-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lksctp-tools@1.0.18-3.el8?arch=aarch64&distro=rhel-8.10&package-id=3698d052477430fc&upstream=lksctp-tools-1.0.18-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=b0c8afe45df6f5be&upstream=lua-5.3.4-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.3.4-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6d18d92559bad86c&upstream=lua-5.3.4-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.8.3-3.el8_4?arch=aarch64&distro=rhel-8.10&package-id=5f623653b82e2295&upstream=lz4-1.8.3-3.el8_4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@3.1.6-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b39be4aa3230f5fc&upstream=mpfr-3.1.6-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/native-image-base/native-image-base@23.1.6.0-1-redhat-00001?package-id=a82b76b0f0aff7ef",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/native-image-base-sources/native-image-base-sources@23.1.6.0-1-redhat-00001?package-id=8163f7941cbead52",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/nativeimage/nativeimage@23.1.6.0-1-redhat-00001?package-id=9333858e871d2e86",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/nativeimage-sources/nativeimage-sources@23.1.6.0-1-redhat-00001?package-id=34bcabc3ee397c3a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.1-10.20180224.el8?arch=noarch&distro=rhel-8.10&package-id=051595e1dbf30365&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.1-10.20180224.el8?arch=aarch64&distro=rhel-8.10&package-id=d5d54f710fc30c6c&upstream=ncurses-6.1-10.20180224.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.4.1-7.el8?arch=aarch64&distro=rhel-8.10&package-id=85f82b06d08c07da&upstream=nettle-3.4.1-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.5-4.el8?arch=aarch64&distro=rhel-8.10&package-id=6e32855431e0b2f1&upstream=npth-1.5-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nspr@4.35.0-1.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f49c22ca630d6fac&upstream=nspr-4.35.0-1.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a1b42013319200fc&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=f35d76f713c9d5de&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-softokn-freebl@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=630795f4ee0f59ae&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-sysinit@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=414018215681a712&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nss-util@3.101.0-11.el8_8?arch=aarch64&distro=rhel-8.10&package-id=a6c23e9089421845&upstream=nss-3.101.0-11.el8_8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/objectfile/objectfile@23.1.6.0-1-redhat-00001?package-id=c3d74d24e7cb80ea",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/objectfile-sources/objectfile-sources@23.1.6.0-1-redhat-00001?package-id=6eac3afee526234c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.4.46-20.el8_10?arch=aarch64&distro=rhel-8.10&package-id=e3a7f8b669b15c6e&upstream=openldap-2.4.46-20.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@1.1.1k-14.el8_6?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=19322cfbb726e69d&upstream=openssl-1.1.1k-14.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=8ab00611a5262639&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.23.22-2.el8?arch=aarch64&distro=rhel-8.10&package-id=bef8eded2f067ea1&upstream=p11-kit-0.23.22-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pam@1.3.1-36.el8_10?arch=aarch64&distro=rhel-8.10&package-id=328b8af675ba36d1&upstream=pam-1.3.1-36.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pango@1.42.4-8.el8?arch=aarch64&distro=rhel-8.10&package-id=3f02b6b82bebe2bb&upstream=pango-1.42.4-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/passwd@0.80-4.el8?arch=aarch64&distro=rhel-8.10&package-id=d32eb1b1193179b2&upstream=passwd-0.80-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.42-6.el8?arch=aarch64&distro=rhel-8.10&package-id=3e4a953d06b3e762&upstream=pcre-8.42-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.32-3.el8_6?arch=aarch64&distro=rhel-8.10&package-id=0efed7b24272dfb6&upstream=pcre2-10.32-3.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pixman@0.38.4-4.el8?arch=aarch64&distro=rhel-8.10&package-id=3d9eb892a2be9298&upstream=pixman-0.38.4-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=96aa135add7867ca&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf-m4@1.4.2-1.el8?arch=noarch&distro=rhel-8.10&package-id=aed1e4f44e00251d&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pkgconf-pkg-config@1.4.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=b061dd442c817159&upstream=pkgconf-1.4.2-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/platform-python@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=04040e71b6a01e44&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/platform-python-setuptools@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=477255759430f283&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/pointsto/pointsto@23.1.6.0-1-redhat-00001?package-id=384a9cce7e57d8b0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/pointsto-sources/pointsto-sources@23.1.6.0-1-redhat-00001?package-id=3a011c8cdea09b4c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=db3651f8dfe4fe78&upstream=popt-1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/publicsuffix-list-dafsa@20180723-1.el8?arch=noarch&distro=rhel-8.10&package-id=0601e909ef05e18e&upstream=publicsuffix-list-20180723-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-chardet@3.0.4-7.el8?arch=noarch&distro=rhel-8.10&package-id=06dfbca7c9b0c789&upstream=python-chardet-3.0.4-7.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-cloud-what@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=fa3bdd3c94948edf&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dateutil@2.6.1-6.el8?arch=noarch&distro=rhel-8.10&epoch=1&package-id=8bf187ec2e0875b2&upstream=python-dateutil-2.6.1-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dbus@1.2.4-15.el8?arch=aarch64&distro=rhel-8.10&package-id=7641f38d8fdd67b0&upstream=dbus-python-1.2.4-15.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-decorator@4.2.1-2.el8?arch=noarch&distro=rhel-8.10&package-id=712af2403553184d&upstream=python-decorator-4.2.1-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=b631777c7177f547&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-dnf-plugins-core@4.0.21-25.el8?arch=noarch&distro=rhel-8.10&package-id=034588ec59821a75&upstream=dnf-plugins-core-4.0.21-25.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-ethtool@0.14-5.el8?arch=aarch64&distro=rhel-8.10&package-id=5934b23038107776&upstream=python-ethtool-0.14-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gobject-base@3.28.3-2.el8?arch=aarch64&distro=rhel-8.10&package-id=fe4447ebb9031347&upstream=pygobject3-3.28.3-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-gpg@1.13.1-12.el8?arch=aarch64&distro=rhel-8.10&package-id=6664419428cfad79&upstream=gpgme-1.13.1-12.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-hawkey@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=0a805fdf275ab160&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-idna@2.5-7.el8_10?arch=noarch&distro=rhel-8.10&package-id=b0b70aa88b8a45b8&upstream=python-idna-2.5-7.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-iniparse@0.4-31.el8?arch=noarch&distro=rhel-8.10&package-id=ef0d7eab43c85fb9&upstream=python-iniparse-0.4-31.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-inotify@0.9.6-13.el8?arch=noarch&distro=rhel-8.10&package-id=9c862e4461296cb5&upstream=python-inotify-0.9.6-13.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libcomps@0.1.18-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f0aa16ee3d997f13&upstream=libcomps-0.1.18-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libdnf@0.63.0-21.el8_10?arch=aarch64&distro=rhel-8.10&package-id=7b64bc837fa3b3b7&upstream=libdnf-0.63.0-21.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-librepo@1.14.2-5.el8?arch=aarch64&distro=rhel-8.10&package-id=2bbd773b962f3af8&upstream=librepo-1.14.2-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-libs@3.6.8-69.el8_10?arch=aarch64&distro=rhel-8.10&package-id=dc6170657118ed50&upstream=python3-3.6.8-69.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pip-wheel@9.0.3-24.el8?arch=noarch&distro=rhel-8.10&package-id=1acbf4022563b70c&upstream=python-pip-9.0.3-24.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-pysocks@1.6.8-3.el8?arch=noarch&distro=rhel-8.10&package-id=7f3bd692f19981d6&upstream=python-pysocks-1.6.8-3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-requests@2.20.0-5.el8_10?arch=noarch&distro=rhel-8.10&package-id=0c9f2f4f8d5e9dbe&upstream=python-requests-2.20.0-5.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=c86eb92ca7a45d5f&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-setuptools-wheel@39.2.0-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=e204b8e9a4a7d867&upstream=python-setuptools-39.2.0-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-six@1.11.0-8.el8?arch=noarch&distro=rhel-8.10&package-id=4379c5a57465882b&upstream=python-six-1.11.0-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-subscription-manager-rhsm@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=288586619e04710e&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-syspurpose@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=f38d22810e2efbb0&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-systemd@234-8.el8?arch=aarch64&distro=rhel-8.10&package-id=bc2f0e1e5e72128d&upstream=python-systemd-234-8.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/python3-urllib3@1.24.2-8.el8_10?arch=noarch&distro=rhel-8.10&package-id=42e847040409cc48&upstream=python-urllib3-1.24.2-8.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-231@23.1.6.0_1-3.el8qks?arch=aarch64&distro=rhel-8.10&package-id=6e3e79ac0fd369d4&upstream=quarkus-mandrel-231-23.1.6.0_1-3.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-java@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=311c9470dc191601&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/quarkus-mandrel-java-jdk-21-binding@23.1.6.0_1-3.redhat_00001.1.el8qks?arch=noarch&distro=rhel-8.10&package-id=0e87ec09879e2008&upstream=quarkus-mandrel-java-23.1.6.0_1-3.redhat_00001.1.el8qks.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@7.0-10.el8?arch=aarch64&distro=rhel-8.10&package-id=bde5d37d5ddc9ec3&upstream=readline-7.0-10.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@8.10-0.3.el8?arch=aarch64&distro=rhel-8.10&package-id=6abfcad7344c4852&upstream=redhat-release-8.10-0.3.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rest@0.8.1-2.el8?arch=aarch64&distro=rhel-8.10&package-id=eb4ecd147aa27fcf&upstream=rest-0.8.1-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.10&package-id=7de19836e854eb46&upstream=rootfiles-8.1-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=cf2bd2d917d5d6ae&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-build-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ba960029a8447681&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.14.3-32.el8_10?arch=aarch64&distro=rhel-8.10&package-id=8ddd5df4d1b6e342&upstream=rpm-4.14.3-32.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.5-5.el8?arch=aarch64&distro=rhel-8.10&package-id=e9a6ef8cd84ecd36&upstream=sed-4.5-5.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.12.2-9.el8?arch=noarch&distro=rhel-8.10&package-id=0f25bcc5623fef3a&upstream=setup-2.12.2-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.6-22.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=07ad7309f6757172&upstream=shadow-utils-4.6-22.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shared-mime-info@1.9-4.el8?arch=aarch64&distro=rhel-8.10&package-id=ed24a806ed7a13d9&upstream=shared-mime-info-1.9-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.26.0-19.el8_9?arch=aarch64&distro=rhel-8.10&package-id=ce027089a651fb5f&upstream=sqlite-3.26.0-19.el8_9.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager@1.28.42-1.el8?arch=aarch64&distro=rhel-8.10&package-id=479b0650a812678a&upstream=subscription-manager-1.28.42-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/subscription-manager-rhsm-certificates@20220623-1.el8?arch=noarch&distro=rhel-8.10&package-id=1ce1b4b4e098f69e&upstream=subscription-manager-rhsm-certificates-20220623-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm/svm@23.1.6.0-1-redhat-00001?package-id=332d55349d4811a3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-agent/svm-agent@23.1.6.0-1-redhat-00001?package-id=1c686259be84cfb9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-agent-sources/svm-agent-sources@23.1.6.0-1-redhat-00001?package-id=e231db4f71f15ab8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.oracle.svm.configure.ConfigurationTool/svm-configure@23.1.6.0-1-redhat-00001?package-id=8ce5567d53eefada",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-configure-sources/svm-configure-sources@23.1.6.0-1-redhat-00001?package-id=af4b09375edc66fc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-diagnostics-agent/svm-diagnostics-agent@23.1.6.0-1-redhat-00001?package-id=6759d7486ce6c312",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-diagnostics-agent-sources/svm-diagnostics-agent-sources@23.1.6.0-1-redhat-00001?package-id=9d8d1071fdae5230",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.oracle.svm.driver.NativeImage/svm-driver@23.1.6.0-1-redhat-00001?package-id=20b2941a3c4f76df",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-driver-sources/svm-driver-sources@23.1.6.0-1-redhat-00001?package-id=44f169be225d0424",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-foreign/svm-foreign@23.1.6.0-1-redhat-00001?package-id=ad8ddd97da7eeeb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-foreign-sources/svm-foreign-sources@23.1.6.0-1-redhat-00001?package-id=c4fdca55ba219c75",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/svm-sources/svm-sources@23.1.6.0-1-redhat-00001?package-id=1d8960c5755a55d8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=4bc16f8c8e456bba&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=d1c980b4175dd44a&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-pam@239-82.el8_10.3?arch=aarch64&distro=rhel-8.10&package-id=368cb220a0e33613&upstream=systemd-239-82.el8_10.3.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tar@1.30-9.el8?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=ed275a36c3211937&upstream=tar-1.30-9.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tpm2-tss@2.3.2-6.el8?arch=aarch64&distro=rhel-8.10&package-id=b4f3e8d3fae5e8ef&upstream=tpm2-tss-2.3.2-6.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/truffle-compiler/truffle-compiler@23.1.6.0-1-redhat-00001?package-id=2e607388c850e132",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/truffle-compiler-sources/truffle-compiler-sources@23.1.6.0-1-redhat-00001?package-id=8fec7b9d23a12ac8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ttmkfdir@3.0.9-54.el8?arch=aarch64&distro=rhel-8.10&package-id=f4fe390f647ec4fc&upstream=ttmkfdir-3.0.9-54.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=33badb42e32c5624&upstream=tzdata-2025a-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata-java@2025a-1.el8?arch=noarch&distro=rhel-8.10&package-id=40e390fbb151a65b&upstream=tzdata-2025a-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/unzip@6.0-47.el8_10?arch=aarch64&distro=rhel-8.10&package-id=ff9f8c1cfaa30998&upstream=unzip-6.0-47.el8_10.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/usermode@1.113-2.el8?arch=aarch64&distro=rhel-8.10&package-id=6aa56f9dac275080&upstream=usermode-1.113-2.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/util-linux@2.32.1-46.el8?arch=aarch64&distro=rhel-8.10&package-id=3159a38905502c6c&upstream=util-linux-2.32.1-46.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/vim-minimal@8.0.1763-19.el8_6.4?arch=aarch64&distro=rhel-8.10&epoch=2&package-id=278bd89e6fb3bee6&upstream=vim-8.0.1763-19.el8_6.4.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/virt-what@1.25-4.el8?arch=aarch64&distro=rhel-8.10&package-id=df8ed92798abe304&upstream=virt-what-1.25-4.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/which@2.21-20.el8?arch=aarch64&distro=rhel-8.10&package-id=8bfe881f7e7b316d&upstream=which-2.21-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/word/word@23.1.6.0-1-redhat-00001?package-id=87f565db8a152367",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/word-sources/word-sources@23.1.6.0-1-redhat-00001?package-id=4b6e109ef55c3461",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xkeyboard-config@2.28-1.el8?arch=noarch&distro=rhel-8.10&package-id=88d7a4cd9d402efb&upstream=xkeyboard-config-2.28-1.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xorg-x11-font-utils@7.5-41.el8?arch=aarch64&distro=rhel-8.10&epoch=1&package-id=b690bb6c551e092b&upstream=xorg-x11-font-utils-7.5-41.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xorg-x11-fonts-Type1@7.5-19.el8?arch=noarch&distro=rhel-8.10&package-id=39e89ea72303c209&upstream=xorg-x11-fonts-7.5-19.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.4-4.el8_6?arch=aarch64&distro=rhel-8.10&package-id=09b524062e30517a&upstream=xz-5.2.4-4.el8_6.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/yum@4.7.0-20.el8?arch=noarch&distro=rhel-8.10&package-id=1265181dd0623da4&upstream=dnf-4.7.0-20.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=f7e9ed0da4bb72af&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=a7258f3c94d69023&upstream=zlib-1.2.11-25.el8.src.rpm",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:38200326-3211-458c-8084-f24670a78ce4"
+}

--- a/modules/analysis/src/endpoints/tests/rh_variant.rs
+++ b/modules/analysis/src/endpoints/tests/rh_variant.rs
@@ -209,9 +209,12 @@ async fn resolve_rh_variant_prod_comp_cdx_external_reference_curl(
               "name": "curl",
               "document_id": "urn:uuid:6895f8e0-2bfd-331c-97f9-97369ef1f3ee/1",
               "relationship": "generates",
+              "descendants":[
+                {
+                    "relationship": "package",
+                }]
             }]
-        }
-      ]
+        }]
     })));
 
     Ok(())
@@ -271,6 +274,212 @@ async fn resolve_rh_variant_source_binary_cdx_external_reference(
                           "document_id": "urn:uuid:a8c83882-79a5-4b47-8ba3-3973ac4e4309/1",
                           "relationship": "generates",
                         }]
+                }]
+            }]
+        }]
+    })));
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn resolve_rh_variant_image_index_cdx_external_reference(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    ctx.ingest_documents([
+        "cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json",
+        "cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json",
+        "cyclonedx/rh/image_index_variants/imageindex_quarkus_mandrel.json",
+    ])
+    .await?;
+
+    let uri = format!(
+        "/api/v2/analysis/component/{}?descendants=10",
+        urlencoding::encode(
+            "pkg:oci/quarkus-mandrel-for-jdk-21-rhel8@sha256%3A04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a"
+        )
+    );
+    let request: Request = TestRequest::get().uri(&uri).to_request();
+    let response: Value = app.call_and_read_body_json(request).await;
+
+    assert!(response.contains_subset(json!({
+      "items": [
+        {
+            "node_id":"quarkus-mandrel-231-rhel8-container_image-index",
+            "name": "quarkus/mandrel-for-jdk-21-rhel8",
+            "document_id": "urn:uuid:8262934b-6d8f-30a7-a216-d933ded97451/1",
+            "descendants": [
+            {
+              "node_id": "quarkus-mandrel-231-rhel8-container_arm64",
+              "purl": [
+                "pkg:oci/mandrel-for-jdk-21-rhel8@sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2?arch=arm64&os=linux&tag=23.1-19.1739757566"
+              ],
+              "name": "quarkus/mandrel-for-jdk-21-rhel8",
+              "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
+              "document_id": "urn:uuid:8262934b-6d8f-30a7-a216-d933ded97451/1",
+              "relationship": "variant",
+              "descendants": [
+                {
+                  "node_id": "quarkus-mandrel-231-rhel8-container_image-index:quarkus-mandrel-231-rhel8-container_arm64",
+                  "name": "quarkus-mandrel-231-rhel8-container_arm64",
+                  "published": "2025-02-17 02:40:50+00",
+                  "document_id": "urn:uuid:8262934b-6d8f-30a7-a216-d933ded97451/1",
+                  "relationship": "package",
+                  "descendants": [
+                    {
+                      "node_id": "pkg:rpm/redhat/zlib-devel@1.2.11-25.el8?arch=aarch64&distro=rhel-8.10&package-id=a7258f3c94d69023&upstream=zlib-1.2.11-25.el8.src.rpm",
+                      "name": "zlib-devel",
+                      "version": "1.2.11-25.el8",
+                      "published": "2025-02-17 02:40:27+00",
+                      "document_id": "urn:uuid:38200326-3211-458c-8084-f24670a78ce4/1",
+                      "relationship": "dependency",
+                    }]
+                }]
+            }]
+        }]
+    })));
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn resolve_rh_variant_image_index_cdx_external_reference2(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    ctx.ingest_documents([
+        "cyclonedx/rh/image_index_variants/example_container_variant_s390x.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_ppc.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_arm64.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_amd64.json",
+        "cyclonedx/rh/image_index_variants/example_container_index.json",
+    ])
+    .await?;
+
+    let uri = format!(
+        "/api/v2/analysis/component/{}?descendants=10",
+        urlencoding::encode(
+            "pkg:oci/openshift-ose-openstack-cinder-csi-driver-operator@sha256%3A4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8"
+        )
+    );
+    let request: Request = TestRequest::get().uri(&uri).to_request();
+    let response: Value = app.call_and_read_body_json(request).await;
+
+    assert!(response.contains_subset(json!({
+      "items": [
+        {
+            "name": "openshift/ose-openstack-cinder-csi-driver-operator",
+            "document_id": "urn:uuid:b3418a5d-8af8-3516-b9ac-5bc53628e803/1",
+            "descendants": [
+            {
+                "node_id": "ose-openstack-cinder-csi-driver-operator-container_ppc64le",
+                "purl": [
+                "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256:64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f?arch=ppc64le&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8"
+                ],
+                "name": "openshift/ose-openstack-cinder-csi-driver-operator",
+                "version": "sha256:64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f",
+                "published": "2025-02-06 19:23:12+00",
+                "document_id": "urn:uuid:b3418a5d-8af8-3516-b9ac-5bc53628e803/1",
+                "relationship": "variant",
+                "descendants": [
+                {
+                    "node_id": "ose-openstack-cinder-csi-driver-operator-container_image-index:ose-openstack-cinder-csi-driver-operator-container_ppc64le",
+                    "name": "ose-openstack-cinder-csi-driver-operator-container_ppc64le",
+                    "document_id": "urn:uuid:b3418a5d-8af8-3516-b9ac-5bc53628e803/1",
+                    "relationship": "package",
+                    "descendants": [
+                    {
+                        "node_id": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=ppc64le&distro=rhel-8.10&package-id=e4ec995f2956806f&upstream=zlib-1.2.11-25.el8.src.rpm",
+                        "purl": [
+                        "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=ppc64le"
+                        ],
+                        "name": "zlib",
+                        "version": "1.2.11-25.el8",
+                        "published": "2025-02-06 19:21:42+00",
+                        "document_id": "urn:uuid:7e5ef761-ab77-460c-bf89-34a772842352/1",
+                        "relationship": "dependency",
+                    }]
+                }]
+            }]
+        }]
+    })));
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+#[ignore = "wait for data change"]
+async fn resolve_rh_variant_image_variant_cdx_external_reference_ancestors(
+    ctx: &TrustifyContext,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    ctx.ingest_documents([
+        "cyclonedx/rh/image_index_variants/example_container_variant_s390x.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_ppc.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_arm64.json",
+        "cyclonedx/rh/image_index_variants/example_container_variant_amd64.json",
+        "cyclonedx/rh/image_index_variants/example_container_index.json",
+    ])
+    .await?;
+
+    // search for a dependency "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=aarch64"
+    let uri = format!(
+        "/api/v2/analysis/component/{}?ancestors=10",
+        urlencoding::encode("pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=s390x")
+    );
+    let request: Request = TestRequest::get().uri(&uri).to_request();
+    let response: Value = app.call_and_read_body_json(request).await;
+
+    log::warn!("test result {:?}", response);
+
+    assert!(response.contains_subset(json!({
+      "items": [
+        {
+            "node_id": "pkg:rpm/redhat/zlib@1.2.11-25.el8?arch=s390x&distro=rhel-8.10&package-id=ca5c659108941f26&upstream=zlib-1.2.11-25.el8.src.rpm",
+            "name": "zlib",
+            "version": "1.2.11-25.el8",
+            "published": "2025-02-06 19:22:37+00",
+            "document_id": "urn:uuid:aa6b5176-94f2-4c73-90bd-613fb1e560e8/1",
+            "ancestors": [
+            {
+                "node_id": "2b8dc6da540ea58f",
+                "purl": [
+                "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d?arch=s390x&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8"
+                ],
+                "cpe": [],
+                "name": "openshift/ose-openstack-cinder-csi-driver-operator",
+                "version": "sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d",
+                "published": "2025-02-06 19:22:37+00",
+                "document_id": "urn:uuid:aa6b5176-94f2-4c73-90bd-613fb1e560e8/1",
+                "relationship": "dependency",
+                "ancestors":[
+                {
+                    "node_id": "ose-openstack-cinder-csi-driver-operator-container_s390x",
+                    "purl": [
+                    "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d?arch=s390x&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8"
+                    ],
+                    "name": "openshift/ose-openstack-cinder-csi-driver-operator",
+                    "version": "sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d",
+                    "published": "2025-02-06 19:23:12+00",
+                    "document_id": "urn:uuid:b3418a5d-8af8-3516-b9ac-5bc53628e803/1",
+                    "relationship": "package",
+                    "ancestors":[
+                    {
+                        "node_id": "ose-openstack-cinder-csi-driver-operator-container_image-index",
+                        "purl": [
+                        "pkg:oci/openshift-ose-openstack-cinder-csi-driver-operator@sha256:4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8"
+                        ],
+                        "name": "openshift/ose-openstack-cinder-csi-driver-operator",
+                        "version": "sha256:4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8",
+                        "published": "2025-02-06 19:23:12+00",
+                        "document_id": "urn:uuid:b3418a5d-8af8-3516-b9ac-5bc53628e803/1",
+                        "relationship": "variant"
+                    }]
                 }]
             }]
         }]

--- a/modules/ingestor/src/graph/sbom/processor/rh_prod_comp.rs
+++ b/modules/ingestor/src/graph/sbom/processor/rh_prod_comp.rs
@@ -103,13 +103,15 @@ impl super::Processor for RedHatProductComponentRelationships {
                 );
             }
 
-            // if it is a top level component, described by the SBOM, packaging components,
-            // then we process those
-            if !((relationship == &Relationship::Generates
-                || relationship == &Relationship::Package)
-                && top_level.contains(prod_node_id))
-            {
-                continue;
+            if relationship != &Relationship::Variant {
+                // if it is a top level component, described by the SBOM, packaging components,
+                // then we process those
+                if !((relationship == &Relationship::Generates
+                    || relationship == &Relationship::Package)
+                    && top_level.contains(prod_node_id))
+                {
+                    continue;
+                }
             }
 
             // artificial external node ID
@@ -187,9 +189,16 @@ fn is_relevant(
         return None;
     }
 
-    // it must have CPEs
+    //check if we have imageindex variant
+    let mut has_imageindex_variant: bool = false;
+    for relationship in relationships {
+        if let sea_orm::ActiveValue::Set(Relationship::Variant) = relationship.relationship {
+            has_imageindex_variant = true;
+        }
+    }
 
-    if find_cpes(cpes, cpes_refs, node_id).is_empty() {
+    // it must have CPEs if not imageindex
+    if !has_imageindex_variant && find_cpes(cpes, cpes_refs, node_id).is_empty() {
         return None;
     }
 


### PR DESCRIPTION
RH imagevariants are a bit 'special' as they currently do not encode **checksum** natively in spdx/cdx ... opting to set _version=sha256###############_. 

This means that we have to handle (for now) with alternate heuristics for determining their relationships.

- [x] add more tests for imagevariant
- [x] lookup for external sbom imageindex>imagevariant
- [x] lookup for ancestor queries with external sbom imageindex>imagevariant
- [x] minor fixes

fixes #1392

**Note: In the future we may remove this special case if/when rh imagevariant start denoting checksums** 