### PR TITLE
fix: Python versions PLSQL comparator (TC-2469)

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -21,6 +21,7 @@ mod m0001000_sbom_non_null_suppliers;
 mod m0001010_alter_mavenver_cmp;
 mod m0001020_alter_pythonver_cmp;
 mod m0001030_perf_adv_gin_index;
+mod m0001040_alter_pythonver_cmp;
 
 pub struct Migrator;
 
@@ -45,6 +46,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001010_alter_mavenver_cmp::Migration),
             Box::new(m0001020_alter_pythonver_cmp::Migration),
             Box::new(m0001030_perf_adv_gin_index::Migration),
+            Box::new(m0001040_alter_pythonver_cmp::Migration),
         ]
     }
 }

--- a/migration/src/m0001040_alter_pythonver_cmp.rs
+++ b/migration/src/m0001040_alter_pythonver_cmp.rs
@@ -1,0 +1,31 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001040_alter_pythonver_cmp_fns/pythonver_cmp_up.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!(
+                "m0001040_alter_pythonver_cmp_fns/pythonver_cmp_down.sql"
+            ))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0001040_alter_pythonver_cmp_fns/pythonver_cmp_down.sql
+++ b/migration/src/m0001040_alter_pythonver_cmp_fns/pythonver_cmp_down.sql
@@ -1,0 +1,118 @@
+CREATE OR REPLACE FUNCTION public.pythonver_cmp(left_p text, right_p text) RETURNS integer
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+    AS $$
+DECLARE
+left_parts text[];
+    right_parts text[];
+
+    left_major BIGINT;
+    left_minor BIGINT;
+    left_patch BIGINT;
+
+    right_major BIGINT;
+    right_minor BIGINT;
+    right_patch BIGINT;
+
+    -- Pre-release, Post-release, Dev-release
+    left_pre TEXT := NULL;
+    right_pre TEXT := NULL;
+
+    left_pre_num BIGINT := NULL;
+    right_pre_num BIGINT := NULL;
+
+    left_post BIGINT := NULL;
+    right_post BIGINT := NULL;
+
+    left_dev BIGINT := NULL;
+    right_dev BIGINT := NULL;
+
+    left_local TEXT := NULL;
+    right_local TEXT := NULL;
+BEGIN
+    left_parts = regexp_split_to_array(substring(left_p, E'^[^[:alpha:]\\+]+'), E'\\.');
+    left_major = left_parts[1]::bigint;
+    left_minor = coalesce(left_parts[2]::bigint, 0);
+    left_patch = coalesce(left_parts[3]::bigint, 0);
+
+    right_parts = regexp_split_to_array(substring(right_p, E'^[^[:alpha:]\\+]+'), E'\\.');
+    right_major = right_parts[1]::bigint;
+    right_minor = coalesce(right_parts[2]::bigint, 0);
+    right_patch = coalesce(right_parts[3]::bigint, 0);
+
+
+IF left_major > right_major THEN RETURN +1;
+    ELSIF left_major < right_major THEN RETURN -1;
+END IF;
+
+    IF left_minor > right_minor THEN RETURN +1;
+    ELSIF left_minor < right_minor THEN RETURN -1;
+END IF;
+
+    IF left_patch > right_patch THEN RETURN +1;
+    ELSIF left_patch < right_patch THEN RETURN -1;
+END IF;
+
+    -- Extract pre-release versions (allow `a1`, `b2`, `rc3` without hyphen)
+    left_pre := (regexp_match(left_p, '\d(a|b|rc)(\d*)'))[2];
+    left_pre_num := NULLIF((regexp_match(left_p, '(\d*)(a|b|rc)(\d*)'))[3], '')::BIGINT;
+
+    right_pre := (regexp_match(right_p, '\d(a|b|rc)(\d*)'))[2];
+    right_pre_num := NULLIF((regexp_match(right_p, '(a|b|rc)(\d*)'))[3], '')::BIGINT;
+
+    IF left_pre IS NOT NULL AND right_pre IS NULL THEN RETURN -1; END IF;
+    IF right_pre IS NOT NULL AND left_pre IS NULL THEN RETURN +1; END IF;
+
+    -- Compare pre-release versions (alpha < beta < rc)
+    IF left_pre IS NOT NULL AND right_pre IS NOT NULL THEN
+        IF left_pre < right_pre THEN RETURN -1;
+        ELSIF left_pre > right_pre THEN RETURN +1;
+        ELSIF left_pre_num < right_pre_num THEN RETURN -1;
+        ELSIF left_pre_num > right_pre_num THEN RETURN +1;
+END IF;
+END IF;
+
+    -- Extract post-release versions (postN)
+    left_post := NULLIF((regexp_match(left_p, 'post(\d+)'))[1], '')::BIGINT;
+    right_post := NULLIF((regexp_match(right_p, 'post(\d+)'))[1], '')::BIGINT;
+
+    IF left_post IS NOT NULL AND right_post IS NULL THEN RETURN +1; END IF;
+    IF right_post IS NOT NULL AND left_post IS NULL THEN RETURN -1; END IF;
+    IF left_post IS NOT NULL AND right_post IS NOT NULL THEN
+        IF left_post > right_post THEN RETURN +1;
+        ELSIF left_post < right_post THEN RETURN -1;
+END IF;
+END IF;
+
+    -- Extract dev-release versions (devN)
+    left_dev := NULLIF((regexp_match(left_p, 'dev(\d+)'))[1], '')::BIGINT;
+    right_dev := NULLIF((regexp_match(right_p, 'dev(\d+)'))[1], '')::BIGINT;
+
+    IF left_dev IS NOT NULL AND right_dev IS NULL THEN RETURN -1; END IF;
+    IF right_dev IS NOT NULL AND left_dev IS NULL THEN RETURN +1; END IF;
+    IF left_dev IS NOT NULL AND right_dev IS NOT NULL THEN
+        IF left_dev > right_dev THEN RETURN +1;
+        ELSIF left_dev < right_dev THEN RETURN -1;
+END IF;
+END IF;
+
+    -- Extract local-release versions (+string)
+    left_local := (regexp_match(left_p, E'\\+([a-zA-Z0-9\\.]+)'))[1];
+    right_local := (regexp_match(right_p, E'\\+([a-zA-Z0-9\\.]+)'))[1];
+
+    IF left_local IS NOT NULL AND right_local IS NULL THEN RETURN +1; END IF;
+    IF right_local IS NOT NULL AND left_local IS NULL THEN RETURN -1; END IF;
+    IF left_local IS NOT NULL AND right_local IS NOT NULL THEN
+        IF left_local > right_local THEN RETURN +1;
+        ELSIF left_local < right_local THEN RETURN -1;
+END IF;
+END IF;
+
+
+    -- If everything is equal, return 0
+RETURN 0;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END
+$$;

