### PR TITLE
perf: advisory and vuln endpoints

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,13 +1,13 @@
 pub use sea_orm_migration::prelude::*;
 
-mod m0000010_init;
-mod m0000020_add_sbom_group;
-mod m0000970_alter_importer_add_heartbeat;
-
 #[cfg(feature = "ai")]
 pub mod ai;
 #[cfg(feature = "ai")]
 mod ai_m0000010_create_conversation;
+mod m0000010_init;
+mod m0000020_add_sbom_group;
+mod m0000030_perf_adv_vuln;
+mod m0000970_alter_importer_add_heartbeat;
 
 pub struct Migrator;
 
@@ -18,6 +18,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000010_init::Migration),
             Box::new(m0000970_alter_importer_add_heartbeat::Migration),
             Box::new(m0000020_add_sbom_group::Migration),
+            Box::new(m0000030_perf_adv_vuln::Migration),
         ]
     }
 }

--- a/migration/src/m0000030_perf_adv_vuln.rs
+++ b/migration/src/m0000030_perf_adv_vuln.rs
@@ -1,0 +1,48 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(VulnerabilityDescription::Table)
+                    .name(Indexes::VulnerabilityDescriptionVulnerabilityIdIdx.to_string())
+                    .col(VulnerabilityDescription::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(VulnerabilityDescription::Table)
+                    .name(Indexes::VulnerabilityDescriptionVulnerabilityIdIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    VulnerabilityDescriptionVulnerabilityIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum VulnerabilityDescription {
+    Table,
+    VulnerabilityId,
+}


### PR DESCRIPTION
This PR helps speed up _api/v2/advisory_ and _api/v2/vulnerability_ endpoints.

After applying this it is good to run:
```sql
VACUUM ANALYZE;
REINDEX database trustify;
```
to start at theoretical baseline performance.