### PR TITLE
account for null namespace when textifying a qualified purl

### DIFF
--- a/migration/src/m0000010_init_up.sql
+++ b/migration/src/m0000010_init_up.sql
@@ -634,7 +634,7 @@ BEGIN
 SELECT
     COALESCE(
             'pkg:' || bp.type ||
-            '/' || COALESCE(bp.namespace, '') || '/' ||
+            replace(('/' || COALESCE(bp.namespace, '') || '/'), '//', '/') ||
             bp.name ||
             '@' || vp.version ||
             CASE


### PR DESCRIPTION
fixes #1440