### PR TITLE
[TC-2332] Keycloak section

### DIFF
--- a/docs/book/modules/admin/pages/infrastructure.adoc
+++ b/docs/book/modules/admin/pages/infrastructure.adoc
@@ -291,3 +291,41 @@ helm upgrade --install --repo https://trustification.io/trustify-helm-charts/ --
 ----
 
 NOTE: The `--devel` flag is currently necessary as the Helm chart has a pre-release version.
+
+=== Keycloak
+
+Trustify requires an OIDC issuer.
+The recommended setup to use Keycloak as OIDC issuer.
+For this, you will need to:
+
+* Install Keycloak
+* Create a new realm
+* Create the following roles for this realm
+** `chicken-user`
+** `chicken-manager`
+** `chicken-admin`
+* Make the `chicken-user` a default role
+* Create the following scopes for this realm
+** `read:document`
+** `create:document`
+** `delete:document`
+* Add the `create:document` and `delete:document` scope to the `chicken-manager` role
+* Create two clients
+** One public client
+*** Set `standardFlowEnabled` to `true`
+*** Set `fullScopedAllowed` to `true`
+*** Set the following `defaultClientScopes`
+**** `read:document`
+**** `create:document`
+**** `delete:document`
+** One protected client
+*** Set `publicClient` to `false`
+*** Set `serviecAccountsEnabled` to `true`
+*** Set `fullScopedAllowed` to `true`
+*** Set the following `defaultClientScopes`
+**** `read:document`
+**** `create:document`
+*** Add role `chicken-manager` to the service account of this client
+** Increase the token timeout for both clients to at least 5 minutes
+* Create a user, acting as administrator
+** Add the `chicken-manager` and `chicken-admin` role to this user


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2332

---



Currently the setup of keycloack is executed with the helm chart https://github.com/trustification/trustify-helm-charts/tree/main/charts/trustify-infrastructure/templates/keycloak or in the compose file https://github.com/trustification/trustify/tree/main/etc/deploy/compose/config/init-sso but we haven't a doc like the v1 https://github.com/trustification/trustification/blob/main/docs/modules/admin/pages/cluster-preparing.adoc#keycloak to explain to the customer that don't use compose or helm-chart how to setup keycloak to be usable with Ansible on Rhel without OCP/AWS

 

For Cognito instead we have a section of the doc https://github.com/trustification/trustify/blob/5e1075324e8821c8a636725c7da004127882cd2f/docs/book/modules/admin/pages/infrastructure.adoc#creating-the-resources
