### PR TITLE
refactor: Update jsonpath parser library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.7.5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+checksum = "6a37c2c87b8d16e788ce359660fead0ea5f4ed29ff400d55be74a4e01d1817d9"
 dependencies = [
  "pest",
  "pest_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ humantime-serde = "1"
 itertools = "0.14"
 jsn = "0.14"
 json-merge-patch = "0.0.1"
-jsonpath-rust = "0.7.0"
+jsonpath-rust = "1.0.1"
 langchain-rust = { version = "4.6.0" }
 lenient_semver = "0.4.2"
 liblzma = "0.3"

--- a/modules/analysis/src/endpoints/tests/cyclonedx.rs
+++ b/modules/analysis/src/endpoints/tests/cyclonedx.rs
@@ -1,7 +1,7 @@
 use crate::test::caller;
 use actix_http::Request;
 use actix_web::test::TestRequest;
-use jsonpath_rust::JsonPathQuery;
+use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
@@ -24,10 +24,10 @@ async fn cdx_generated_from(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
     let response: Value = app.call_and_read_body_json(request).await;
     tracing::debug!(test = "", "{response:#?}");
 
-    let deps = response.path(&format!(
+    let deps = response.query(&format!(
         "$.items[?(@.node_id=='{src}')].descendants[?(@.relationship=='generates')]"
     ))?;
-    assert_eq!(35, deps.as_array().unwrap().len());
+    assert_eq!(35, deps.len());
 
     // Ensure binary rpm GeneratedFrom src rpm
     let x86 = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64";

--- a/modules/analysis/src/endpoints/tests/spdx.rs
+++ b/modules/analysis/src/endpoints/tests/spdx.rs
@@ -1,7 +1,7 @@
 use crate::test::caller;
 use actix_http::Request;
 use actix_web::test::TestRequest;
-use jsonpath_rust::JsonPathQuery;
+use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
@@ -24,10 +24,10 @@ async fn spdx_generated_from(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     let response: Value = app.call_and_read_body_json(request).await;
     log::debug!("{response:#?}");
 
-    let deps = response.path(
+    let deps = response.query(
         "$.items[?(@.node_id=='SPDXRef-SRPM')].descendants[?(@.relationship=='generates')]",
     )?;
-    assert_eq!(35, deps.as_array().unwrap().len());
+    assert_eq!(35, deps.len());
 
     // Ensure binary rpm GeneratedFrom src rpm
     let x86 = "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64";

--- a/modules/fundamental/src/advisory/endpoints/test.rs
+++ b/modules/fundamental/src/advisory/endpoints/test.rs
@@ -5,7 +5,7 @@ use crate::{
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
 use hex::ToHex;
-use jsonpath_rust::JsonPathQuery;
+use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use test_context::test_context;
@@ -180,19 +180,17 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let response: Value = app.call_and_read_body_json(request).await;
 
     assert_eq!(
-        response.clone().path("$.issuer.name").unwrap(),
-        json!(["Red Hat Product Security"])
+        response.clone().query("$.issuer.name")?,
+        [&json!("Red Hat Product Security")]
     );
 
-    let cvss3_scores = response
-        .path("$.vulnerabilities[*].cvss3_scores.*")
-        .unwrap();
+    let cvss3_scores = response.query("$.vulnerabilities[*].cvss3_scores.*")?;
 
     log::debug!("{:#?}", cvss3_scores);
 
     assert_eq!(
         cvss3_scores,
-        json!(["CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N"])
+        [&json!("CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N")]
     );
 
     let uri = format!("/api/v2/advisory/urn:uuid:{}", advisory1.advisory.id);
@@ -201,9 +199,9 @@ async fn one_advisory(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response: Value = app.call_and_read_body_json(request).await;
 
-    let vulns = response.path("$.vulnerabilities").unwrap();
+    let vulns = response.query("$.vulnerabilities")?;
 
-    assert_eq!(vulns, json!([[]]));
+    assert_eq!(vulns, [&json!([])]);
 
     Ok(())
 }
@@ -281,19 +279,17 @@ async fn one_advisory_by_uuid(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     log::debug!("{:#?}", response);
 
     assert_eq!(
-        response.clone().path("$.issuer.name").unwrap(),
-        json!(["Red Hat Product Security"])
+        response.clone().query("$.issuer.name")?,
+        [&json!("Red Hat Product Security")]
     );
 
-    let cvss3_scores = response
-        .path("$.vulnerabilities[*].cvss3_scores.*")
-        .unwrap();
+    let cvss3_scores = response.query("$.vulnerabilities[*].cvss3_scores.*")?;
 
     log::debug!("{:#?}", cvss3_scores);
 
     assert_eq!(
         cvss3_scores,
-        json!(["CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N"])
+        [&json!("CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:N/A:N")]
     );
 
     Ok(())

--- a/modules/fundamental/src/organization/endpoints/test.rs
+++ b/modules/fundamental/src/organization/endpoints/test.rs
@@ -1,7 +1,7 @@
 use crate::test::caller;
 use actix_web::cookie::time::OffsetDateTime;
 use actix_web::test::TestRequest;
-use jsonpath_rust::JsonPathQuery;
+use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
@@ -58,14 +58,14 @@ async fn all_organizations(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response: Value = app.call_and_read_body_json(request).await;
 
-    let names = response.path("$.items[*].name").unwrap();
+    let names = response.query("$.items[*].name").unwrap();
 
     assert_eq!(
         names,
-        json!([
-            "Capt Pickles Boutique Emporium",
-            "Capt Pickles Industrial Conglomerate",
-        ])
+        [
+            &json!("Capt Pickles Boutique Emporium"),
+            &json!("Capt Pickles Industrial Conglomerate")
+        ]
     );
 
     Ok(())
@@ -116,9 +116,9 @@ async fn one_organization(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response: Value = app.call_and_read_body_json(request).await;
 
-    let name = response.clone().path("$.name").unwrap();
+    let name = response.query("$.name")?;
 
-    assert_eq!(name, json!(["Capt Pickles Industrial Conglomerate"]));
+    assert_eq!(name, [&json!("Capt Pickles Industrial Conglomerate")]);
 
     Ok(())
 }

--- a/modules/fundamental/src/product/endpoints/test.rs
+++ b/modules/fundamental/src/product/endpoints/test.rs
@@ -1,7 +1,7 @@
 use crate::test::caller;
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
-use jsonpath_rust::JsonPathQuery;
+use jsonpath_rust::JsonPath;
 use serde_json::{Value, json};
 use test_context::test_context;
 use test_log::test;
@@ -43,9 +43,12 @@ async fn all_products(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response: Value = app.call_and_read_body_json(request).await;
 
-    let names = response.path("$.items[*].name").unwrap();
+    let names = response.query("$.items[*].name").unwrap();
 
-    assert_eq!(names, json!(["AMQ Broker", "Trusted Profile Analyzer",]));
+    assert_eq!(
+        names,
+        [&json!("AMQ Broker"), &json!("Trusted Profile Analyzer"),]
+    );
 
     Ok(())
 }
@@ -83,9 +86,9 @@ async fn one_product(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     let response: Value = app.call_and_read_body_json(request).await;
 
-    let name = response.clone().path("$.name").unwrap();
+    let name = response.query("$.name")?;
 
-    assert_eq!(name, json!(["Trusted Profile Analyzer"]));
+    assert_eq!(name, [&json!("Trusted Profile Analyzer")]);
 
     Ok(())
 }

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -34,7 +34,7 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
-    JsonPath(#[from] jsonpath_rust::parser::JsonPathParserError),
+    JsonPath(#[from] jsonpath_rust::parser::errors::JsonPathError),
     #[error(transparent)]
     Xml(#[from] roxmltree::Error),
     #[error(transparent)]


### PR DESCRIPTION
BREAKING-CHANGE: The upgraded parser aligns with RFC 9535, and not longer supports the `$.[]` notation. It must be converted into `$[]`. This is important for the group extraction with OIDC, specifically with AWS Cognito.