--- a/migration/src/m0001040_alter_pythonver_cmp_fns/pythonver_cmp_up.sql
+++ b/migration/src/m0001040_alter_pythonver_cmp_fns/pythonver_cmp_up.sql
@@ -1,0 +1,118 @@
+CREATE OR REPLACE FUNCTION public.pythonver_cmp(left_p text, right_p text) RETURNS integer
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+    AS $$
+DECLARE
+left_parts text[];
+    right_parts text[];
+
+    left_major BIGINT;
+    left_minor BIGINT;
+    left_patch BIGINT;
+
+    right_major BIGINT;
+    right_minor BIGINT;
+    right_patch BIGINT;
+
+    -- Pre-release, Post-release, Dev-release
+    left_pre TEXT := NULL;
+    right_pre TEXT := NULL;
+
+    left_pre_num BIGINT := NULL;
+    right_pre_num BIGINT := NULL;
+
+    left_post BIGINT := NULL;
+    right_post BIGINT := NULL;
+
+    left_dev BIGINT := NULL;
+    right_dev BIGINT := NULL;
+
+    left_local TEXT := NULL;
+    right_local TEXT := NULL;
+BEGIN
+    left_parts = regexp_split_to_array(substring(left_p, E'^[^[:alpha:]\\+-]+'), E'\\.');
+    left_major = left_parts[1]::bigint;
+    left_minor = coalesce(left_parts[2]::bigint, 0);
+    left_patch = coalesce(left_parts[3]::bigint, 0);
+
+    right_parts = regexp_split_to_array(substring(right_p, E'^[^[:alpha:]\\+-]+'), E'\\.');
+    right_major = right_parts[1]::bigint;
+    right_minor = coalesce(right_parts[2]::bigint, 0);
+    right_patch = coalesce(right_parts[3]::bigint, 0);
+
+
+IF left_major > right_major THEN RETURN +1;
+    ELSIF left_major < right_major THEN RETURN -1;
+END IF;
+
+    IF left_minor > right_minor THEN RETURN +1;
+    ELSIF left_minor < right_minor THEN RETURN -1;
+END IF;
+
+    IF left_patch > right_patch THEN RETURN +1;
+    ELSIF left_patch < right_patch THEN RETURN -1;
+END IF;
+
+    -- Extract pre-release versions (allow `a1`, `b2`, `rc3` without hyphen)
+    left_pre := (regexp_match(left_p, '\d[-_\.]?(a|b|rc)(\d*)'))[1];
+    left_pre_num := NULLIF((regexp_match(left_p, '\d*[-_\.]?(a|b|rc)(\d*)'))[2], '')::BIGINT;
+
+    right_pre := (regexp_match(right_p, '\d[-_\.]?(a|b|rc)(\d*)'))[1];
+    right_pre_num := NULLIF((regexp_match(right_p, '\d*[-_\.]?(a|b|rc)(\d*)'))[2], '')::BIGINT;
+
+    IF left_pre IS NOT NULL AND right_pre IS NULL THEN RETURN -1; END IF;
+    IF right_pre IS NOT NULL AND left_pre IS NULL THEN RETURN +1; END IF;
+
+    -- Compare pre-release versions (alpha < beta < rc)
+    IF left_pre IS NOT NULL AND right_pre IS NOT NULL THEN
+        IF left_pre < right_pre THEN RETURN -1;
+        ELSIF left_pre > right_pre THEN RETURN +1;
+        ELSIF left_pre_num < right_pre_num THEN RETURN -1;
+        ELSIF left_pre_num > right_pre_num THEN RETURN +1;
+END IF;
+END IF;
+
+    -- Extract post-release versions (postN)
+    left_post := NULLIF((regexp_match(left_p, 'post(\d+)'))[1], '')::BIGINT;
+    right_post := NULLIF((regexp_match(right_p, 'post(\d+)'))[1], '')::BIGINT;
+
+    IF left_post IS NOT NULL AND right_post IS NULL THEN RETURN +1; END IF;
+    IF right_post IS NOT NULL AND left_post IS NULL THEN RETURN -1; END IF;
+    IF left_post IS NOT NULL AND right_post IS NOT NULL THEN
+        IF left_post > right_post THEN RETURN +1;
+        ELSIF left_post < right_post THEN RETURN -1;
+END IF;
+END IF;
+
+    -- Extract dev-release versions (devN)
+    left_dev := NULLIF((regexp_match(left_p, 'dev(\d+)'))[1], '')::BIGINT;
+    right_dev := NULLIF((regexp_match(right_p, 'dev(\d+)'))[1], '')::BIGINT;
+
+    IF left_dev IS NOT NULL AND right_dev IS NULL THEN RETURN -1; END IF;
+    IF right_dev IS NOT NULL AND left_dev IS NULL THEN RETURN +1; END IF;
+    IF left_dev IS NOT NULL AND right_dev IS NOT NULL THEN
+        IF left_dev > right_dev THEN RETURN +1;
+        ELSIF left_dev < right_dev THEN RETURN -1;
+END IF;
+END IF;
+
+    -- Extract local-release versions (+string)
+    left_local := (regexp_match(left_p, E'\\+([a-zA-Z0-9\\.]+)'))[1];
+    right_local := (regexp_match(right_p, E'\\+([a-zA-Z0-9\\.]+)'))[1];
+
+    IF left_local IS NOT NULL AND right_local IS NULL THEN RETURN +1; END IF;
+    IF right_local IS NOT NULL AND left_local IS NULL THEN RETURN -1; END IF;
+    IF left_local IS NOT NULL AND right_local IS NOT NULL THEN
+        IF left_local > right_local THEN RETURN +1;
+        ELSIF left_local < right_local THEN RETURN -1;
+END IF;
+END IF;
+
+
+    -- If everything is equal, return 0
+RETURN 0;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END
+$$;

--- a/modules/ingestor/tests/version/pythonver.rs
+++ b/modules/ingestor/tests/version/pythonver.rs
@@ -77,6 +77,15 @@ async fn test_pythonver_cmp(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
         Some(-1),
         pythonver_cmp(&ctx.db, "1.2.3+abc", "1.2.3+def").await?
     );
+    assert_eq!(
+        Some(-1),
+        pythonver_cmp(&ctx.db, "1.2.3-rc0", "1.2.3").await?
+    );
+    assert_eq!(Some(1), pythonver_cmp(&ctx.db, "1.2.3", "1.2.3-rc0").await?);
+    assert_eq!(
+        Some(0),
+        pythonver_cmp(&ctx.db, "1.2.3-rc0", "1.2.3-rc0").await?
+    );
     Ok(())
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2469

[PEP-0440](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions) allowed a more permissive convention for pre-release versions allowing to have a `-` between the version and the pre-release marker, e.g. `1.2.3-rc0`.

So the regex to retrieve the `{left,right}_pre{_num}` fields have been updated consistently and three tests to cover this scenario has been added swapping left and right in order to ensure the same patterns are applied to both left and right fields.