### PR TITLE
test: test reproducing the issue 1535

### DIFF
--- a/modules/fundamental/tests/sbom/issue_1535.rs
+++ b/modules/fundamental/tests/sbom/issue_1535.rs
@@ -1,0 +1,17 @@
+use test_context::test_context;
+use test_log::test;
+use trustify_module_ingestor::service::Format;
+use trustify_test_context::TrustifyContext;
+
+/// This is a test for issue #1535
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+async fn not_really_clearly_defined(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let result = ctx
+        .ingest_document_as("csaf/timeout/rhsa-2024_5363.json.xz", Format::SBOM)
+        .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/modules/fundamental/tests/sbom/mod.rs
+++ b/modules/fundamental/tests/sbom/mod.rs
@@ -3,6 +3,7 @@
 mod cyclonedx;
 mod details;
 mod graph;
+mod issue_1535;
 mod license;
 mod reingest;
 mod spdx;


### PR DESCRIPTION
This is the panic we see when using serde_yml for this specific case:

```
failures:
    sbom::issue_1535::not_really_clearly_defined

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 68
    filtered out; finished in 4.51s

    ──── STDERR:             trustify-module-fundamental::fundamental
    sbom::issue_1535::not_really_clearly_defined

    thread 'sbom::issue_1535::not_really_clearly_defined' panicked at
    /home/heliofrota/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f
    /libyml-0.0.5/src/scanner.rs:2798:17:
    String join would overflow memory bounds
    note: run with `RUST_BACKTRACE=1` environment variable to display
    a backtrace

      Cancelling due to test failure
      ────────────
           Summary [   4.526s] 1 test run: 0 passed, 1 failed, 422
           skipped
                   FAIL [   4.517s]
                   trustify-module-fundamental::fundamental
                   sbom::issue_1535::not_really_clearly_defined
                   error: test run failed
                   ➜  trustify git:(test) ✗
```