### PR TITLE
fix: return 400 instead of 500 in case of validation errors

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -418,7 +418,7 @@ struct UploadQuery {
     ),
     responses(
         (status = 201, description = "Upload an SBOM", body = IngestResult),
-        (status = 400, description = "The file could not be parsed as an advisory"),
+        (status = 400, description = "The file could not be parsed as an SBOM"),
     )
 )]
 #[post("/v2/sbom")]

--- a/modules/fundamental/tests/sbom/cyclonedx/corner_cases.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/corner_cases.rs
@@ -1,6 +1,11 @@
+use actix_http::StatusCode;
+use actix_web::test::TestRequest;
 use test_context::test_context;
 use test_log::test;
-use trustify_test_context::TrustifyContext;
+use trustify_module_fundamental::{Config, configure};
+use trustify_test_context::document_bytes;
+
+include!("../../../src/test/common.rs");
 
 /// test to see some error message, instead of plain failure
 #[test_context(TrustifyContext)]
@@ -11,7 +16,25 @@ async fn ingest_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         .await
         .expect_err("must fail");
 
-    assert_eq!(result.to_string(), "Invalid reference: b");
+    assert_eq!(result.to_string(), "invalid content: Invalid reference: b");
+
+    Ok(())
+}
+
+/// test to see some error message and 400, instead of plain failure
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn ingest_broken_refs_api(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    let request = TestRequest::post()
+        .uri("/api/v2/sbom")
+        .set_payload(document_bytes("cyclonedx/broken-refs.json").await?)
+        .to_request();
+
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     Ok(())
 }

--- a/modules/fundamental/tests/sbom/cyclonedx/mod.rs
+++ b/modules/fundamental/tests/sbom/cyclonedx/mod.rs
@@ -147,8 +147,9 @@ where
             >(data)?)
         },
         async move |ctx, sbom, tx| {
-            ctx.ingest_cyclonedx(Box::new(sbom.clone()), &Discard, tx)
-                .await
+            Ok(ctx
+                .ingest_cyclonedx(Box::new(sbom.clone()), &Discard, tx)
+                .await?)
         },
         |sbom| sbom::cyclonedx::Information(sbom).into(),
         f,

--- a/modules/fundamental/tests/sbom/spdx.rs
+++ b/modules/fundamental/tests/sbom/spdx.rs
@@ -128,7 +128,7 @@ async fn ingest_spdx_broken_refs(ctx: &TrustifyContext) -> Result<(), anyhow::Er
 
     assert_eq!(
         err.to_string(),
-        "Invalid reference: SPDXRef-0068e307-de91-4e82-b407-7a41217f9758"
+        "invalid content: Invalid reference: SPDXRef-0068e307-de91-4e82-b407-7a41217f9758"
     );
 
     let result = sbom

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -350,7 +350,9 @@ impl SbomContext {
             .add_source(&doc_id)
             .add_source(&packages)
             .add_source(&files);
-        relationships.validate(sources).map_err(Error::Generic)?;
+        relationships
+            .validate(sources)
+            .map_err(Error::InvalidContent)?;
 
         // create packages, files, and relationships
 

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -47,7 +47,9 @@ pub enum Error {
     Storage(#[source] anyhow::Error),
     #[error(transparent)]
     Generic(anyhow::Error),
-    #[error("Invalid format: {0}")]
+    #[error("invalid content: {0}")]
+    InvalidContent(#[source] anyhow::Error),
+    #[error("invalid format: {0}")]
     UnsupportedFormat(String),
     #[error("failed to await the task: {0}")]
     Join(#[from] JoinError),
@@ -115,9 +117,14 @@ impl ResponseError for Error {
                 message: err.to_string(),
                 details: None,
             }),
+            Self::InvalidContent(details) => HttpResponse::BadRequest().json(ErrorInformation {
+                error: "InvalidContent".into(),
+                message: "Invalid content".to_string(),
+                details: Some(details.to_string()),
+            }),
             Self::UnsupportedFormat(fmt) => HttpResponse::BadRequest().json(ErrorInformation {
                 error: "UnsupportedFormat".into(),
-                message: format!("Unsupported advisory format: {fmt}"),
+                message: format!("Unsupported document format: {fmt}"),
                 details: None,
             }),
             Error::HashKey(inner) => HttpResponse::BadRequest().json(ErrorInformation {

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -60,9 +60,7 @@ impl<'g> CyclonedxLoader<'g> {
         {
             Outcome::Existed(sbom) => sbom,
             Outcome::Added(sbom) => {
-                sbom.ingest_cyclonedx(cdx, &warnings, &tx)
-                    .await
-                    .map_err(Error::Generic)?;
+                sbom.ingest_cyclonedx(cdx, &warnings, &tx).await?;
                 tx.commit().await?;
 
                 sbom

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1155,7 +1155,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/IngestResult'
         '400':
-          description: The file could not be parsed as an advisory
+          description: The file could not be parsed as an SBOM
   /api/v2/sbom/by-package:
     get:
       tags:


### PR DESCRIPTION
When a document contains invalid references (or other validation errors)
we reject the content. However, returning 500 (or any 5xx) is not
correct. It's a client error (4xx) and the best match seems 400.