### PR TITLE
feat: add analyze endpoint for purl-based vulnerability scan

### DIFF
--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -2,15 +2,14 @@
 mod test;
 
 use crate::{
-    Error,
-    Error::Internal,
+    Error::{self, Internal},
     endpoints::Deprecation,
     vulnerability::{
-        model::{VulnerabilityDetails, VulnerabilitySummary},
+        model::{AnalysisRequest, AnalysisResponse, VulnerabilityDetails, VulnerabilitySummary},
         service::VulnerabilityService,
     },
 };
-use actix_web::{HttpResponse, Responder, delete, get, web};
+use actix_web::{HttpResponse, Responder, ResponseError, delete, get, post, web};
 use sea_orm::TransactionTrait;
 use trustify_auth::{DeleteVulnerability, ReadAdvisory, authorizer::Require};
 use trustify_common::{
@@ -25,7 +24,8 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
         .app_data(web::Data::new(db))
         .service(all)
         .service(delete)
-        .service(get);
+        .service(get)
+        .service(analyze);
 }
 
 #[utoipa::path(
@@ -130,5 +130,32 @@ pub async fn delete(
         }
     } else {
         Ok(HttpResponse::NotFound().finish())
+    }
+}
+
+#[utoipa::path(
+  operation_id = "analyze",
+  tag = "vulnerability",
+  request_body = AnalysisRequest,
+  responses(
+      (status = 200, description = "Analyze the provided purls to search for known vulnerabilities", body = AnalysisResponse),
+  ),
+)]
+#[post("/v2/vulnerability/analyze")]
+/// Analyze the provided purls for the known vulnerabilities
+pub async fn analyze(
+    service: web::Data<VulnerabilityService>,
+    db: web::Data<Database>,
+    request: web::Json<AnalysisRequest>,
+    _: Require<ReadAdvisory>,
+) -> actix_web::Result<impl Responder> {
+    let purls: Vec<&str> = request.purls.iter().map(|s| s.as_str()).collect();
+    match service.analyze_purls(purls, db.as_ref()).await {
+        Ok(details) => Ok(HttpResponse::Ok().json(details)),
+        Err(error) => match error {
+            Error::BadRequest(_) => Ok(error.error_response()),
+            _ => Ok(HttpResponse::InternalServerError()
+                .body(format!("Error analyzing purls: {}", error))),
+        },
     }
 }

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,6 +1,8 @@
 mod details;
 mod summary;
 
+use std::{collections::HashMap, ops::Deref};
+
 use async_graphql::SimpleObject;
 pub use details::*;
 use sea_orm::{ColumnTrait, ConnectionTrait, ModelTrait, QueryFilter};
