### PR TITLE
feat: filter components by partial matches of a purl and/or cpe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8392,6 +8392,7 @@ dependencies = [
  "tracing",
  "trustify-migration",
  "trustify-test-context",
+ "urlencoding",
  "utoipa",
  "uuid",
  "walker-common",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["url"] }
 uuid = { workspace = true, features = ["v5", "serde"] }
 walker-common = { workspace = true, features = ["bzip2", "liblzma"]}

--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -6,7 +6,7 @@ mod value;
 
 pub use columns::{Columns, IntoColumns};
 pub use filtering::Filtering;
-pub use value::Value;
+pub use value::{Valuable, Value};
 
 use filter::{Filter, Operator};
 use regex::Regex;
@@ -89,8 +89,8 @@ impl Query {
             } => context.get(f.as_str()).is_some_and(|field| match o {
                 Equal => vs.iter().any(|v| field.eq(v)),
                 NotEqual => vs.iter().all(|v| field.ne(v)),
-                Like => vs.iter().any(|v| field.contains(v)),
-                NotLike => vs.iter().all(|v| !field.contains(v)),
+                Like => vs.iter().any(|v| field.like(v)),
+                NotLike => vs.iter().all(|v| !field.like(v)),
                 GreaterThan => vs.iter().all(|v| field.gt(v)),
                 GreaterThanOrEqual => vs.iter().all(|v| field.ge(v)),
                 LessThan => vs.iter().all(|v| field.lt(v)),
@@ -103,7 +103,7 @@ impl Query {
                 ..
             } => context
                 .values()
-                .any(|field| vs.iter().any(|v| field.contains(v))),
+                .any(|field| vs.iter().any(|v| field.like(v))),
             _ => false,
         })
     }

