### PR TITLE
clean up the api endpoint namespace a bit

### DIFF
--- a/modules/fundamental/src/license/endpoints/spdx.rs
+++ b/modules/fundamental/src/license/endpoints/spdx.rs
@@ -8,7 +8,7 @@ use trustify_common::{
 };
 
 #[utoipa::path(
-    tag = "licenses",
+    tag = "license",
     operation_id = "listSpdxLicenses",
     params(
         Query,
@@ -31,7 +31,7 @@ pub async fn list_spdx_licenses(
 }
 
 #[utoipa::path(
-    tag = "licenses",
+    tag = "license",
     operation_id = "getSpdxLicense",
     responses(
         (status = 200, description = "SPDX license details", body = SpdxLicenseDetails),

--- a/modules/fundamental/src/license/endpoints/spdx.rs
+++ b/modules/fundamental/src/license/endpoints/spdx.rs
@@ -8,7 +8,7 @@ use trustify_common::{
 };
 
 #[utoipa::path(
-    tag = "spdx license",
+    tag = "licenses",
     operation_id = "listSpdxLicenses",
     params(
         Query,
@@ -31,7 +31,7 @@ pub async fn list_spdx_licenses(
 }
 
 #[utoipa::path(
-    tag = "spdx license",
+    tag = "licenses",
     operation_id = "getSpdxLicense",
     responses(
         (status = 200, description = "SPDX license details", body = SpdxLicenseDetails),

--- a/modules/fundamental/src/organization/endpoints/mod.rs
+++ b/modules/fundamental/src/organization/endpoints/mod.rs
@@ -23,7 +23,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 }
 
 #[utoipa::path(
-    tag = "organization",
+    tag = "admin",
     operation_id = "listOrganizations",
     params(
         Query,
@@ -50,7 +50,7 @@ pub async fn all(
 }
 
 #[utoipa::path(
-    tag = "organization",
+    tag = "admin",
     operation_id = "getOrganization",
     params(
         ("id", Path, description = "Opaque ID of the organization")

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -16,7 +16,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 }
 
 #[utoipa::path(
-    tag = "weakness",
+    tag = "licenses",
     operation_id = "listWeaknesses",
     params(
         Query,
@@ -38,7 +38,7 @@ pub async fn list_weaknesses(
 }
 
 #[utoipa::path(
-    tag = "weakness",
+    tag = "licenses",
     operation_id = "getWeakness",
     responses(
         (status = 200, description = "The weakness", body = LicenseSummary),

--- a/modules/fundamental/src/weakness/endpoints/mod.rs
+++ b/modules/fundamental/src/weakness/endpoints/mod.rs
@@ -16,7 +16,7 @@ pub fn configure(config: &mut utoipa_actix_web::service_config::ServiceConfig, d
 }
 
 #[utoipa::path(
-    tag = "licenses",
+    tag = "license",
     operation_id = "listWeaknesses",
     params(
         Query,
@@ -38,7 +38,7 @@ pub async fn list_weaknesses(
 }
 
 #[utoipa::path(
-    tag = "licenses",
+    tag = "license",
     operation_id = "getWeakness",
     responses(
         (status = 200, description = "The weakness", body = LicenseSummary),

--- a/modules/ingestor/src/endpoints.rs
+++ b/modules/ingestor/src/endpoints.rs
@@ -43,7 +43,7 @@ struct UploadParams {
 }
 
 #[utoipa::path(
-    tag = "dataset",
+    tag = "admin",
     operation_id = "uploadDataset",
     request_body = inline(BinaryData),
     params(UploadParams),

--- a/modules/user/src/endpoints.rs
+++ b/modules/user/src/endpoints.rs
@@ -16,7 +16,7 @@ pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: 
 }
 
 #[utoipa::path(
-    tag = "userPreferences",
+    tag = "admin",
     operation_id = "getUserPreferences",
     params(
         ("key", Path, description = "The key to the user preferences"),
@@ -49,7 +49,7 @@ async fn get(
 }
 
 #[utoipa::path(
-    tag = "userPreferences",
+    tag = "admin",
     operation_id = "setUserPreferences",
     request_body = serde_json::Value,
     params(
@@ -94,7 +94,7 @@ async fn set(
 }
 
 #[utoipa::path(
-    tag = "userPreferences",
+    tag = "admin",
     operation_id = "deleteUserPreferences",
     request_body = serde_json::Value,
     params(

--- a/modules/user/src/endpoints.rs
+++ b/modules/user/src/endpoints.rs
@@ -16,7 +16,7 @@ pub fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfig, db: 
 }
 
 #[utoipa::path(
-    tag = "admin",
+    tag = "user",
     operation_id = "getUserPreferences",
     params(
         ("key", Path, description = "The key to the user preferences"),
@@ -49,7 +49,7 @@ async fn get(
 }
 
 #[utoipa::path(
-    tag = "admin",
+    tag = "user",
     operation_id = "setUserPreferences",
     request_body = serde_json::Value,
     params(
@@ -94,7 +94,7 @@ async fn set(
 }
 
 #[utoipa::path(
-    tag = "admin",
+    tag = "user",
     operation_id = "deleteUserPreferences",
     request_body = serde_json::Value,
     params(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -717,7 +717,7 @@ paths:
   /api/v2/license/spdx/license:
     get:
       tags:
-      - licenses
+      - license
       summary: List SPDX licenses
       operationId: listSpdxLicenses
       parameters:
@@ -763,7 +763,7 @@ paths:
   /api/v2/license/spdx/license/{id}:
     get:
       tags:
-      - licenses
+      - license
       summary: Get SPDX license details
       operationId: getSpdxLicense
       parameters:
@@ -1517,7 +1517,7 @@ paths:
   /api/v2/userPreference/{key}:
     get:
       tags:
-      - admin
+      - user
       summary: Get user preferences
       operationId: getUserPreferences
       parameters:
@@ -1542,7 +1542,7 @@ paths:
           description: Unknown user preference key
     put:
       tags:
-      - admin
+      - user
       summary: Set user preferences
       operationId: setUserPreferences
       parameters:
@@ -1577,7 +1577,7 @@ paths:
           description: The provided If-Match revision did not match the actual revision
     delete:
       tags:
-      - admin
+      - user
       summary: Delete user preferences
       operationId: deleteUserPreferences
       parameters:
@@ -1697,7 +1697,7 @@ paths:
   /api/v2/weakness:
     get:
       tags:
-      - licenses
+      - license
       summary: List weaknesses
       operationId: listWeaknesses
       parameters:
@@ -1743,7 +1743,7 @@ paths:
   /api/v2/weakness/{id}:
     get:
       tags:
-      - licenses
+      - license
       summary: Retrieve weakness details
       operationId: getWeakness
       parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -449,7 +449,7 @@ paths:
   /api/v2/dataset:
     post:
       tags:
-      - dataset
+      - admin
       summary: Upload a new dataset
       operationId: uploadDataset
       parameters:
@@ -717,7 +717,7 @@ paths:
   /api/v2/license/spdx/license:
     get:
       tags:
-      - spdx license
+      - licenses
       summary: List SPDX licenses
       operationId: listSpdxLicenses
       parameters:
@@ -763,7 +763,7 @@ paths:
   /api/v2/license/spdx/license/{id}:
     get:
       tags:
-      - spdx license
+      - licenses
       summary: Get SPDX license details
       operationId: getSpdxLicense
       parameters:
@@ -782,7 +782,7 @@ paths:
   /api/v2/organization:
     get:
       tags:
-      - organization
+      - admin
       summary: List organizations
       operationId: listOrganizations
       parameters:
@@ -828,7 +828,7 @@ paths:
   /api/v2/organization/{id}:
     get:
       tags:
-      - organization
+      - admin
       summary: Retrieve organization details
       operationId: getOrganization
       parameters:
@@ -1517,7 +1517,7 @@ paths:
   /api/v2/userPreference/{key}:
     get:
       tags:
-      - userPreferences
+      - admin
       summary: Get user preferences
       operationId: getUserPreferences
       parameters:
@@ -1542,7 +1542,7 @@ paths:
           description: Unknown user preference key
     put:
       tags:
-      - userPreferences
+      - admin
       summary: Set user preferences
       operationId: setUserPreferences
       parameters:
@@ -1577,7 +1577,7 @@ paths:
           description: The provided If-Match revision did not match the actual revision
     delete:
       tags:
-      - userPreferences
+      - admin
       summary: Delete user preferences
       operationId: deleteUserPreferences
       parameters:
@@ -1697,7 +1697,7 @@ paths:
   /api/v2/weakness:
     get:
       tags:
-      - weakness
+      - licenses
       summary: List weaknesses
       operationId: listWeaknesses
       parameters:
@@ -1743,7 +1743,7 @@ paths:
   /api/v2/weakness/{id}:
     get:
       tags:
-      - weakness
+      - licenses
       summary: Retrieve weakness details
       operationId: getWeakness
       parameters:


### PR DESCRIPTION
relates #1453

Moves license-related endpoints beneath "licences"

Collects admin-related endpoints beneath "admin"

As most of these are currently unused, I think, we can move them around as the UX coagulates.