### PR TITLE
chore: remove imageindex>imagevariant custom codepath.

### DIFF
--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_index.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_index.json
@@ -34,6 +34,13 @@
       "type": "container",
       "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_image-index",
       "version": "sha256:4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4e1a8039dfcd2a1ae7672d99be63777b42f9fad3baca5e9273653b447ae72fe8"
+        }
+      ],
+
       "pedigree": {
         "variants": [
           {
@@ -42,6 +49,12 @@
             "type": "container",
             "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_amd64",
             "version": "sha256:601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"
@@ -56,6 +69,12 @@
             "type": "container",
             "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_arm64",
             "version": "sha256:0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"
@@ -70,6 +89,12 @@
             "type": "container",
             "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_ppc64le",
             "version": "sha256:64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"
@@ -84,6 +109,12 @@
             "type": "container",
             "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_s390x",
             "version": "sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_amd64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_amd64.json
@@ -32,6 +32,12 @@
       "type": "container",
       "bom-ref": "2da3b0bd11fcb379",
       "version": "sha256:601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285"
+        }
+      ],
       "pedigree": {
         "commits": [
           {

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
@@ -32,6 +32,12 @@
       "type": "container",
       "bom-ref": "fb61cd6dd75398fb",
       "version": "sha256:0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f"
+        }
+      ],
       "pedigree": {
         "commits": [
           {

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_ppc.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_ppc.json
@@ -32,6 +32,12 @@
       "type": "container",
       "bom-ref": "1739dbbd9af5cdd8",
       "version": "sha256:64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f"
+        }
+      ],
       "pedigree": {
         "commits": [
           {

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_s390x.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_s390x.json
@@ -32,6 +32,12 @@
       "type": "container",
       "bom-ref": "2b8dc6da540ea58f",
       "version": "sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d"
+        }
+      ],
       "pedigree": {
         "commits": [
           {

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imageindex_quarkus_mandrel.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imageindex_quarkus_mandrel.json
@@ -33,6 +33,12 @@
       "type": "container",
       "bom-ref": "quarkus-mandrel-231-rhel8-container_image-index",
       "version": "sha256:04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "04b6da7bed65d56e14bd50a119b6fa9b46b534fedafb623af7c95b1a046bb66a"
+        }
+      ],
       "pedigree": {
         "variants": [
           {
@@ -41,6 +47,12 @@
             "type": "container",
             "bom-ref": "quarkus-mandrel-231-rhel8-container_amd64",
             "version": "sha256:6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"
@@ -55,6 +67,12 @@
             "type": "container",
             "bom-ref": "quarkus-mandrel-231-rhel8-container_arm64",
             "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2"
+              }
+            ],
             "supplier": {
               "url": [
                 "https://www.redhat.com"

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
@@ -46,6 +46,13 @@
       "type": "container",
       "bom-ref": "1c4abceaa349a8c2",
       "version": "sha256:6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da"
+        }
+      ],
+
       "pedigree": {
         "commits": [
           {

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
@@ -46,6 +46,12 @@
       "type": "container",
       "bom-ref": "b2d5dcab2ab572d7",
       "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2"
+        }
+      ],
       "pedigree": {
         "commits": [
           {

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -159,9 +159,14 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             Some(graph::Node::Package(current_node)) => {
                 // collect external sbom ancestor nodes
                 let current_sbom_id = &current_node.sbom_id;
+                let current_sbom_uuid = Uuid::parse_str(current_sbom_id).unwrap_or_else(|err| {
+                    log::warn!("Error parsing UUID: {}", err);
+                    Uuid::nil()
+                });
                 let current_node_id = &current_node.node_id;
                 let mut resolved_external_nodes: Vec<Node> = vec![];
                 let find_sbom_externals = resolve_rh_external_sbom_ancestors(
+                    current_sbom_uuid,
                     current_node.node_id.clone().to_string(),
                     self.connection,
                 )


### PR DESCRIPTION
Now that rh imageindex>imagevariant encodes sha256 hashes, we can remove custom codepath. fixes #1459