### PR TITLE
fix: set title for vunerabilities with non typical description language code

### DIFF
--- a/e2e/ds3.hurl
+++ b/e2e/ds3.hurl
@@ -26,3 +26,11 @@ HTTP 200
 
 [Asserts]
 jsonpath "$.advisories[*].status[*].vulnerability.published" not isEmpty
+
+
+# Check vulnerability title
+GET http://localhost:8080/api/v2/vulnerability/CVE-2023-21971
+HTTP 200
+
+[Asserts]
+jsonpath "$.title" not isEmpty

--- a/etc/datasets/ds3/cve/2024/CVE-2024-1300.json
+++ b/etc/datasets/ds3/cve/2024/CVE-2024-1300.json
@@ -1,0 +1,744 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2024-1300",
+        "assignerOrgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+        "state": "PUBLISHED",
+        "assignerShortName": "redhat",
+        "dateReserved": "2024-02-07T07:11:11.156Z",
+        "datePublished": "2024-04-02T07:33:05.215Z",
+        "dateUpdated": "2025-03-03T16:41:15.639Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Io.vertx:vertx-core: memory leak when a tcp server is configured with tls and sni support",
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "value": "Moderate",
+                            "namespace": "https://access.redhat.com/security/updates/classification/"
+                        },
+                        "type": "Red Hat severity rating"
+                    }
+                },
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "LOW",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "LOW",
+                        "baseScore": 5.4,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "LOW",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "LOW",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A vulnerability in the Eclipse Vert.x toolkit causes a memory leak in TCP servers configured with TLS and SNI support. When processing an unknown SNI server name assigned the default certificate instead of a mapped certificate, the SSL context is erroneously cached in the server name map, leading to memory exhaustion. This flaw allows attackers to send TLS client hello messages with fake server names, triggering a JVM out-of-memory error."
+                }
+            ],
+            "affected": [
+                {
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "4.3.4",
+                            "versionType": "semver",
+                            "lessThanOrEqual": "4.5.2"
+                        }
+                    ],
+                    "packageName": "io.vertx:vertx-core",
+                    "collectionURL": "https://vertx.io/docs/vertx-core/java/",
+                    "defaultStatus": "unaffected"
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "CEQ 3.2",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "defaultStatus": "unaffected",
+                    "packageName": "vertx-core",
+                    "cpes": [
+                        "cpe:/a:redhat:camel_quarkus:3"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/cryostat-grafana-dashboard-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-7",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/cryostat-operator-bundle",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/cryostat-reports-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/cryostat-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/cryostat-rhel8-operator",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-9",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Cryostat 2 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "cryostat-tech-preview/jfr-datasource-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "2.4.0-4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:cryostat:2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Migration Toolkit for Runtimes 1 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "mtr/mtr-operator-bundle",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "1.2-18",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:migration_toolkit_runtimes:1.0::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Migration Toolkit for Runtimes 1 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "mtr/mtr-rhel8-operator",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "1.2-11",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:migration_toolkit_runtimes:1.0::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Migration Toolkit for Runtimes 1 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "mtr/mtr-web-container-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "1.2-12",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:migration_toolkit_runtimes:1.0::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Migration Toolkit for Runtimes 1 on RHEL 8",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "mtr/mtr-web-executor-container-rhel8",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "1.2-10",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:migration_toolkit_runtimes:1.0::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "MTA-6.2-RHEL-9",
+                    "collectionURL": "https://catalog.redhat.com/software/containers/",
+                    "packageName": "mta/mta-windup-addon-rhel9",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "6.2.3-2",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:migration_toolkit_applications:6.2::el9",
+                        "cpe:/a:redhat:migration_toolkit_applications:6.2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat AMQ Streams 2.7.0",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "defaultStatus": "unaffected",
+                    "packageName": "vertx-core",
+                    "cpes": [
+                        "cpe:/a:redhat:amq_streams:2"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Apache Camel 4.4.1 for Spring Boot",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "defaultStatus": "unaffected",
+                    "packageName": "vertx-core",
+                    "cpes": [
+                        "cpe:/a:redhat:apache_camel_spring_boot:4.4.1"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Quarkus 3.2.11.Final",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "io.vertx/vertx-core",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "4.4.8.redhat-00001",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:quarkus:3.2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "RHINT Service Registry 2.5.11 GA",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "defaultStatus": "unaffected",
+                    "packageName": "vertx-core",
+                    "cpes": [
+                        "cpe:/a:redhat:service_registry:2.5"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "A-MQ Clients 2",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:a_mq_clients:2"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "OpenShift Serverless",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:serverless:1"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat AMQ Broker 7",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:amq_broker:7"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Apache Camel for Spring Boot 3",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:camel_spring_boot:3"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Build of Keycloak",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:build_keycloak:"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of OptaPlanner 8",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:optaplanner:::el6"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Quarkus",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "io.vertx/vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:quarkus:2"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Data Grid 8",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_data_grid:8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Fuse 7",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_fuse:7"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Integration Camel K 1",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:integration:1"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Integration Camel Quarkus 2",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:camel_quarkus:2"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat JBoss Data Grid 7",
+                    "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_data_grid:7"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat JBoss Enterprise Application Platform 7",
+                    "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_enterprise_application_platform:7"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat JBoss Enterprise Application Platform 8",
+                    "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_enterprise_application_platform:8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat JBoss Enterprise Application Platform Expansion Pack",
+                    "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jbosseapxp"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Process Automation 7",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "vertx-core",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_enterprise_bpms_platform:7"
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1662",
+                    "name": "RHSA-2024:1662",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1706",
+                    "name": "RHSA-2024:1706",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1923",
+                    "name": "RHSA-2024:1923",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:2088",
+                    "name": "RHSA-2024:2088",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:2833",
+                    "name": "RHSA-2024:2833",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:3527",
+                    "name": "RHSA-2024:3527",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:3989",
+                    "name": "RHSA-2024:3989",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:4884",
+                    "name": "RHSA-2024:4884",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-1300",
+                    "tags": [
+                        "vdb-entry",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2263139",
+                    "name": "RHBZ#2263139",
+                    "tags": [
+                        "issue-tracking",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://vertx.io/docs/vertx-core/java/#_server_name_indication_sni."
+                }
+            ],
+            "datePublic": "2024-02-06T00:00:00.000Z",
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-401",
+                            "description": "Missing Release of Memory after Effective Lifetime",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "x_redhatCweChain": "CWE-1392->CWE-401: Use of Default Credentials leads to Missing Release of Memory after Effective Lifetime",
+            "workarounds": [
+                {
+                    "lang": "en",
+                    "value": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+                }
+            ],
+            "timeline": [
+                {
+                    "lang": "en",
+                    "time": "2024-02-07T00:00:00+00:00",
+                    "value": "Reported to Red Hat."
+                },
+                {
+                    "lang": "en",
+                    "time": "2024-02-06T00:00:00+00:00",
+                    "value": "Made public."
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+                "shortName": "redhat",
+                "dateUpdated": "2025-03-03T16:41:15.639Z"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-04-02T15:16:36.592165Z",
+                                "id": "CVE-2024-1300",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-06-20T19:53:23.394Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-01T18:33:25.527Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1662",
+                        "name": "RHSA-2024:1662",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1706",
+                        "name": "RHSA-2024:1706",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1923",
+                        "name": "RHSA-2024:1923",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:2088",
+                        "name": "RHSA-2024:2088",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:2833",
+                        "name": "RHSA-2024:2833",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:3527",
+                        "name": "RHSA-2024:3527",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:3989",
+                        "name": "RHSA-2024:3989",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:4884",
+                        "name": "RHSA-2024:4884",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/security/cve/CVE-2024-1300",
+                        "tags": [
+                            "vdb-entry",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2263139",
+                        "name": "RHBZ#2263139",
+                        "tags": [
+                            "issue-tracking",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://vertx.io/docs/vertx-core/java/#_server_name_indication_sni.",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/etc/datasets/ds3/cve/2024/CVE-2024-1726.json
+++ b/etc/datasets/ds3/cve/2024/CVE-2024-1726.json
@@ -1,0 +1,249 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2024-1726",
+        "assignerOrgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+        "state": "PUBLISHED",
+        "assignerShortName": "redhat",
+        "dateReserved": "2024-02-21T21:51:58.713Z",
+        "datePublished": "2024-04-25T16:29:04.615Z",
+        "dateUpdated": "2025-03-15T04:10:46.621Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Quarkus: security checks for some inherited endpoints performed after serialization in resteasy reactive may trigger a denial of service",
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "value": "Low",
+                            "namespace": "https://access.redhat.com/security/updates/classification/"
+                        },
+                        "type": "Red Hat severity rating"
+                    }
+                },
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "LOW",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "LOW",
+                        "baseScore": 5.3,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "NONE",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A flaw was discovered in the RESTEasy Reactive implementation in Quarkus. Due to security checks for some JAX-RS endpoints being performed after serialization, more processing resources are consumed while the HTTP request is checked. In certain configurations, if an attacker has knowledge of any POST, PUT, or PATCH request paths, they can potentially identify vulnerable endpoints and trigger excessive resource usage as the endpoints process the requests. This can result in a denial of service."
+                }
+            ],
+            "affected": [
+                {
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "0",
+                            "lessThan": "3.2.11.Final",
+                            "versionType": "custom"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.3.0.CR1",
+                            "lessThan": "3.7.4",
+                            "versionType": "custom"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "3.8.0.CR1",
+                            "versionType": "custom"
+                        },
+                        {
+                            "status": "unaffected",
+                            "version": "3.8.0",
+                            "versionType": "custom"
+                        }
+                    ],
+                    "packageName": "quarkus-resteasy-reactive",
+                    "collectionURL": "https://github.com/quarkusio/quarkus",
+                    "defaultStatus": "unaffected"
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Quarkus 3.2.11.Final",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "io.quarkus/quarkus-resteasy-reactive",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "3.2.11.Final-redhat-00001",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:quarkus:3.2::el8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat build of Quarkus",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "io.quarkus.resteasy.reactive/resteasy-reactive",
+                    "defaultStatus": "affected",
+                    "cpes": [
+                        "cpe:/a:redhat:quarkus:2"
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1662",
+                    "name": "RHSA-2024:1662",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-1726",
+                    "tags": [
+                        "vdb-entry",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2265158",
+                    "name": "RHBZ#2265158",
+                    "tags": [
+                        "issue-tracking",
+                        "x_refsource_REDHAT"
+                    ]
+                }
+            ],
+            "datePublic": "2024-02-19T00:00:00.000Z",
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-281",
+                            "description": "Improper Preservation of Permissions",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "x_redhatCweChain": "CWE-281: Improper Preservation of Permissions",
+            "workarounds": [
+                {
+                    "lang": "en",
+                    "value": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+                }
+            ],
+            "timeline": [
+                {
+                    "lang": "en",
+                    "time": "2024-02-19T00:00:00+00:00",
+                    "value": "Reported to Red Hat."
+                },
+                {
+                    "lang": "en",
+                    "time": "2024-02-19T00:00:00+00:00",
+                    "value": "Made public."
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "value": "This issue was discovered by Michal Vavřík (Red Hat)."
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+                "shortName": "redhat",
+                "dateUpdated": "2025-03-15T04:10:46.621Z"
+            }
+        },
+        "adp": [
+            {
+                "title": "CISA ADP Vulnrichment",
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "id": "CVE-2024-1726",
+                                "role": "CISA Coordinator",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "version": "2.0.3",
+                                "timestamp": "2024-04-26T20:10:39.915513Z"
+                            }
+                        }
+                    }
+                ],
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-06-04T18:00:54.662Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-01T18:48:21.934Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1662",
+                        "name": "RHSA-2024:1662",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/security/cve/CVE-2024-1726",
+                        "tags": [
+                            "vdb-entry",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2265158",
+                        "name": "RHBZ#2265158",
+                        "tags": [
+                            "issue-tracking",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/etc/datasets/ds3/cve/2024/CVE-2024-28834.json
+++ b/etc/datasets/ds3/cve/2024/CVE-2024-28834.json
@@ -1,0 +1,515 @@
+{
+    "dataType": "CVE_RECORD",
+    "cveMetadata": {
+        "cveId": "CVE-2024-28834",
+        "assignerOrgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+        "state": "PUBLISHED",
+        "assignerShortName": "redhat",
+        "dateReserved": "2024-03-11T14:43:43.973Z",
+        "datePublished": "2024-03-21T13:29:11.532Z",
+        "dateUpdated": "2024-11-25T02:45:53.454Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Gnutls: vulnerable to minerva side-channel information leak",
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "value": "Moderate",
+                            "namespace": "https://access.redhat.com/security/updates/classification/"
+                        },
+                        "type": "Red Hat severity rating"
+                    }
+                },
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "HIGH",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "NONE",
+                        "baseScore": 5.3,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "HIGH",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "LOW",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A flaw was found in GnuTLS. The Minerva attack is a cryptographic vulnerability that exploits deterministic behavior in systems like GnuTLS, leading to side-channel leaks. In specific scenarios, such as when using the GNUTLS_PRIVKEY_FLAG_REPRODUCIBLE flag, it can result in a noticeable step in nonce size from 513 to 512 bits, exposing a potential timing side-channel."
+                }
+            ],
+            "affected": [
+                {
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "3.7.6-23"
+                        }
+                    ],
+                    "packageName": "gnutls",
+                    "collectionURL": "https://gitlab.com/gnutls/gnutls/",
+                    "defaultStatus": "unaffected"
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 8",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.6.16-8.el8_9.3",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:8::appstream",
+                        "cpe:/o:redhat:enterprise_linux:8::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 8",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.6.16-8.el8_9.3",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:8::appstream",
+                        "cpe:/o:redhat:enterprise_linux:8::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 8.6 Extended Update Support",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.6.16-5.el8_6.4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/o:redhat:rhel_eus:8.6::baseos",
+                        "cpe:/a:redhat:rhel_eus:8.6::appstream"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 8.8 Extended Update Support",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.6.16-7.el8_8.3",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/o:redhat:rhel_eus:8.8::baseos",
+                        "cpe:/a:redhat:rhel_eus:8.8::appstream"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.7.6-23.el9_3.4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:9::appstream",
+                        "cpe:/o:redhat:enterprise_linux:9::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.8.3-4.el9_4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:9::appstream",
+                        "cpe:/o:redhat:enterprise_linux:9::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.7.6-23.el9_3.4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:9::appstream",
+                        "cpe:/o:redhat:enterprise_linux:9::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.8.3-4.el9_4",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/a:redhat:enterprise_linux:9::appstream",
+                        "cpe:/o:redhat:enterprise_linux:9::baseos"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9.2 Extended Update Support",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "affected",
+                    "versions": [
+                        {
+                            "version": "0:3.7.6-21.el9_2.3",
+                            "lessThan": "*",
+                            "versionType": "rpm",
+                            "status": "unaffected"
+                        }
+                    ],
+                    "cpes": [
+                        "cpe:/o:redhat:rhel_eus:9.2::baseos",
+                        "cpe:/a:redhat:rhel_eus:9.2::appstream"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 6",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "unknown",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:6"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 7",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "gnutls",
+                    "defaultStatus": "unknown",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:7"
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1784",
+                    "name": "RHSA-2024:1784",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1879",
+                    "name": "RHSA-2024:1879",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:1997",
+                    "name": "RHSA-2024:1997",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:2044",
+                    "name": "RHSA-2024:2044",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:2570",
+                    "name": "RHSA-2024:2570",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/errata/RHSA-2024:2889",
+                    "name": "RHSA-2024:2889",
+                    "tags": [
+                        "vendor-advisory",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-28834",
+                    "tags": [
+                        "vdb-entry",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2269228",
+                    "name": "RHBZ#2269228",
+                    "tags": [
+                        "issue-tracking",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://lists.gnupg.org/pipermail/gnutls-help/2024-March/004845.html"
+                },
+                {
+                    "url": "https://minerva.crocs.fi.muni.cz/"
+                }
+            ],
+            "datePublic": "2024-03-21T00:00:00+00:00",
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-327",
+                            "description": "Use of a Broken or Risky Cryptographic Algorithm",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "x_redhatCweChain": "CWE-327: Use of a Broken or Risky Cryptographic Algorithm",
+            "workarounds": [
+                {
+                    "lang": "en",
+                    "value": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+                }
+            ],
+            "timeline": [
+                {
+                    "lang": "en",
+                    "time": "2024-03-11T00:00:00+00:00",
+                    "value": "Reported to Red Hat."
+                },
+                {
+                    "lang": "en",
+                    "time": "2024-03-21T00:00:00+00:00",
+                    "value": "Made public."
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+                "shortName": "redhat",
+                "dateUpdated": "2024-11-25T02:45:53.454Z"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "id": "CVE-2024-28834",
+                                "role": "CISA Coordinator",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "version": "2.0.3",
+                                "timestamp": "2024-03-21T18:20:34.669036Z"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-07-05T17:21:15.410Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T00:56:58.323Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/22/1",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/22/2",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1784",
+                        "name": "RHSA-2024:1784",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1879",
+                        "name": "RHSA-2024:1879",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:1997",
+                        "name": "RHSA-2024:1997",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:2044",
+                        "name": "RHSA-2024:2044",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:2570",
+                        "name": "RHSA-2024:2570",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2024:2889",
+                        "name": "RHSA-2024:2889",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://access.redhat.com/security/cve/CVE-2024-28834",
+                        "tags": [
+                            "vdb-entry",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2269228",
+                        "name": "RHBZ#2269228",
+                        "tags": [
+                            "issue-tracking",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.gnupg.org/pipermail/gnutls-help/2024-March/004845.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://minerva.crocs.fi.muni.cz/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://people.redhat.com/~hkario/marvin/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240524-0004/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "dataVersion": "5.1"
+}

--- a/etc/datasets/ds3/cve/2024/CVE-2024-50602.json
+++ b/etc/datasets/ds3/cve/2024/CVE-2024-50602.json
@@ -1,0 +1,136 @@
+{
+    "dataType": "CVE_RECORD",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2024-50602",
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "dateUpdated": "2024-10-30T18:02:03.122Z",
+        "dateReserved": "2024-10-27T00:00:00",
+        "datePublished": "2024-10-27T00:00:00"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre",
+                "dateUpdated": "2024-10-27T04:47:56.612235"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "An issue was discovered in libexpat before 2.6.4. There is a crash within the XML_ResumeParser function because XML_StopParser can stop/suspend an unstarted parser."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://github.com/libexpat/libexpat/pull/915"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "n/a"
+                        }
+                    ]
+                }
+            ]
+        },
+        "adp": [
+            {
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "type": "CWE",
+                                "cweId": "CWE-754",
+                                "lang": "en",
+                                "description": "CWE-754 Improper Check for Unusual or Exceptional Conditions"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "libexpat_project",
+                        "product": "libexpat",
+                        "cpes": [
+                            "cpe:2.3:a:libexpat_project:libexpat:*:*:*:*:*:*:*:*"
+                        ],
+                        "defaultStatus": "unknown",
+                        "versions": [
+                            {
+                                "version": "0",
+                                "status": "affected",
+                                "lessThan": "2.6.4",
+                                "versionType": "custom"
+                            }
+                        ]
+                    }
+                ],
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "scope": "UNCHANGED",
+                            "version": "3.1",
+                            "baseScore": 5.9,
+                            "attackVector": "NETWORK",
+                            "baseSeverity": "MEDIUM",
+                            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                            "integrityImpact": "NONE",
+                            "userInteraction": "NONE",
+                            "attackComplexity": "HIGH",
+                            "availabilityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "confidentialityImpact": "NONE"
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-10-30T18:00:51.860291Z",
+                                "id": "CVE-2024-50602",
+                                "options": [
+                                    {
+                                        "Exploitation": "poc"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-10-30T18:02:03.122Z"
+                }
+            }
+        ]
+    },
+    "dataVersion": "5.1"
+}

--- a/modules/fundamental/tests/dataset.rs
+++ b/modules/fundamental/tests/dataset.rs
@@ -56,7 +56,7 @@ async fn ingest(ctx: TrustifyContext) -> anyhow::Result<()> {
     log::info!("ingest: {}", humantime::Duration::from(ingest_time));
 
     assert!(result.warnings.is_empty());
-    assert_eq!(result.files.len(), 68);
+    assert_eq!(result.files.len(), 72);
 
     // get a document
 


### PR DESCRIPTION
Fixes #1495

I opted for a simple `starts_with` check instead of using BCP47 parser, as it would work anyways for the non standard `en_US` cases. We can improve this in the future if needed.

I also added missing CVE files for DS3