### PR TITLE
perf: drop advisory_vulnerability_vulnerability_id_gist index for now

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -10,6 +10,7 @@ mod m0000030_perf_adv_vuln;
 mod m0000040_create_license_export;
 mod m0000050_perf_adv_vuln2;
 mod m0000060_perf_adv_vuln3;
+mod m0000070_perf_adv_vuln4;
 mod m0000970_alter_importer_add_heartbeat;
 
 pub struct Migrator;
@@ -25,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0000040_create_license_export::Migration),
             Box::new(m0000050_perf_adv_vuln2::Migration),
             Box::new(m0000060_perf_adv_vuln3::Migration),
+            Box::new(m0000070_perf_adv_vuln4::Migration),
         ]
     }
 }

--- a/migration/src/m0000070_perf_adv_vuln4.rs
+++ b/migration/src/m0000070_perf_adv_vuln4.rs
@@ -1,0 +1,34 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    DROP INDEX IF EXISTS advisory_vulnerability_vulnerability_id_gist;
+                ",
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "
+                    CREATE INDEX advisory_vulnerability_vulnerability_id_gist ON advisory_vulnerability USING GIST (vulnerability_id gist_trgm_ops);
+                ")
+            .await
+            .map(|_| ())?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
The `advisory_vulnerability_vulnerability_id_gist` considerably slows down `sbom/{id}/advisory` endpoint. Let's disable it for now, until we can further investigate it.