### PR TITLE
fix: scale test references the PR number

### DIFF
--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build Containers
         run: |
-          docker compose -f compose.yaml build --build-arg rev=${{ github.event.pull_request.head.sha }}
+          docker compose -f compose.yaml build --build-arg rev=${{ github.event.issue.number }}
 
       - name: Run
         run: |

--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           cp publish/baseline.json baseline/
 
+      # 'rev' supports the PR number in https://github.com/trustification/trustify-load-test-runs/blob/main/Containerfile.trustify
+      # the PR number is stored in 'github.event.issue.number' when managing an 'issue_comment' event as reported in
+      # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
       - name: Build Containers
         run: |
           docker compose -f compose.yaml build --build-arg rev=${{ github.event.issue.number }}


### PR DESCRIPTION
Based upon https://github.com/trustification/trustify-load-test-runs/pull/9 for working with the PR number which is retrieved from `github.event.issue.number` as reported in https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only