### PR TITLE
feat: add pg_stats to the compose database

### DIFF
--- a/etc/deploy/compose/compose.yaml
+++ b/etc/deploy/compose/compose.yaml
@@ -9,4 +9,4 @@ services:
     restart: always
     shm_size: '1g'
     command: >
-      postgres -c random_page_cost=1.1 -c max_parallel_workers_per_gather=4
+      postgres -c random_page_cost=1.1 -c max_parallel_workers_per_gather=4 -c shared_preload_libraries='pg_stat_statements'


### PR DESCRIPTION
Unless this hurts a local setup, I'd like to have this enabled by default.