### PR TITLE
perf: change version related pg funcs to IMMUTABLE PARALLEL SAFE

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -9,6 +9,7 @@ mod m0000020_add_sbom_group;
 mod m0000030_perf_adv_vuln;
 mod m0000040_create_license_export;
 mod m0000050_perf_adv_vuln2;
+mod m0000060_perf_adv_vuln3;
 mod m0000970_alter_importer_add_heartbeat;
 
 pub struct Migrator;
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000030_perf_adv_vuln::Migration),
             Box::new(m0000040_create_license_export::Migration),
             Box::new(m0000050_perf_adv_vuln2::Migration),
+            Box::new(m0000060_perf_adv_vuln3::Migration),
         ]
     }
 }

--- a/migration/src/m0000060_perf_adv_vuln3.rs
+++ b/migration/src/m0000060_perf_adv_vuln3.rs
@@ -1,0 +1,67 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // This is a stable change eg. no need for rollback
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    ALTER FUNCTION generic_version_matches IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION is_numeric IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION maven_version_matches IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION mavenver_cmp IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION python_version_matches IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION pythonver_cmp IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION rpmver_cmp IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION rpmver_version_matches IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_cmp IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_eq IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_gt IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_gte IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_lt IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_lte IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION semver_version_matches IMMUTABLE PARALLEL SAFE;
+                    ALTER FUNCTION version_matches IMMUTABLE PARALLEL SAFE;
+                ",
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    ALTER FUNCTION generic_version_matches IMMUTABLE;
+                    ALTER FUNCTION is_numeric IMMUTABLE;
+                    ALTER FUNCTION maven_version_matches IMMUTABLE;
+                    ALTER FUNCTION mavenver_cmp IMMUTABLE;
+                    ALTER FUNCTION python_version_matches IMMUTABLE;
+                    ALTER FUNCTION pythonver_cmp IMMUTABLE;
+                    ALTER FUNCTION rpmver_cmp IMMUTABLE;
+                    ALTER FUNCTION rpmver_version_matches IMMUTABLE;
+                    ALTER FUNCTION semver_cmp IMMUTABLE;
+                    ALTER FUNCTION semver_eq IMMUTABLE;
+                    ALTER FUNCTION semver_gt IMMUTABLE;
+                    ALTER FUNCTION semver_gte IMMUTABLE;
+                    ALTER FUNCTION semver_lt IMMUTABLE;
+                    ALTER FUNCTION semver_lte IMMUTABLE;
+                    ALTER FUNCTION semver_version_matches IMMUTABLE;
+                    ALTER FUNCTION version_matches IMMUTABLE;
+                ",
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR changes version related pg funcs to IMMUTABLE PARALLEL SAFE

final fixes #1298