--- a/common/src/db/query/filter.rs
+++ b/common/src/db/query/filter.rs
@@ -41,8 +41,8 @@ impl TryFrom<(&str, Operator, &Vec<String>, &Columns)> for Filter {
                     .map(
                         |s| match columns.translate(field, &operator.to_string(), s) {
                             Some(x) => q(&x).filter_for(columns),
-                            None => columns.for_field(field).and_then(|(expr, col_def)| {
-                                Arg::parse(s, col_def.get_column_type()).map(|v| Filter {
+                            None => columns.for_field(field).and_then(|(expr, ref ty)| {
+                                Arg::parse(s, ty).map(|v| Filter {
                                     operands: Operand::Simple(expr, v),
                                     operator,
                                 })

--- a/entity/src/qualified_purl.rs
+++ b/entity/src/qualified_purl.rs
@@ -237,6 +237,6 @@ mod test {
         )
         .unwrap();
         let cp1: CanonicalPurl = purl.clone().into();
-        assert_eq!(purl, cp1.into());
+        assert_eq!(purl, Purl::from(cp1));
     }
 }

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -4,24 +4,32 @@ use crate::{
     model::{PackageGraph, graph},
     service::{AnalysisService, ComponentReference, GraphQuery},
 };
+use ::cpe::{
+    component::Component,
+    cpe::{Cpe, CpeType, Language},
+    uri::OwnedUri,
+};
 use anyhow::anyhow;
 use petgraph::{Graph, prelude::NodeIndex};
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityOrSelect, EntityTrait,
-    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, QueryTrait, RelationTrait, Statement,
+    ColumnTrait, ColumnType, ConnectionTrait, DatabaseBackend, DbErr, EntityOrSelect, EntityTrait,
+    FromQueryResult, IntoIdentity, QueryFilter, QueryOrder, QuerySelect, QueryTrait, RelationTrait,
+    Statement,
 };
-use sea_query::{JoinType, Order, SelectStatement};
+use sea_query::{Expr, Func, JoinType, Order, SelectStatement, SimpleExpr};
 use serde_json::Value;
+use std::str::FromStr;
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     sync::Arc,
 };
 use tracing::{Level, instrument};
-use trustify_common::{cpe::Cpe, db::query::Filtering, purl::Purl};
+use trustify_common::db::query::IntoColumns;
+use trustify_common::{cpe::Cpe as TrustifyCpe, db::query::Filtering, purl::Purl};
 use trustify_entity::{
-    cpe::CpeDto, package_relates_to_package, relationship::Relationship, sbom, sbom_external_node,
-    sbom_external_node::ExternalType, sbom_node, sbom_package, sbom_package_cpe_ref,
-    sbom_package_purl_ref,
+    cpe, cpe::CpeDto, package_relates_to_package, relationship::Relationship, sbom,
+    sbom_external_node, sbom_external_node::ExternalType, sbom_node, sbom_package,
+    sbom_package_cpe_ref, sbom_package_purl_ref,
 };
 use uuid::Uuid;
 
@@ -188,13 +196,13 @@ fn to_purls(purls: Option<Vec<String>>) -> Vec<Purl> {
         .collect()
 }
 
-fn to_cpes(cpes: Option<Vec<Value>>) -> Vec<Cpe> {
+fn to_cpes(cpes: Option<Vec<Value>>) -> Vec<TrustifyCpe> {
     cpes.into_iter()
         .flatten()
         .flat_map(|cpe| {
             serde_json::from_value::<CpeDto>(cpe)
                 .ok()
-                .and_then(|cpe| Cpe::try_from(cpe).ok())
+                .and_then(|cpe| TrustifyCpe::try_from(cpe).ok())
         })
         .collect()
 }
@@ -237,9 +245,59 @@ impl AnalysisService {
                 .distinct()
                 .into_query(),
             GraphQuery::Query(query) => sbom_node::Entity::find()
-                .filtering(query.clone())?
+                .join(JoinType::Join, sbom_node::Relation::Package.def())
+                .join(JoinType::LeftJoin, sbom_package::Relation::Purl.def())
+                .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
+                .join(
+                    JoinType::LeftJoin,
+                    sbom_package_cpe_ref::Relation::Cpe.def(),
+                )
                 .select_only()
                 .column(sbom_node::Column::SbomId)
+                .filtering_with(
+                    query.clone(),
+                    sbom_node::Entity
+                        .columns()
+                        .add_columns(cpe::Entity.columns())
+                        .translator(|f, op, v| {
+                            match (f, op, OwnedUri::from_str(v)) {
+                                ("cpe", "=" | "~", Ok(cpe)) => {
+                                    // We break out cpe into its constituent columns in CPE table
+                                    let q = match (cpe.part(), cpe.language()) {
+                                        (CpeType::Any, Language::Any) => String::new(),
+                                        (CpeType::Any, l) => format!("language={l}"),
+                                        (p, Language::Any) => format!("part={p}"),
+                                        (p, l) => format!("part={p}&language={l}"),
+                                    };
+                                    let translated = [
+                                        ("vendor", cpe.vendor()),
+                                        ("product", cpe.product()),
+                                        ("version", cpe.version()),
+                                        ("update", cpe.update()),
+                                        ("edition", cpe.edition()),
+                                    ]
+                                    .iter()
+                                    .fold(q, |acc, (k, v)| match v {
+                                        Component::Value(s) => format!("{acc}&{k}={s}|*"),
+                                        _ => acc,
+                                    });
+                                    Some(translated)
+                                }
+                                ("cpe", "~", Err(_)) => Some(v.into()),
+                                ("cpe", _, Err(e)) => Some(e.to_string()),
+                                ("cpe", _, _) => Some("illegal operation for cpe".into()),
+                                _ => None,
+                            }
+                        })
+                        .add_expr(
+                            "purl",
+                            SimpleExpr::FunctionCall(
+                                Func::cust("get_purl".into_identity())
+                                    .arg(Expr::col(sbom_package_purl_ref::Column::QualifiedPurlId)),
+                            ),
+                            ColumnType::Text,
+                        ),
+                )?
                 .distinct()
                 .into_query(),
         };

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -426,14 +426,14 @@ impl AnalysisService {
             }
             GraphQuery::Query(query) => graph.node_weight(i).is_some_and(|node| {
                 let purls: Vec<_> = match node {
-                    graph::Node::Package(p) => p.purl.iter().map(|p| p.to_string()).collect(),
+                    graph::Node::Package(p) => p.purl.iter().map(|p| Value::Custom(p)).collect(),
                     _ => vec![],
                 };
                 let mut context = HashMap::from([
                     ("sbom_id", Value::String(&node.sbom_id)),
                     ("node_id", Value::String(&node.node_id)),
                     ("name", Value::String(&node.name)),
-                    ("purl", Value::from(&purls)),
+                    ("purl", Value::Array(purls)),
                 ]);
                 match node {
                     graph::Node::Package(package) => {

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -425,19 +425,18 @@ impl AnalysisService {
                 })
             }
             GraphQuery::Query(query) => graph.node_weight(i).is_some_and(|node| {
-                let purls: Vec<_> = match node {
-                    graph::Node::Package(p) => p.purl.iter().map(|p| Value::Custom(p)).collect(),
-                    _ => vec![],
-                };
                 let mut context = HashMap::from([
                     ("sbom_id", Value::String(&node.sbom_id)),
                     ("node_id", Value::String(&node.node_id)),
                     ("name", Value::String(&node.name)),
-                    ("purl", Value::Array(purls)),
                 ]);
                 match node {
                     graph::Node::Package(package) => {
-                        context.extend([("version", Value::String(&package.version))]);
+                        context.extend([
+                            ("version", Value::String(&package.version)),
+                            ("purl", Value::from(&package.purl)),
+                            ("cpe", Value::from(&package.cpe)),
+                        ]);
                     }
                     graph::Node::External(external) => {
                         context.extend([


### PR DESCRIPTION
Fixes: #1280

Added the proper logic to translate CPE queries into their constituent columns and Purl queries into comparisons against the `get_purl()` proc, which stringifies the associated JSON blob in the database.

This accounts for the loading of the graph. The fact that both `Cpe` and `Purl` structs now implement Valuable accounts for querying the graph, i.e. applying the query to a context constructed from the graph.