### PR TITLE
fix: when deleting an entity, delete also a source document

### DIFF
--- a/e2e/ds3.hurl
+++ b/e2e/ds3.hurl
@@ -7,10 +7,13 @@ HTTP 201
 [Asserts]
 jsonpath "$.files.['spdx/quarkus-bom-2.13.8.Final-redhat-00004.json.bz2'].id" exists
 jsonpath "$.files.['spdx/ubi8-8.8-1067.json.bz2'].id" exists
+jsonpath "$.files.['csaf/2023/cve-2023-0044.json'].id" exists
 
 [Captures]
 quarkus_sbom_id: jsonpath "$.files.['spdx/quarkus-bom-2.13.8.Final-redhat-00004.json.bz2'].id"
 ubi8_sbom_id: jsonpath "$.files.['spdx/ubi8-8.8-1067.json.bz2'].id"
+advisory_id: jsonpath "$.files.['csaf/2023/cve-2023-0044.json'].id"
+
 
 # Check vulnerabilities for UBI 8 SBOM
 GET http://localhost:8080/api/v2/sbom/{{ubi8_sbom_id}}/advisory
@@ -34,3 +37,13 @@ HTTP 200
 
 [Asserts]
 jsonpath "$.title" not isEmpty
+
+## Test delete and re-upload advisory
+DELETE http://localhost:8080/api/v2/advisory/{{advisory_id}}
+
+HTTP 200
+
+POST http://localhost:8080/api/v2/advisory
+file,etc/datasets/ds3/csaf/2023/cve-2023-0044.json;
+
+HTTP 201

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -22,6 +22,7 @@ mod m0001010_alter_mavenver_cmp;
 mod m0001020_alter_pythonver_cmp;
 mod m0001030_perf_adv_gin_index;
 mod m0001040_alter_pythonver_cmp;
+mod m0001050_foreign_key_cascade;
 
 pub struct Migrator;
 
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001020_alter_pythonver_cmp::Migration),
             Box::new(m0001030_perf_adv_gin_index::Migration),
             Box::new(m0001040_alter_pythonver_cmp::Migration),
+            Box::new(m0001050_foreign_key_cascade::Migration),
         ]
     }
 }

--- a/migration/src/m0001050_foreign_key_cascade.rs
+++ b/migration/src/m0001050_foreign_key_cascade.rs
@@ -1,0 +1,133 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name(Keys::CVSS3AdvisoryIdFkey.to_string())
+                    .from(CVSS3::Table, CVSS3::AdvisoryId)
+                    .to(Advisory::Table, Advisory::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name(Keys::CVSS4AdvisoryIdFkey.to_string())
+                    .from(CVSS4::Table, CVSS4::AdvisoryId)
+                    .to(Advisory::Table, Advisory::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductVersion::Table)
+                    .drop_foreign_key(Keys::ProductVersionSbomIdFkey)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name(Keys::ProductVersionSbomIdFkey.to_string())
+                    .from(ProductVersion::Table, ProductVersion::SbomId)
+                    .to(Sbom::Table, Sbom::SbomId)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CVSS3::Table)
+                    .drop_foreign_key(Keys::CVSS3AdvisoryIdFkey)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CVSS4::Table)
+                    .drop_foreign_key(Keys::CVSS4AdvisoryIdFkey)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProductVersion::Table)
+                    .drop_foreign_key(Keys::ProductVersionSbomIdFkey)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name(Keys::ProductVersionSbomIdFkey.to_string())
+                    .from(ProductVersion::Table, ProductVersion::SbomId)
+                    .to(Sbom::Table, Sbom::SbomId)
+                    .on_delete(ForeignKeyAction::SetNull)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum CVSS3 {
+    Table,
+    AdvisoryId,
+}
+
+#[derive(DeriveIden)]
+enum CVSS4 {
+    Table,
+    AdvisoryId,
+}
+
+#[derive(DeriveIden)]
+enum Advisory {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
+enum ProductVersion {
+    Table,
+    SbomId,
+}
+
+#[derive(DeriveIden)]
+enum Sbom {
+    Table,
+    SbomId,
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Keys {
+    CVSS3AdvisoryIdFkey,
+    CVSS4AdvisoryIdFkey,
+    ProductVersionSbomIdFkey,
+}


### PR DESCRIPTION
When deleting an entity (advisory or sbom), the source document is left in the database. This makes uploading the same file again (after deleting) fails.

This PR fixes this. And additionally adds foreign keys to the CVSS tables to clean them as well after deleting an advisory.