### PR TITLE
chore: lowered otel-collector logs

### DIFF
--- a/etc/telemetry/config-otel-tempo.yaml
+++ b/etc/telemetry/config-otel-tempo.yaml
@@ -12,7 +12,7 @@ exporters:
     tls:
       insecure: true
   debug:
-    verbosity: detailed
+    verbosity: basic
 
 processors:
   batch: {}

--- a/etc/telemetry/config.yaml
+++ b/etc/telemetry/config.yaml
@@ -10,7 +10,7 @@ exporters:
     tls:
       insecure: true
   debug:
-    verbosity: detailed
+    verbosity: basic
   prometheus:
     endpoint: "0.0.0.0:9464"
 


### PR DESCRIPTION
level detailed was useful during development but is causing span drops

I wasn't caring about this warning:

```
2025-04-07T19:01:33.028587Z  WARN
get:fetch_vulnerability:from_entity:from_entities:from_query_result:from_query_result_multi_model:
opentelemetry_sdk:  name="BatchSpanProcessor.SpanDroppingStarted"
BatchSpanProcessor dropped a Span due to queue full/internal errors. No
further internal log will be emitted for further drops until Shutdown.
During Shutdown time, a log will be emitted with exact count of total
Spans dropped.
```

Until notice the difference of half the spans being dropped