### PR TITLE
fix: prevent stack overflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,6 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
           RUST_LOG: warn,sqlx=error,sea_orm=error
-          RUST_MIN_STACK: 50000000 # 50 MB
       - name: Export and Validate Generated Openapi Spec
         run: |
           cargo xtask openapi

--- a/modules/fundamental/tests/sbom/details.rs
+++ b/modules/fundamental/tests/sbom/details.rs
@@ -1,25 +1,14 @@
-use std::env;
 use test_context::test_context;
 use test_log::test;
 use tracing::instrument;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_module_fundamental::sbom::model::details::SbomDetails;
-use trustify_module_fundamental::sbom::service::SbomService;
+use trustify_module_fundamental::sbom::{model::details::SbomDetails, service::SbomService};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
 #[instrument]
 async fn sbom_details_cyclonedx_osv(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    // get the env var RUST_MIN_STACK and make sure it set to 50000000
-    let stack_size = env::var("RUST_MIN_STACK").unwrap_or("".to_string());
-    if stack_size != "50000000" {
-        println!(
-            "skipping sbom_details_cyclonedx_osv test, RUST_MIN_STACK=50000000 env var is not set"
-        );
-        return Ok(());
-    }
-
     let sbom = SbomService::new(ctx.db.clone());
 
     // ingest the SBOM

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -26,7 +26,7 @@ impl<'g> CyclonedxLoader<'g> {
     ) -> Result<IngestResult, Error> {
         let warnings = Warnings::default();
 
-        let cdx: serde_cyclonedx::cyclonedx::v_1_6::CycloneDx = serde_json::from_slice(buffer)
+        let cdx: Box<serde_cyclonedx::cyclonedx::v_1_6::CycloneDx> = serde_json::from_slice(buffer)
             .map_err(|err| Error::UnsupportedFormat(format!("Failed to parse: {err}")))?;
 
         let labels = labels.add("type", "cyclonedx");


### PR DESCRIPTION
Instead of keeping the CycloneDX structure on the stack, we move it to the heap (using Box). This prevents the stack overflow.

This is done both for the deserialized struct, as well as of the recursively created component creators.

Closes: #1322