@@ -124,5 +126,21 @@ impl VulnerabilityHead {
             released: advisory_vulnerability.release_date,
             cwes: advisory_vulnerability.cwes.clone().unwrap_or_default(),
         }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisRequest {
+    pub purls: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisResponse(HashMap<String, Vec<VulnerabilityDetails>>);
+
+impl Deref for AnalysisResponse {
+    type Target = HashMap<String, Vec<VulnerabilityDetails>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,8 +1,14 @@
+use std::{collections::HashMap, str::FromStr};
+
 use crate::{
     Error,
     vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
 };
-use sea_orm::{EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait, prelude::*};
+use futures_util::{TryFutureExt, TryStreamExt};
+use sea_orm::{
+    EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait, Statement, StreamTrait,
+    prelude::*,
+};
 use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
 use trustify_common::{
     db::{
@@ -11,6 +17,7 @@ use trustify_common::{
         query::{Columns, Filtering, Query},
     },
     model::{Paginated, PaginatedResults},
+    purl::{Purl, PurlErr},
 };
 use trustify_entity::{
     cvss3::{self, Severity},
@@ -154,6 +161,103 @@ impl VulnerabilityService {
         let result = query.exec(connection).await?;
 
         Ok(result.rows_affected)
+    }
+
+    pub async fn analyze_purls<C>(
+        &self,
+        purls: Vec<&str>,
+        connection: &C,
+    ) -> Result<HashMap<String, Vec<VulnerabilityDetails>>, Error>
+    where
+        C: ConnectionTrait + StreamTrait,
+    {
+        let query = purls
+            .iter()
+            .map(|p| {
+                let purl = Purl::from_str(p)?;
+
+                let ns_condition = match &purl.namespace {
+                    Some(namespace) => {
+                        let sql = "base_purl.namespace = $1";
+                        Statement::from_sql_and_values(
+                            connection.get_database_backend(),
+                            sql,
+                            [namespace.into()],
+                        )
+                    }
+                    None => Statement::from_string(
+                        connection.get_database_backend(),
+                        "base_purl.namespace IS NULL",
+                    ),
+                };
+
+                let values = [
+                    p.to_string().into(),
+                    purl.name.into(),
+                    purl.ty.into(),
+                    purl.version.ok_or_else(|| PurlErr::MissingVersion(p.to_string()))?.into(),
+                ];
+                let sql = format!(r#"
+                  SELECT $1 as requested_purl,
+                    vulnerability.id, vulnerability.title, vulnerability.reserved,
+                    vulnerability.published, vulnerability.modified, vulnerability.withdrawn, vulnerability.cwes
+                  FROM base_purl
+                    LEFT JOIN purl_status ON base_purl.id = purl_status.base_purl_id
+                    INNER JOIN version_range ON purl_status.version_range_id = version_range.id
+                    LEFT JOIN vulnerability ON purl_status.vulnerability_id = vulnerability.id
+                    INNER JOIN status ON purl_status.status_id = status.id
+                  WHERE {ns_condition}
+                    AND base_purl.name = $2
+                    AND base_purl.type = $3
+                    AND version_matches($4, version_range.*) = TRUE
+                    AND status.slug != 'fixed'"#);
+                let query =
+                    Statement::from_sql_and_values(connection.get_database_backend(), &sql, values);
+                Ok(query.to_string())
+            })
+            .collect::<Result<Vec<String>, Error>>()?
+            .join(" UNION ALL ");
+
+        let stmt = Statement::from_string(connection.get_database_backend(), query);
+        let result = connection.stream(stmt).map_err(Error::from).await?;
+        let result = result
+            .map_err(Error::from)
+            .and_then(|row| self.to_vuln(row, connection))
+            .try_fold(
+                HashMap::new(),
+                |mut acc: HashMap<String, Vec<VulnerabilityDetails>>,
+                 (requested_purl, vuln_details)| async {
+                    acc.entry(requested_purl).or_default().push(vuln_details);
+                    Ok(acc)
+                },
+            )
+            .await?;
+
+        Ok(result)
+    }
+
+    async fn to_vuln<C: ConnectionTrait>(
+        &self,
+        row: QueryResult,
+        connection: &C,
+    ) -> Result<(String, VulnerabilityDetails), Error> {
+        let requested_purl: String = row.try_get("", "requested_purl")?;
+        let vulnerability = vulnerability::Model {
+            id: row.try_get("", "id")?,
+            title: row.try_get("", "title")?,
+            reserved: row.try_get("", "reserved")?,
+            published: row.try_get("", "published")?,
+            modified: row.try_get("", "modified")?,
+            withdrawn: row.try_get("", "withdrawn")?,
+            cwes: row.try_get("", "cwes")?,
+        };
+        let vuln_details =
+            VulnerabilityDetails::from_entity(&vulnerability, Deprecation::Ignore, connection)
+                .await;
+        match vuln_details {
+            Ok(details) => Ok((requested_purl, details)),
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -423,3 +423,52 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 
     Ok(())
 }
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = VulnerabilityService::new();
+
+    ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "osv/GHSA-2ccf-ffrj-m4qw.json"])
+        .await?;
+
+    let result = service.analyze_purls(vec![], &ctx.db).await?;
+
+    assert!(result.is_empty());
+
+    for purl in ["this is not valid", "pkg:npm/missing.version"].iter() {
+        let result = service.analyze_purls(vec![purl], &ctx.db).await;
+        assert!(result.is_err());
+    }
+
+    let expected = [
+        "pkg:npm/%40fastify/passport@1.0.0", // ECOSYSTEM:afected
+        "pkg:cargo/hyper@0.14.9",            // SEMVER:affected - no namespace
+    ];
+
+    let not_found = [
+        "pkg:npm/%40fastify/passport@2.3.0", // ECOSYSTEM:fixed
+        "pkg:golang/github.com/metal3-io/baremetal-operator/apis@0.8.0", // Missing
+        "pkg:cargo/hyper@0.14.11",           // SEMVER:fixed - no namespace
+    ];
+
+    let items: Vec<&str> = expected.iter().chain(&not_found).copied().collect();
+
+    let result = service.analyze_purls(items, &ctx.db).await?;
+
+    expected.iter().for_each(|&item| {
+        assert!(
+            result.contains_key(item),
+            "Expected key '{}' not found in result",
+            item
+        )
+    });
+    not_found.iter().for_each(|&item| {
+        assert!(
+            !result.contains_key(item),
+            "Unexpected key '{}' found in result",
+            item
+        )
+    });
+    Ok(())
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1624,6 +1624,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_VulnerabilitySummary'
+  /api/v2/vulnerability/analyze:
+    post:
+      tags:
+      - vulnerability
+      summary: Analyze the provided purls for the known vulnerabilities
+      operationId: analyze
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalysisRequest'
+        required: true
+      responses:
+        '200':
+          description: Analyze the provided purls to search for known vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalysisResponse'
   /api/v2/vulnerability/{id}:
     get:
       tags:
@@ -1886,6 +1905,23 @@ components:
               All CVSS3 scores from the advisory for the given vulnerability.
               May include several, varying by minor version of the CVSS3 vector.
       description: Summary of information from this advisory regarding a single specific vulnerability.
+    AnalysisRequest:
+      type: object
+      required:
+      - purls
+      properties:
+        purls:
+          type: array
+          items:
+            type: string
+    AnalysisResponse:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: '#/components/schemas/VulnerabilityDetails'
+      propertyNames:
+        type: string
     AnalysisStatus:
       type: object
       required:


### PR DESCRIPTION
Fix #1449 

The proposed solution evaluates if the provided purls are within the range of the vulnerable versions available in the database.

It returns a HashMap where the key is the purl and the value is a Vector containing the vulnerabilities.

Drop endpoint added it #1425 because it is not needed from any client and this endpoint implements what the other endpoint was meant for.