### PR TITLE
feat: add endpoint to process multiple purls

### DIFF
--- a/modules/fundamental/src/ai/service/tools/package_info.rs
+++ b/modules/fundamental/src/ai/service/tools/package_info.rs
@@ -68,7 +68,7 @@ Input: The package name, its Identifier URI, or UUID.
             .to_string();
 
         let mut purl_details = match service
-            .fetch_purl_details(&vec![input.clone()], Deprecation::Ignore, db)
+            .fetch_purl_details(&[input.as_str()], Deprecation::Ignore, db)
             .await
         {
             Err(_) => None,
@@ -94,7 +94,7 @@ Input: The package name, its Identifier URI, or UUID.
                 1 => {
                     let details = service
                         .fetch_purl_details(
-                            &vec![results.items[0].head.uuid.to_string()],
+                            &[results.items[0].head.uuid.to_string().as_str()],
                             Deprecation::Ignore,
                             db,
                         )

--- a/modules/fundamental/src/ai/service/tools/package_info.rs
+++ b/modules/fundamental/src/ai/service/tools/package_info.rs
@@ -68,11 +68,11 @@ Input: The package name, its Identifier URI, or UUID.
             .to_string();
 
         let mut purl_details = match service
-            .fetch_purl_details(&[input.as_str()], Deprecation::Ignore, db)
+            .fetch_purl_details(&[&input], Deprecation::Ignore, db)
             .await
         {
             Err(_) => None,
-            Ok(details) => details.get(&input.clone()).cloned(),
+            Ok(details) => details.get(&input).cloned(),
         };
 
         // Fallback to search
@@ -94,7 +94,7 @@ Input: The package name, its Identifier URI, or UUID.
                 1 => {
                     let details = service
                         .fetch_purl_details(
-                            &[results.items[0].head.uuid.to_string().as_str()],
+                            &[results.items[0].head.uuid.to_string()],
                             Deprecation::Ignore,
                             db,
                         )

--- a/modules/fundamental/src/error.rs
+++ b/modules/fundamental/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     Ingestor(#[from] trustify_module_ingestor::service::Error),
     #[error(transparent)]
     Purl(#[from] PurlErr),
+    #[error(transparent)]
+    Uuid(#[from] uuid::Error),
     #[error("Bad request: {0}")]
     BadRequest(String),
     #[error("Not found: {0}")]

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -1,19 +1,19 @@
 use crate::{
-    Error,
     endpoints::Deprecation,
     purl::{
         model::{details::purl::PurlDetails, summary::purl::PurlSummary},
         service::PurlService,
     },
 };
-use actix_web::{HttpResponse, Responder, get, web};
+use actix_web::{HttpResponse, Responder, get, post, web};
 use sea_orm::prelude::Uuid;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use trustify_auth::{ReadSbom, authorizer::Require};
 use trustify_common::{
-    db::Database, db::query::Query, id::IdError, model::Paginated, model::PaginatedResults,
-    purl::Purl,
+    db::Database, db::query::Query, model::Paginated, model::PaginatedResults, purl::Purl,
 };
+
+use super::model::details::purl::{PurlsRequest, PurlsResponse};
 
 mod base;
 mod r#type;
@@ -33,7 +33,43 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .service(base::all_base_purls)
         .service(version::get_versioned_purl)
         .service(get)
+        .service(get_multiple)
         .service(all);
+}
+
+async fn fetch_purl_details(
+    service: &PurlService,
+    db: &Database,
+    deprecated: trustify_module_ingestor::common::Deprecation,
+    identifiers: &[String],
+) -> Result<HashMap<String, PurlDetails>, String> {
+    let mut purls: Vec<Purl> = Vec::new();
+    let mut uuids: Vec<Uuid> = Vec::new();
+    for key in identifiers {
+        if key.starts_with("pkg:") {
+            let purl = Purl::from_str(key).map_err(|e| format!("Invalid purl '{}': {}", key, e))?;
+            purls.push(purl);
+        } else {
+            let id = Uuid::from_str(key).map_err(|e| format!("Invalid UUID '{}': {}", key, e))?;
+            uuids.push(id);
+        }
+    }
+    let mut result: HashMap<String, PurlDetails> = HashMap::new();
+    let purl_details = service
+        .purls_by_purl(purls, deprecated, db)
+        .await
+        .map_err(|e| format!("Failed to fetch purl details by purl: {}", e))?;
+    for detail in purl_details {
+        result.insert(detail.head.purl.to_string(), detail);
+    }
+    let uuid_details = service
+        .purls_by_uuid(uuids, deprecated, db)
+        .await
+        .map_err(|e| format!("Failed to fetch purl details by uuid: {}", e))?;
+    for detail in uuid_details {
+        result.insert(detail.head.uuid.to_string(), detail);
+    }
+    Ok(result)
 }
 
 #[utoipa::path(
@@ -56,12 +92,43 @@ pub async fn get(
     web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
-    if key.starts_with("pkg") {
-        let purl = Purl::from_str(&key).map_err(Error::Purl)?;
-        Ok(HttpResponse::Ok().json(service.purl_by_purl(&purl, deprecated, db.as_ref()).await?))
-    } else {
-        let id = Uuid::from_str(&key).map_err(|e| Error::IdKey(IdError::InvalidUuid(e)))?;
-        Ok(HttpResponse::Ok().json(service.purl_by_uuid(&id, deprecated, db.as_ref()).await?))
+    let result_key = key.into_inner();
+    let identifiers = vec![result_key.clone()];
+    match fetch_purl_details(&service, &db, deprecated, &identifiers).await {
+        Ok(details) => match details.get(&result_key) {
+            Some(detail) => Ok(HttpResponse::Ok().json(detail)),
+            None => Ok(HttpResponse::NotFound().body("Identifier not found")),
+        },
+        Err(error) => Ok(HttpResponse::InternalServerError()
+            .body(format!("Error fetching purl {result_key}: {}", error))),
+    }
+}
+
+#[utoipa::path(
+    operation_id = "getPurls",
+    tag = "purl",
+    params(
+        Deprecation
+    ),
+    request_body = PurlsRequest,
+    responses(
+        (status = 200, description = "Details for the qualified PURLs", body = PurlsResponse),
+    ),
+)]
+#[post("/v2/purl")]
+/// Retrieve details for multiple qualified PURLs
+pub async fn get_multiple(
+    service: web::Data<PurlService>,
+    db: web::Data<Database>,
+    request: web::Json<PurlsRequest>,
+    web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
+    _: Require<ReadSbom>,
+) -> actix_web::Result<impl Responder> {
+    match fetch_purl_details(&service, &db, deprecated, &request.items).await {
+        Ok(details) => Ok(HttpResponse::Ok().json(details)),
+        Err(error) => Ok(
+            HttpResponse::InternalServerError().body(format!("Error fetching purls: {}", error))
+        ),
     }
 }
 

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -54,12 +54,12 @@ pub async fn get(
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     let result_key = key.into_inner();
-    let identifiers = vec![result_key.clone()];
+    let identifiers = vec![result_key.as_str()];
     match service
         .fetch_purl_details(&identifiers, deprecated, db.as_ref())
         .await
     {
-        Ok(details) => match details.get(&result_key) {
+        Ok(details) => match details.get(result_key.as_str()) {
             Some(detail) => Ok(HttpResponse::Ok().json(detail)),
             None => Ok(HttpResponse::NotFound().body("Identifier not found")),
         },
@@ -88,8 +88,9 @@ pub async fn get_multiple(
     web::Query(Deprecation { deprecated }): web::Query<Deprecation>,
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
+    let items: Vec<&str> = request.items.iter().map(|s| s.as_str()).collect();
     match service
-        .fetch_purl_details(&request.items, deprecated, db.as_ref())
+        .fetch_purl_details(&items, deprecated, db.as_ref())
         .await
     {
         Ok(details) => Ok(HttpResponse::Ok().json(details)),

--- a/modules/fundamental/src/purl/endpoints/mod.rs
+++ b/modules/fundamental/src/purl/endpoints/mod.rs
@@ -54,7 +54,7 @@ pub async fn get(
     _: Require<ReadSbom>,
 ) -> actix_web::Result<impl Responder> {
     let result_key = key.into_inner();
-    let identifiers = vec![result_key.as_str()];
+    let identifiers = [&result_key];
     match service
         .fetch_purl_details(&identifiers, deprecated, db.as_ref())
         .await

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -1,6 +1,6 @@
-use crate::purl::model::details::base_purl::BasePurlDetails;
-use crate::purl::model::details::purl::PurlDetails;
+use crate::purl::model::details::purl::{PurlDetails, PurlsResponse};
 use crate::purl::model::details::versioned_purl::VersionedPurlDetails;
+use crate::purl::model::details::{base_purl::BasePurlDetails, purl::PurlsRequest};
 use crate::purl::model::summary::base_purl::BasePurlSummary;
 use crate::purl::model::summary::purl::PurlSummary;
 use crate::purl::model::summary::r#type::TypeSummary;
@@ -347,6 +347,46 @@ async fn package_with_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
         "critical",
         response["advisories"][0]["status"][0]["average_severity"]
     );
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn multiple_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    ctx.ingestor
+        .graph()
+        .ingest_qualified_package(&Purl::from_str("pkg:cargo/hyper@0.14.1")?, &ctx.db)
+        .await?;
+
+    ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "cve/CVE-2021-32714.json"])
+        .await?;
+
+    let app = caller(ctx).await?;
+    let uri = "/api/v2/purl/type/cargo/hyper@0.14.1";
+    let request = TestRequest::get().uri(uri).to_request();
+    let hyper_0_14_1: VersionedPurlDetails = app.call_and_read_body_json(request).await;
+
+    let purls = vec![
+        hyper_0_14_1.head.uuid.to_string(),
+        hyper_0_14_1.head.purl.to_string(),
+        String::from("pkg:maven/org.example/notfound@1.2.3?jdk=11"),
+    ];
+
+    let uri = "/api/v2/purl";
+    let request_body = PurlsRequest {
+        items: purls.clone(),
+    };
+    let request = TestRequest::post()
+        .set_json(request_body)
+        .uri(uri)
+        .to_request();
+    let response: PurlsResponse = app.call_and_read_body_json(request).await;
+
+    assert_eq!(2, response.len());
+    assert!(response.get(purls[0].as_str()).is_some());
+    assert!(response.get(purls[1].as_str()).is_some());
+    assert!(response.get(purls[2].as_str()).is_none());
 
     Ok(())
 }

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -32,7 +32,7 @@ use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, Clone)]
 pub struct PurlDetails {
     #[serde(flatten)]
     pub head: PurlHead,
@@ -182,7 +182,7 @@ impl Deref for PurlsResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq, Clone)]
 pub struct PurlAdvisory {
     #[serde(flatten)]
     pub head: AdvisoryHead,
@@ -284,7 +284,7 @@ impl PurlAdvisory {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq, Clone)]
 pub struct PurlStatus {
     pub vulnerability: VulnerabilityHead,
     pub average_severity: Severity,

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -12,7 +12,10 @@ use sea_orm::{
 };
 use sea_query::{Asterisk, ColumnRef, Expr, Func, IntoIden, JoinType, SimpleExpr};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, hash_map::Entry};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    ops::Deref,
+};
 use trustify_common::{
     db::VersionMatches,
     db::multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
@@ -161,6 +164,22 @@ async fn get_product_statuses_for_purl<C: ConnectionTrait>(
         .await?;
 
     Ok(product_statuses)
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct PurlsRequest {
+    pub items: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct PurlsResponse(HashMap<String, PurlDetails>);
+
+impl Deref for PurlsResponse {
+    type Target = HashMap<String, PurlDetails>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, PartialEq, Eq)]

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -274,6 +274,9 @@ impl PurlService {
         deprecation: Deprecation,
         connection: &C,
     ) -> Result<Vec<PurlDetails>, Error> {
+        if purls.is_empty() {
+            return Ok(Default::default());
+        }
         let canonical: Vec<CanonicalPurl> = purls
             .iter()
             .map(|purl| CanonicalPurl::from(purl.clone()))
@@ -298,6 +301,9 @@ impl PurlService {
         deprecation: Deprecation,
         connection: &C,
     ) -> Result<Vec<PurlDetails>, Error> {
+        if uuids.is_empty() {
+            return Ok(Default::default());
+        }
         let items = qualified_purl::Entity::find()
             .filter(qualified_purl::Column::Id.is_in(uuids.to_vec()))
             .all(connection)

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -638,13 +638,19 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     assert_eq!(1, results.items.len());
 
-    let uuid = results.items[0].head.uuid;
+    let expected_uuid = results.items[0].head.uuid;
+    let uuid = &expected_uuid.to_string();
 
     let results = service
-        .purl_by_uuid(&uuid, Default::default(), &ctx.db)
-        .await?;
+        .fetch_purl_details(&vec![uuid.clone()], Default::default(), &ctx.db)
+        .await;
 
-    assert_eq!(uuid, results.unwrap().head.uuid);
+    assert!(results.is_ok());
+    let purls = results.unwrap();
+    assert!(purls.contains_key(uuid));
+
+    let details = purls.get(uuid).unwrap();
+    assert_eq!(expected_uuid, details.head.uuid);
 
     Ok(())
 }
@@ -669,16 +675,17 @@ async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let tomcat_jsp = tomcat_jsp.unwrap();
 
-    let uuid = tomcat_jsp.head.uuid;
+    let uuid = &tomcat_jsp.head.uuid.to_string();
 
-    let tomcat_jsp = service
-        .purl_by_uuid(&uuid, Default::default(), &ctx.db)
-        .await?;
+    let result = service
+        .fetch_purl_details(&vec![uuid.clone()], Default::default(), &ctx.db)
+        .await;
 
-    assert!(tomcat_jsp.is_some());
+    assert!(result.is_ok());
+    let details = result.unwrap();
+    assert!(details.contains_key(uuid));
 
-    let tomcat_jsp = tomcat_jsp.unwrap();
-
+    let tomcat_jsp = details.get(uuid).unwrap();
     assert_eq!(1, tomcat_jsp.advisories.len());
 
     let advisory = &tomcat_jsp.advisories[0];
@@ -850,13 +857,13 @@ async fn unqualified_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::E
     let purl = "pkg:maven/org.apache/log4j@1.2.3";
 
     let results = service
-        .purl_by_purl(&Purl::from_str(purl)?, Default::default(), &ctx.db)
-        .await?
+        .fetch_purl_details(&vec![purl.to_string()], Default::default(), &ctx.db)
+        .await
         .unwrap();
 
     log::debug!("{results:#?}");
-    assert_eq!(results.head.purl.to_string(), purl);
-    assert_eq!(results.version.version, "1.2.3");
+    assert_eq!(results.get(purl).unwrap().head.purl.to_string(), purl);
+    assert_eq!(results.get(purl).unwrap().version.version, "1.2.3");
 
     Ok(())
 }

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -642,7 +642,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let uuid = &expected_uuid.to_string();
 
     let results = service
-        .fetch_purl_details(&[uuid.as_str()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[uuid], Default::default(), &ctx.db)
         .await;
 
     assert!(results.is_ok());
@@ -678,7 +678,7 @@ async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let uuid = &tomcat_jsp.head.uuid.to_string();
 
     let result = service
-        .fetch_purl_details(&[uuid.as_str()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[uuid], Default::default(), &ctx.db)
         .await;
 
     assert!(result.is_ok());

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -642,7 +642,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let uuid = &expected_uuid.to_string();
 
     let results = service
-        .fetch_purl_details(&vec![uuid.clone()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[uuid.as_str()], Default::default(), &ctx.db)
         .await;
 
     assert!(results.is_ok());
@@ -678,7 +678,7 @@ async fn contextual_status(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let uuid = &tomcat_jsp.head.uuid.to_string();
 
     let result = service
-        .fetch_purl_details(&vec![uuid.clone()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[uuid.as_str()], Default::default(), &ctx.db)
         .await;
 
     assert!(result.is_ok());
@@ -857,7 +857,7 @@ async fn unqualified_purl_by_purl(ctx: &TrustifyContext) -> Result<(), anyhow::E
     let purl = "pkg:maven/org.apache/log4j@1.2.3";
 
     let results = service
-        .fetch_purl_details(&vec![purl.to_string()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[purl], Default::default(), &ctx.db)
         .await
         .unwrap();
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -301,7 +301,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // Ensure that purl->vuln mapping is good
     let results = purl_service
-        .fetch_purl_details(&vec![purl.to_string()], Default::default(), &ctx.db)
+        .fetch_purl_details(&[purl], Default::default(), &ctx.db)
         .await;
 
     log::debug!("{:#?}", results);

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -297,18 +297,22 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         ["https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-2.13.8.Final-redhat-00004",],
     );
 
-    // Ensure that purl->vuln mapping is good
-    let purl = purl_service
-        .purl_by_purl(
-            &Purl::try_from("pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar")?,
-            Default::default(),
-            &ctx.db,
-        )
-        .await?;
+    let purl = "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar";
 
+    // Ensure that purl->vuln mapping is good
+    let results = purl_service
+        .fetch_purl_details(&vec![purl.to_string()], Default::default(), &ctx.db)
+        .await;
+
+    log::debug!("{:#?}", results);
+
+    assert!(results.is_ok());
+    let purls = results.unwrap();
+
+    assert!(purls.contains_key(purl));
+    let purl = purls.get(purl).unwrap();
     log::debug!("{:#?}", purl);
-    assert!(purl.is_some());
-    let purl = purl.unwrap();
+
     assert_eq!(1, purl.advisories.len());
 
     let cve_advisory = purl

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -111,17 +111,24 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // get vuln by purl
 
-    let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Ignore, &ctx.db)
-        .await?
+    let purls = service
+        .fetch_purl_details(
+            &vec![purl.head.uuid.to_string()],
+            Deprecation::Ignore,
+            &ctx.db,
+        )
+        .await
         .expect("must find something");
 
     // must be 1, as we deleted the latter one
+    assert!(purls.contains_key(&purl.head.uuid.to_string()));
 
-    assert_eq!(purl.advisories.len(), 1);
-    purl.advisories
-        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
-    let adv1 = &purl.advisories[0];
+    let purl_details = purls.get(&purl.head.uuid.to_string()).unwrap();
+
+    assert_eq!(purl_details.advisories.len(), 1);
+    let mut advisories = purl_details.advisories.iter().collect::<Vec<_>>();
+    advisories.sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+    let adv1 = advisories[0];
 
     assert_eq!(
         adv1.head.identifier,

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -113,7 +113,7 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let purls = service
         .fetch_purl_details(
-            &vec![purl.head.uuid.to_string()],
+            &[purl.head.uuid.to_string().as_str()],
             Deprecation::Ignore,
             &ctx.db,
         )

--- a/modules/fundamental/tests/advisory/csaf/delete.rs
+++ b/modules/fundamental/tests/advisory/csaf/delete.rs
@@ -112,18 +112,16 @@ async fn delete_check_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let purls = service
-        .fetch_purl_details(
-            &[purl.head.uuid.to_string().as_str()],
-            Deprecation::Ignore,
-            &ctx.db,
-        )
+        .fetch_purl_details(&[&purl.head.uuid.to_string()], Deprecation::Ignore, &ctx.db)
         .await
         .expect("must find something");
 
     // must be 1, as we deleted the latter one
     assert!(purls.contains_key(&purl.head.uuid.to_string()));
 
-    let purl_details = purls.get(&purl.head.uuid.to_string()).unwrap();
+    let purl_details = purls
+        .get(&purl.head.uuid.to_string())
+        .expect("must find one");
 
     assert_eq!(purl_details.advisories.len(), 1);
     let mut advisories = purl_details.advisories.iter().collect::<Vec<_>>();

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -134,15 +134,14 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
     // get vuln by purl
 
     let results = service
-        .fetch_purl_details(
-            &[purl.head.uuid.to_string().as_str()],
-            Deprecation::Ignore,
-            &ctx.db,
-        )
+        .fetch_purl_details(&[purl.head.uuid.to_string()], Deprecation::Ignore, &ctx.db)
         .await
         .expect("must find something");
 
-    let purl = results.get(&purl.head.uuid.to_string()).unwrap();
+    let purl = results
+        .get(&purl.head.uuid.to_string())
+        .expect("must find one");
+
     assert_eq!(purl.advisories.len(), 1);
     let adv = &purl.advisories[0];
 
@@ -233,7 +232,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let results = service
         .fetch_purl_details(
-            &[purl.head.uuid.to_string().as_str()],
+            &[purl.head.uuid.to_string()],
             Deprecation::Consider,
             &ctx.db,
         )
@@ -241,7 +240,9 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
         .expect("must find something");
 
     // must be 2, as we consider deprecated ones too
-    let purl = results.get(&purl.head.uuid.to_string()).unwrap();
+    let purl = results
+        .get(&purl.head.uuid.to_string())
+        .expect("must find one");
     assert_eq!(purl.advisories.len(), 2);
     let mut advisories = purl.advisories.iter().collect::<Vec<_>>();
     advisories.sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));

--- a/modules/fundamental/tests/advisory/csaf/reingest.rs
+++ b/modules/fundamental/tests/advisory/csaf/reingest.rs
@@ -135,7 +135,7 @@ async fn change_ps_list_vulns(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let results = service
         .fetch_purl_details(
-            &vec![purl.head.uuid.to_string()],
+            &[purl.head.uuid.to_string().as_str()],
             Deprecation::Ignore,
             &ctx.db,
         )
@@ -233,7 +233,7 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let results = service
         .fetch_purl_details(
-            &vec![purl.head.uuid.to_string()],
+            &[purl.head.uuid.to_string().as_str()],
             Deprecation::Consider,
             &ctx.db,
         )
@@ -245,8 +245,8 @@ async fn change_ps_list_vulns_all(ctx: &TrustifyContext) -> anyhow::Result<()> {
     assert_eq!(purl.advisories.len(), 2);
     let mut advisories = purl.advisories.iter().collect::<Vec<_>>();
     advisories.sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
-    let adv1 = &purl.advisories[0];
-    let adv2 = &purl.advisories[1];
+    let adv1 = advisories[0];
+    let adv2 = advisories[1];
 
     assert_eq!(
         adv1.head.identifier,

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -100,7 +100,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let results = service
         .fetch_purl_details(
-            &[purl.head.uuid.to_string().as_str()],
+            &[purl.head.uuid.to_string()],
             Deprecation::Consider,
             &ctx.db,
         )

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -100,7 +100,7 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     let results = service
         .fetch_purl_details(
-            &vec![purl.head.uuid.to_string()],
+            &[purl.head.uuid.to_string().as_str()],
             Deprecation::Consider,
             &ctx.db,
         )

--- a/modules/fundamental/tests/advisory/osv/reingest.rs
+++ b/modules/fundamental/tests/advisory/osv/reingest.rs
@@ -98,16 +98,21 @@ async fn withdrawn(ctx: &TrustifyContext) -> anyhow::Result<()> {
 
     // get vuln by purl
 
-    let mut purl = service
-        .purl_by_uuid(&purl.head.uuid, Deprecation::Consider, &ctx.db)
-        .await?
+    let results = service
+        .fetch_purl_details(
+            &vec![purl.head.uuid.to_string()],
+            Deprecation::Consider,
+            &ctx.db,
+        )
+        .await
         .expect("must find something");
 
     // must be 2, as we consider deprecated ones too
 
+    let purl = results.get(&purl.head.uuid.to_string()).unwrap();
     assert_eq!(purl.advisories.len(), 2);
-    purl.advisories
-        .sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
+    let mut advisories = purl.advisories.iter().collect::<Vec<_>>();
+    advisories.sort_unstable_by(|a, b| a.head.modified.cmp(&b.head.modified));
     let adv1 = &purl.advisories[0];
     let adv2 = &purl.advisories[1];
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -982,6 +982,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_PurlSummary'
+    post:
+      tags:
+      - purl
+      summary: Retrieve details for multiple qualified PURLs
+      operationId: getPurls
+      parameters:
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PurlsRequest'
+        required: true
+      responses:
+        '200':
+          description: Details for the qualified PURLs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurlsResponse'
   /api/v2/purl/base:
     get:
       tags:
@@ -3182,6 +3209,21 @@ components:
             deprecated: true
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
+    PurlsRequest:
+      type: object
+      required:
+      - items
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+    PurlsResponse:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/PurlDetails'
+      propertyNames:
+        type: string
     Relationship:
       type: string
       enum:


### PR DESCRIPTION
Allow retrieving multiple PurlDetails by either purl or uuid

Fix #1425 