### PR TITLE
fix: purl components now properly encoded in Display impl

### DIFF
--- a/common/src/purl.rs
+++ b/common/src/purl.rs
@@ -1,6 +1,5 @@
 use deepsize::DeepSizeOf;
 use packageurl::PackageUrl;
-use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use sea_orm::FromJsonQueryResult;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -9,7 +8,7 @@ use serde::{
 use std::{borrow::Cow, cmp::Ordering};
 use std::{
     collections::BTreeMap,
-    fmt::{Debug, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     hash::Hash,
     str::FromStr,
 };
@@ -83,6 +82,13 @@ const NAMESPACE: Uuid = Uuid::from_bytes([
 ]);
 
 impl Purl {
+    // clone from self with the passed version
+    pub fn with_version<T: ToString>(&self, version: T) -> Self {
+        let mut result = self.clone();
+        result.version = Some(version.to_string());
+        result
+    }
+
     pub fn package_uuid(&self) -> Uuid {
         let mut result = Uuid::new_v5(&NAMESPACE, self.ty.as_bytes());
         if let Some(namespace) = &self.namespace {
@@ -194,67 +200,19 @@ impl Visitor<'_> for PurlVisitor {
     }
 }
 
-const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS
-    .add(b' ') // Space must be encoded as %20 or +.
-    .add(b'"') // Double quote
-    .add(b'#') // Fragment identifier
-    .add(b'<') // Less than
-    .add(b'>') // Greater than
-    .add(b'[') // Left square bracket
-    .add(b']') // Right square bracket
-    .add(b'{') // Left curly brace
-    .add(b'}') // Right curly brace
-    .add(b'|') // Pipe
-    .add(b'\\') // Backslash
-    .add(b'^') // Caret
-    .add(b'`') // Backtick
-    .add(b'~') // Tilde
-    .add(b'@') // At sign
-    .add(b'!') // Exclamation mark
-    .add(b'$') // Dollar sign
-    .add(b'&') // Ampersand
-    .add(b'\'') // Single quote
-    .add(b'(') // Left parenthesis
-    .add(b')') // Right parenthesis
-    .add(b'*') // Asterisk
-    .add(b'+') // Plus
-    .add(b',') // Comma
-    .add(b';') // Semicolon
-    .add(b'=') // Equals
-    .add(b'%'); // Percent itself.
-
 impl Display for Purl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let ns = if let Some(ns) = &self.namespace {
-            format!("/{}", ns)
-        } else {
-            "".to_string()
-        };
-
-        let qualifiers = if self.qualifiers.is_empty() {
-            "".to_string()
-        } else {
-            format!(
-                "?{}",
-                self.qualifiers
-                    .iter()
-                    .map(|(k, v)| format!("{}={}", k, utf8_percent_encode(v, QUERY_ENCODE_SET)))
-                    .collect::<Vec<_>>()
-                    .join("&")
-            )
-        };
-
-        let version = if let Some(version) = &self.version {
-            format!("@{}", version)
-        } else {
-            "".to_string()
-        };
-
-        write!(
-            f,
-            "pkg:{}{}/{}{}{}",
-            self.ty, ns, self.name, version, qualifiers
-        )
+        let mut purl = PackageUrl::new(&self.ty, &self.name).map_err(|_| fmt::Error)?;
+        if let Some(ns) = &self.namespace {
+            purl.with_namespace(ns);
+        }
+        if let Some(version) = &self.version {
+            purl.with_version(version);
+        }
+        for (key, value) in &self.qualifiers {
+            purl.add_qualifier(key, value).map_err(|_| fmt::Error)?;
+        }
+        Display::fmt(&purl, f)
     }
 }
 
@@ -437,6 +395,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(purl1, purl2);
+        Ok(())
+    }
+
+    #[test(tokio::test)]
+    async fn purl_encoding() -> Result<(), anyhow::Error> {
+        let purl = Purl::from_str("pkg:npm/@fastify/this@that@3.8-%236.el8")?;
+        assert_eq!(
+            purl.to_string().as_str(),
+            "pkg:npm/%40fastify/this%40that@3.8-%236.el8"
+        );
+
         Ok(())
     }
 }

--- a/modules/ingestor/src/graph/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/graph/sbom/clearly_defined.rs
@@ -69,8 +69,7 @@ impl Curation {
     pub fn iter(&self) -> impl Iterator<Item = (Purl, String)> + '_ {
         self.revisions.iter().flat_map(|(version, details)| {
             if let Some(licensed) = &details.licensed {
-                let mut purl = self.coordinates.base_purl();
-                purl.version = Some(version.clone());
+                let purl = self.coordinates.base_purl().with_version(version);
                 Some((purl, licensed.declared.clone()))
             } else {
                 None

--- a/modules/ingestor/src/service/advisory/cve/divination.rs
+++ b/modules/ingestor/src/service/advisory/cve/divination.rs
@@ -1,5 +1,7 @@
 //! Helpers to try to divine pURLs from arbitrary bits of information.
 
+use std::str::FromStr;
+
 use cve::common::Product;
 use trustify_common::purl::Purl;
 
@@ -17,17 +19,9 @@ fn divine_maven(product: &Product) -> Option<Purl> {
             if parts.len() == 2 {
                 let group_id = parts[0];
                 let artifact_id = parts[1];
-
-                return Some(Purl {
-                    ty: "maven".to_string(),
-                    namespace: Some(group_id.to_string()),
-                    name: artifact_id.to_string(),
-                    version: None,
-                    qualifiers: Default::default(),
-                });
+                return Purl::from_str(&format!("pkg:maven/{group_id}/{artifact_id}")).ok();
             }
         }
     }
-
     None
 }

--- a/modules/ingestor/src/service/advisory/osv/loader.rs
+++ b/modules/ingestor/src/service/advisory/osv/loader.rs
@@ -134,9 +134,7 @@ impl<'g> OsvLoader<'g> {
                 for purl in purls {
                     // iterate through the known versions, apply the version, and create them
                     for version in affected.versions.iter().flatten() {
-                        let mut purl = purl.clone();
-                        purl.version = Some(version.clone());
-                        purl_creator.add(purl);
+                        purl_creator.add(purl.with_version(version));
                     }
 
                     for range in affected.ranges.iter().flatten() {


### PR DESCRIPTION
Also added a with_version() helper to avoid some mutability. I'd like to hide all the public fields at some point, as their pub-ness still allows improper encoding, but that's a bigger change.