### PR TITLE
Revert "account for null namespace when textifying a qualified purl"

### DIFF
--- a/migration/src/m0000010_init_up.sql
+++ b/migration/src/m0000010_init_up.sql
@@ -634,7 +634,7 @@ BEGIN
 SELECT
     COALESCE(
             'pkg:' || bp.type ||
-            replace(('/' || COALESCE(bp.namespace, '') || '/'), '//', '/') ||
+            '/' || COALESCE(bp.namespace, '') || '/' ||
             bp.name ||
             '@' || vp.version ||
             CASE


### PR DESCRIPTION
fixes #1447

This reverts commit 5e1075324e8821c8a636725c7da004127882cd2f.