### PR TITLE
refactor: remove three later PURL processing in more places

### DIFF
--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -1,6 +1,7 @@
 use deepsize::DeepSizeOf;
 use packageurl::PackageUrl;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use sea_orm::FromJsonQueryResult;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error, Visitor},
@@ -26,7 +27,7 @@ pub enum PurlErr {
     Package(#[from] packageurl::Error),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, DeepSizeOf)]
+#[derive(Clone, PartialEq, Eq, Hash, DeepSizeOf, FromJsonQueryResult)]
 pub struct Purl {
     pub ty: String,
     pub namespace: Option<String>,
@@ -105,6 +106,17 @@ impl Purl {
             name: self.name.clone(),
             namespace: self.namespace.clone(),
             version: None,
+            qualifiers: Default::default(),
+        }
+    }
+
+    /// Create a new instance with only the version information
+    pub fn to_version(&self) -> Self {
+        Self {
+            ty: self.ty.clone(),
+            name: self.name.clone(),
+            namespace: self.namespace.clone(),
+            version: self.version.clone(),
             qualifiers: Default::default(),
         }
     }

--- a/modules/fundamental/src/purl/model/summary/purl.rs
+++ b/modules/fundamental/src/purl/model/summary/purl.rs
@@ -1,11 +1,8 @@
-use crate::Error;
 use crate::purl::model::{BasePurlHead, PurlHead, VersionedPurlHead};
-use sea_orm::{ConnectionTrait, LoaderTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use trustify_common::purl::Purl;
-use trustify_entity::qualified_purl::{CanonicalPurl, Qualifiers};
-use trustify_entity::{base_purl, qualified_purl, versioned_purl};
+use trustify_entity::qualified_purl;
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, ToSchema, Hash)]
@@ -20,82 +17,38 @@ pub struct PurlSummary {
     pub qualifiers: BTreeMap<String, String>,
 }
 
-impl From<CanonicalPurl> for PurlSummary {
-    fn from(value: CanonicalPurl) -> Self {
-        let purl = Purl::from(value.clone());
-
+impl From<Purl> for PurlSummary {
+    #[allow(deprecated)]
+    fn from(purl: Purl) -> Self {
         let base_purl_id = purl.package_uuid();
         let versioned_purl_id = purl.version_uuid();
         let qualified_purl_id = purl.qualifier_uuid();
 
-        PurlSummary::from_entity(
-            &base_purl::Model {
-                id: base_purl_id,
-                r#type: purl.ty.clone(),
-                namespace: purl.namespace.clone(),
-                name: purl.name.clone(),
+        PurlSummary {
+            head: PurlHead {
+                uuid: qualified_purl_id,
+                purl: purl.clone(),
             },
-            &versioned_purl::Model {
-                id: purl.version_uuid(),
-                base_purl_id,
+            base: BasePurlHead {
+                uuid: base_purl_id,
+                purl: purl.to_base(),
+            },
+            version: VersionedPurlHead {
+                uuid: versioned_purl_id,
+                purl: purl.to_version(),
                 version: purl.version.clone().unwrap_or_default(),
             },
-            &qualified_purl::Model {
-                id: qualified_purl_id,
-                versioned_purl_id,
-                qualifiers: Qualifiers(purl.qualifiers),
-                purl: value,
-            },
-        )
+            qualifiers: purl.qualifiers,
+        }
     }
 }
 
 impl PurlSummary {
-    #[allow(deprecated)]
-    pub async fn from_entities<C: ConnectionTrait>(
-        qualified_packages: &Vec<qualified_purl::Model>,
-        tx: &C,
-    ) -> Result<Vec<Self>, Error> {
-        let package_versions = qualified_packages
-            .load_one(versioned_purl::Entity, tx)
-            .await?;
-
-        let mut summaries = Vec::new();
-
-        for (package_version, qualified_package) in
-            package_versions.iter().zip(qualified_packages.iter())
-        {
-            if let (Some(package_version), qualified_package) = (package_version, qualified_package)
-            {
-                if let Some(package) = package_version
-                    .find_related(base_purl::Entity)
-                    .one(tx)
-                    .await?
-                {
-                    summaries.push(PurlSummary {
-                        head: PurlHead::from_entity(&package, package_version, qualified_package),
-                        base: BasePurlHead::from_entity(&package),
-                        version: VersionedPurlHead::from_entity(&package, package_version),
-                        qualifiers: qualified_package.qualifiers.0.clone(),
-                    })
-                }
-            }
-        }
-
-        Ok(summaries)
+    pub fn from_entities(qualified_packages: &[qualified_purl::Model]) -> Vec<Self> {
+        qualified_packages.iter().map(Self::from_entity).collect()
     }
 
-    #[allow(deprecated)]
-    pub fn from_entity(
-        base_purl: &base_purl::Model,
-        versioned_purl: &versioned_purl::Model,
-        purl: &qualified_purl::Model,
-    ) -> Self {
-        PurlSummary {
-            head: PurlHead::from_entity(base_purl, versioned_purl, purl),
-            base: BasePurlHead::from_entity(base_purl),
-            version: VersionedPurlHead::from_entity(base_purl, versioned_purl),
-            qualifiers: purl.qualifiers.0.clone(),
-        }
+    pub fn from_entity(purl: &qualified_purl::Model) -> Self {
+        Purl::from(purl.purl.clone()).into()
     }
 }

--- a/modules/fundamental/src/purl/service/mod.rs
+++ b/modules/fundamental/src/purl/service/mod.rs
@@ -311,7 +311,7 @@ impl PurlService {
         let total = limiter.total().await?;
 
         Ok(PaginatedResults {
-            items: PurlSummary::from_entities(&limiter.fetch().await?, connection).await?,
+            items: PurlSummary::from_entities(&limiter.fetch().await?),
             total,
         })
     }

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -150,13 +150,6 @@ impl SbomDetails {
                 "vulnerability"."modified" AS "vulnerability$modified",
                 "vulnerability"."withdrawn" AS "vulnerability$withdrawn",
                 "vulnerability"."cwes" AS "vulnerability$cwes",
-                "base_purl"."id" AS "base_purl$id",
-                "base_purl"."type" AS "base_purl$type",
-                "base_purl"."namespace" AS "base_purl$namespace",
-                "base_purl"."name" AS "base_purl$name",
-                "versioned_purl"."id" AS "versioned_purl$id",
-                "versioned_purl"."base_purl_id" AS "versioned_purl$base_purl_id",
-                "versioned_purl"."version" AS "versioned_purl$version",
                 "qualified_purl"."id" AS "qualified_purl$id",
                 "qualified_purl"."versioned_purl_id" AS "qualified_purl$versioned_purl_id",
                 "qualified_purl"."qualifiers" AS "qualified_purl$qualifiers",
@@ -356,11 +349,7 @@ impl SbomAdvisory {
                 id: each.sbom_package.node_id.clone(),
                 name: each.sbom_node.name.clone(),
                 version: each.sbom_package.version.clone(),
-                purl: vec![PurlSummary::from_entity(
-                    &each.base_purl,
-                    &each.versioned_purl,
-                    &each.qualified_purl,
-                )],
+                purl: vec![PurlSummary::from_entity(&each.qualified_purl)],
                 cpe: vec![],
             });
         }

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -15,6 +15,7 @@ use sea_query::{Expr, JoinType, extension::postgres::PgExpr};
 use serde_json::Value;
 use std::{collections::HashMap, fmt::Debug};
 use tracing::instrument;
+use trustify_common::purl::Purl;
 use trustify_common::{
     cpe::Cpe,
     db::{
@@ -550,7 +551,7 @@ fn package_from_row(row: PackageCatcher) -> SbomPackage {
                 })
                 .ok()
         })
-        .map(|purl| purl.into())
+        .map(|purl| Purl::from(purl).into())
         .collect();
 
     let cpe = row
@@ -588,8 +589,6 @@ fn package_from_row(row: PackageCatcher) -> SbomPackage {
 #[derive(Debug)]
 pub struct QueryCatcher {
     pub advisory: advisory::Model,
-    pub base_purl: base_purl::Model,
-    pub versioned_purl: versioned_purl::Model,
     pub qualified_purl: qualified_purl::Model,
     pub sbom_package: sbom_package::Model,
     pub sbom_node: sbom_node::Model,
@@ -610,8 +609,6 @@ impl FromQueryResult for QueryCatcher {
                 advisory_vulnerability::Entity,
             )?,
             vulnerability: Self::from_query_result_multi_model(res, "", vulnerability::Entity)?,
-            base_purl: Self::from_query_result_multi_model(res, "", base_purl::Entity)?,
-            versioned_purl: Self::from_query_result_multi_model(res, "", versioned_purl::Entity)?,
             qualified_purl: Self::from_query_result_multi_model(res, "", qualified_purl::Entity)?,
             sbom_package: Self::from_query_result_multi_model(res, "", sbom_package::Entity)?,
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,

--- a/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
+++ b/modules/fundamental/src/vulnerability/model/details/vulnerability_advisory.rs
@@ -204,13 +204,6 @@ impl VulnerabilityAdvisorySummary {
                 "status"."slug" AS "status$slug",
                 "status"."name" AS "status$name",
                 "status"."description" AS "status$description",
-                "base_purl"."id" AS "base_purl$id",
-                "base_purl"."type" AS "base_purl$type",
-                "base_purl"."namespace" AS "base_purl$namespace",
-                "base_purl"."name" AS "base_purl$name",
-                "versioned_purl"."id" AS "versioned_purl$id",
-                "versioned_purl"."base_purl_id" AS "versioned_purl$base_purl_id",
-                "versioned_purl"."version" AS "versioned_purl$version",
                 "qualified_purl"."id" AS "qualified_purl$id",
                 "qualified_purl"."versioned_purl_id" AS "qualified_purl$versioned_purl_id",
                 "qualified_purl"."qualifiers" AS "qualified_purl$qualifiers",
@@ -228,7 +221,7 @@ impl VulnerabilityAdvisorySummary {
             -- find all sboms matching product versions
             JOIN "sbom" ON "product_version"."sbom_id" = "sbom"."sbom_id"
 
-            -- find purls belonging to the sboms having a name mathcing package patterns
+            -- find purls belonging to the sboms having a name matching package patterns
             JOIN base_purl on "product_status"."package" LIKE CONCAT("base_purl"."namespace", '/', "base_purl"."name") OR "product_status"."package" = "base_purl"."name"
             JOIN "versioned_purl" ON "versioned_purl"."base_purl_id" = "base_purl"."id"
             JOIN "qualified_purl" ON "qualified_purl"."versioned_purl_id" = "versioned_purl"."id"
@@ -454,8 +447,6 @@ struct SbomStatusCatcher {
     sbom_package: sbom_package::Model,
     sbom_node: sbom_node::Model,
     status: status::Model,
-    base_purl: base_purl::Model,
-    versioned_purl: versioned_purl::Model,
     qualified_purl: qualified_purl::Model,
 }
 
@@ -467,8 +458,6 @@ impl FromQueryResult for SbomStatusCatcher {
             sbom_package: Self::from_query_result_multi_model(res, "", sbom_package::Entity)?,
             sbom_node: Self::from_query_result_multi_model(res, "", sbom_node::Entity)?,
             status: Self::from_query_result_multi_model(res, "", status::Entity)?,
-            base_purl: Self::from_query_result_multi_model(res, "", base_purl::Entity)?,
-            versioned_purl: Self::from_query_result_multi_model(res, "", versioned_purl::Entity)?,
             qualified_purl: Self::from_query_result_multi_model(res, "", qualified_purl::Entity)?,
         })
     }
@@ -528,11 +517,7 @@ impl VulnerabilitySbomStatus {
                 .entry(status.status.slug.clone())
                 .or_insert(Default::default());
 
-            purl_status.insert(PurlSummary::from_entity(
-                &status.base_purl,
-                &status.versioned_purl,
-                &status.qualified_purl,
-            ));
+            purl_status.insert(PurlSummary::from_entity(&status.qualified_purl));
         }
 
         Ok(sboms.into_values().collect())


### PR DESCRIPTION
Instead of using the three PURL layers (base, version, qualifier) for building result PURLs, we only use the `purl` field from the qualified result, and evaluate the rest inline.

The allows us to reduce load on the database even more. I'll run a scale-test next.