### PR TITLE
ci: add branch cherry-pick automation

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,17 @@
+name: backport
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  cherry_pick_job:
+    permissions:
+      pull-requests: write
+      contents: write
+    if: github.event.pull_request.merged == true
+    secrets: inherit
+    uses: trustification/release-tools/.github/workflows/backport.yaml@main


### PR DESCRIPTION
This PR should connect this repository to the release-tools cherry-pick automation across branches.

Generally speaking this is how it should work:
- Every PR that needs to be backport its changes to another branch e.g. `release/0.2.z.` needs to have a label indicating the desire to do so. 

Setting this PR as draft just because I'd like double-check the status of the release-tools repository. And set exact instructions and avoid confusion