### PR TITLE
perf: TC-2428 add gin index to advisory

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -20,6 +20,7 @@ mod m0000990_sbom_add_suppliers;
 mod m0001000_sbom_non_null_suppliers;
 mod m0001010_alter_mavenver_cmp;
 mod m0001020_alter_pythonver_cmp;
+mod m0001030_perf_adv_gin_index;
 
 pub struct Migrator;
 
@@ -43,6 +44,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001000_sbom_non_null_suppliers::Migration),
             Box::new(m0001010_alter_mavenver_cmp::Migration),
             Box::new(m0001020_alter_pythonver_cmp::Migration),
+            Box::new(m0001030_perf_adv_gin_index::Migration),
         ]
     }
 }

--- a/migration/src/m0001030_perf_adv_gin_index.rs
+++ b/migration/src/m0001030_perf_adv_gin_index.rs
@@ -1,0 +1,45 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001030_perf_adv_gin_index/advisory_identifier_version_document_id_title.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .table(Advisory::Table)
+                    .name(Indexes::AdvisoryIdentifierVersionDocumentIdTitle.to_string())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    AdvisoryIdentifierVersionDocumentIdTitle,
+}
+
+#[derive(DeriveIden)]
+pub enum Advisory {
+    Table,
+}

--- a/migration/src/m0001030_perf_adv_gin_index/advisory_identifier_version_document_id_title.sql
+++ b/migration/src/m0001030_perf_adv_gin_index/advisory_identifier_version_document_id_title.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS advisory_identifier_version_document_id_title
+    ON public.advisory USING gin
+    (identifier public.gin_trgm_ops, version public.gin_trgm_ops, document_id public.gin_trgm_ops, title public.gin_trgm_ops);

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -3,9 +3,9 @@ use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTypeTrait, ConnectionTrait, DatabaseBackend, DbErr,
-    EntityTrait, FromQueryResult, IntoActiveModel, IntoIdentity, QueryResult, QuerySelect,
-    QueryTrait, RelationTrait, Select, Statement, TransactionTrait,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, ColumnTypeTrait, ConnectionTrait,
+    DatabaseBackend, DbErr, EntityTrait, FromQueryResult, IntoActiveModel, IntoIdentity,
+    QueryResult, QuerySelect, QueryTrait, RelationTrait, Select, Statement, TransactionTrait,
 };
 use sea_query::{ColumnRef, ColumnType, Expr, Func, IntoColumnRef, IntoIden, JoinType, SimpleExpr};
 use trustify_common::{
@@ -94,7 +94,10 @@ impl AdvisoryService {
             .filtering_with(
                 search,
                 Columns::from_entity::<advisory::Entity>()
-                    .add_columns(source_document::Entity)
+                    .add_column(
+                        source_document::Column::Ingested.into_identity(),
+                        source_document::Column::Ingested.def(),
+                    )
                     .add_column("average_score", ColumnType::Decimal(None).def())
                     .add_column(
                         "average_severity",


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2428

within the context of the advisory search:
- the columns from the `advisory` table have been added to a `gin` index to improve search performances
- the digests columns from `source_document` table have been removed to make the execution plan more reliable