### PR TITLE
perf: change cvss related pg funcs to immutable parallel safe and a few key indexes

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m0000010_init;
 mod m0000020_add_sbom_group;
 mod m0000030_perf_adv_vuln;
 mod m0000040_create_license_export;
+mod m0000050_perf_adv_vuln2;
 mod m0000970_alter_importer_add_heartbeat;
 
 pub struct Migrator;
@@ -21,6 +22,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000020_add_sbom_group::Migration),
             Box::new(m0000030_perf_adv_vuln::Migration),
             Box::new(m0000040_create_license_export::Migration),
+            Box::new(m0000050_perf_adv_vuln2::Migration),
         ]
     }
 }

--- a/migration/src/m0000050_perf_adv_vuln2.rs
+++ b/migration/src/m0000050_perf_adv_vuln2.rs
@@ -1,0 +1,168 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryModifiedIdx.to_string())
+                    .col(Advisory::Modified)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryIdentifierIdx.to_string())
+                    .col(Advisory::Identifier)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomPublishedIdx.to_string())
+                    .col(Sbom::Published)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    DROP INDEX IF EXISTS purl_status_vulnerability_id_gist;
+                    CREATE INDEX purl_status_vulnerability_id_gist ON purl_status USING GIST (vulnerability_id gist_trgm_ops);
+                    DROP INDEX IF EXISTS advisory_vulnerability_vulnerability_id_gist;
+                    CREATE INDEX advisory_vulnerability_vulnerability_id_gist ON advisory_vulnerability USING GIST (vulnerability_id gist_trgm_ops);
+                ")
+            .await
+            .map(|_| ())?;
+
+        // This is a stable change eg. no need for rollback
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    ALTER FUNCTION cvss3_a_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_ac_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_ac_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_c_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_exploitability IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_i_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_impact IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_pr_scoped_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_scope_changed IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_severity IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION cvss3_ui_score IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION encode_uri_component IMMUTABLE PARALLEL SAFE;
+                ",
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryIdentifierIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryModifiedIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(PurlStatus::Table)
+                    .name(Indexes::PurlStatusVulnerabilityIdGistIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(AdvisoryVulnerability::Table)
+                    .name(Indexes::AdvisoryVulnerabilityVulnerabilityIdGistIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Sbom::Table)
+                    .name(Indexes::SbomPublishedIdx.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    SbomPublishedIdx,
+    AdvisoryVulnerabilityVulnerabilityIdGistIdx,
+    PurlStatusVulnerabilityIdGistIdx,
+    AdvisoryIdentifierIdx,
+    AdvisoryModifiedIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum Sbom {
+    Table,
+    Published,
+}
+
+#[derive(DeriveIden)]
+#[allow(dead_code)]
+pub enum AdvisoryVulnerability {
+    Table,
+    VulnerabilityId,
+}
+
+#[derive(DeriveIden)]
+#[allow(dead_code)]
+pub enum PurlStatus {
+    Table,
+    VulnerabilityId,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+    Identifier,
+    Modified,
+}


### PR DESCRIPTION
This PR should help advisory/vuln endpoints by enabling some pg functions to run in parallel. Also a few key indexes are added.