### PR TITLE
Speed up ingestion

### DIFF
--- a/modules/analysis/Cargo.toml
+++ b/modules/analysis/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 spdx-rs = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras", "uuid"] }
 utoipa-actix-web = { workspace = true }

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -452,6 +452,7 @@ impl AnalysisService {
     }
 
     /// Load all SBOMs by the provided IDs
+    #[instrument(skip(self, connection), err(level=tracing::Level::INFO))]
     pub async fn load_graphs<C: ConnectionTrait>(
         &self,
         connection: &C,

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -270,7 +270,7 @@ impl AnalysisService {
             .await?
             .into_iter()
             .map(|record| record.sbom_id.to_string()) // Assuming sbom_id is of type String
-            .collect();
+            .collect::<Vec<_>>();
 
         self.load_graphs(connection, &distinct_sbom_ids).await
     }

--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -21,7 +21,7 @@ async fn test_simple_analysis_service(ctx: &TrustifyContext) -> Result<(), anyho
     ctx.ingest_documents(["spdx/simple.json", "spdx/simple.json"])
         .await?; //double ingestion intended
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -81,7 +81,7 @@ async fn test_simple_analysis_cyclonedx_service(
     ctx.ingest_documents(["cyclonedx/simple.json", "cyclonedx/simple.json"])
         .await?; //double ingestion intended
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -139,7 +139,7 @@ async fn test_simple_analysis_cyclonedx_service(
 async fn test_simple_by_name_analysis_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -188,7 +188,7 @@ async fn simple_by_name_analysis_service_filter_rel(
 ) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -229,7 +229,7 @@ async fn simple_by_name_analysis_service_filter_rel(
 async fn test_simple_by_purl_analysis_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let component_purl: Purl = Purl::from_str("pkg:rpm/redhat/B@0.0.0").map_err(Error::Purl)?;
 
@@ -281,7 +281,7 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
     ])
     .await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -335,7 +335,7 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
 async fn test_status_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     let all_graphs = service.load_all_graphs(&ctx.db).await?;
     assert_eq!(all_graphs.len(), 1);
 
@@ -364,7 +364,7 @@ async fn test_status_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 async fn test_cache_size_used(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     assert_eq!(service.cache_size_used(), 0u64);
 
     let all_graphs = service.load_all_graphs(&ctx.db).await?;
@@ -385,9 +385,12 @@ async fn test_cache_size_used(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     assert!(big_sbom_size < 960 * kb);
 
     // Now lets try it with small cache that can at least fit the small bom
-    let service = AnalysisService::new(AnalysisConfig {
-        max_cache_size: BinaryByteSize::from(small_sbom_size * 2),
-    });
+    let service = AnalysisService::new(
+        AnalysisConfig {
+            max_cache_size: BinaryByteSize::from(small_sbom_size * 2),
+        },
+        ctx.db.clone(),
+    );
 
     let all_graphs = service.load_all_graphs(&ctx.db).await?;
     // we should be able to load all the graphs even if they can't fit in the cache.
@@ -405,7 +408,7 @@ async fn test_cache_size_used(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 async fn test_simple_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -442,7 +445,7 @@ async fn test_simple_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::E
 async fn test_simple_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["cyclonedx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -475,7 +478,7 @@ async fn test_simple_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(),
 async fn test_simple_by_name_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -506,7 +509,7 @@ async fn test_simple_by_name_deps_service(ctx: &TrustifyContext) -> Result<(), a
 async fn test_simple_by_purl_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/simple.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let component_purl: Purl =
         Purl::from_str("pkg:rpm/redhat/AA@0.0.0?arch=src").map_err(Error::Purl)?;
@@ -539,7 +542,7 @@ async fn test_quarkus_deps_service(ctx: &TrustifyContext) -> Result<(), anyhow::
     ])
     .await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -561,7 +564,7 @@ async fn test_circular_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(
     ctx.ingest_documents(["cyclonedx/cyclonedx-circular.json"])
         .await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -583,7 +586,7 @@ async fn test_circular_deps_cyclonedx_service(ctx: &TrustifyContext) -> Result<(
 async fn test_circular_deps_spdx_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     ctx.ingest_documents(["spdx/loop.json"]).await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let analysis_graph = service
         .retrieve(
@@ -606,7 +609,7 @@ async fn test_retrieve_all_sbom_roots_by_name(ctx: &TrustifyContext) -> Result<(
     ctx.ingest_documents(["spdx/quarkus-bom-3.2.11.Final-redhat-00001.json"])
         .await?;
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     let component_name = "quarkus-vertx-http".to_string();
 
     let analysis_graph = service
@@ -678,7 +681,7 @@ async fn load_performance(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     log::info!("Start populating graph");
 
     let start = SystemTime::now();
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     service.load_all_graphs(&ctx.db).await?;
 
     log::info!(

--- a/modules/analysis/src/test.rs
+++ b/modules/analysis/src/test.rs
@@ -11,7 +11,7 @@ use trustify_test_context::{
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
-    let analysis = AnalysisService::new(AnalysisConfig::default());
+    let analysis = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     call::caller(|svc| configure(svc, ctx.db.clone(), analysis)).await
 }
 

--- a/modules/fundamental/benches/bench-otel.rs
+++ b/modules/fundamental/benches/bench-otel.rs
@@ -11,7 +11,7 @@ pub(crate) mod trustify_benches {
     use criterion::{Criterion, black_box};
     use std::ops::Add;
     use trustify_entity::labels::Labels;
-    use trustify_module_ingestor::service::Format;
+    use trustify_module_ingestor::service::{Cache, Format};
 
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_sdk::{
@@ -95,7 +95,13 @@ pub(crate) mod trustify_benches {
                         let start = Instant::now();
                         black_box(
                             ctx.ingestor
-                                .ingest(&data, Format::Advisory, Labels::default(), None)
+                                .ingest(
+                                    &data,
+                                    Format::Advisory,
+                                    Labels::default(),
+                                    None,
+                                    Cache::Skip,
+                                )
                                 .await
                                 .expect("ingest ok"),
                         );

--- a/modules/fundamental/benches/bench.rs
+++ b/modules/fundamental/benches/bench.rs
@@ -12,7 +12,7 @@ pub(crate) mod trustify_benches {
     use crate::common;
     use criterion::{Criterion, black_box};
     use trustify_entity::labels::Labels;
-    use trustify_module_ingestor::service::Format;
+    use trustify_module_ingestor::service::{Cache, Format};
 
     pub fn ingestion(c: &mut Criterion) {
         let (runtime, ctx) = common::setup_runtime_and_ctx();
@@ -33,7 +33,13 @@ pub(crate) mod trustify_benches {
                         let start = Instant::now();
                         black_box(
                             ctx.ingestor
-                                .ingest(&data, Format::Advisory, Labels::default(), None)
+                                .ingest(
+                                    &data,
+                                    Format::Advisory,
+                                    Labels::default(),
+                                    None,
+                                    Cache::Skip,
+                                )
                                 .await
                                 .expect("ingest ok"),
                         );

--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -162,6 +162,7 @@ struct UploadParams {
     labels: Labels,
     /// The format of the uploaded document.
     #[serde(default = "default_format")]
+    #[param(inline)]
     format: Format,
 }
 

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -411,10 +411,12 @@ struct UploadQuery {
 
     /// The format of the uploaded document.
     #[serde(default = "default_format")]
+    #[param(inline)]
     format: Format,
 
     /// Await loading the document into the analysis graph cache
     #[serde(default)]
+    #[param(inline)]
     cache: Cache,
 }
 

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -408,6 +408,7 @@ struct UploadQuery {
     #[serde(flatten, with = "trustify_entity::labels::prefixed")]
     labels: Labels,
 
+    /// The format of the uploaded document.
     #[serde(default = "default_format")]
     format: Format,
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -6,12 +6,12 @@ mod test;
 
 pub use query::*;
 
-use crate::license::{
-    get_sanitize_filename,
-    service::{LicenseService, license_export::LicenseExporter},
-};
 use crate::{
     Error::{self, Internal},
+    license::{
+        get_sanitize_filename,
+        service::{LicenseService, license_export::LicenseExporter},
+    },
     purl::service::PurlService,
     sbom::{
         model::{

--- a/modules/fundamental/src/test/common.rs
+++ b/modules/fundamental/src/test/common.rs
@@ -1,8 +1,8 @@
 use trustify_module_analysis::config::AnalysisConfig;
 use trustify_module_analysis::service::AnalysisService;
 use trustify_test_context::{
-    call::{self, CallService},
     TrustifyContext,
+    call::{self, CallService},
 };
 
 pub async fn caller(ctx: &TrustifyContext) -> anyhow::Result<impl CallService + '_> {
@@ -13,6 +13,6 @@ async fn caller_with(
     ctx: &TrustifyContext,
     config: Config,
 ) -> anyhow::Result<impl CallService + '_> {
-    let analysis = AnalysisService::new(AnalysisConfig::default());
+    let analysis = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     call::caller(|svc| configure(svc, config, ctx.db.clone(), ctx.storage.clone(), analysis)).await
 }

--- a/modules/fundamental/tests/sbom/reingest.rs
+++ b/modules/fundamental/tests/sbom/reingest.rs
@@ -9,7 +9,7 @@ use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
 use trustify_module_fundamental::sbom::model::SbomExternalPackageReference;
 use trustify_module_fundamental::sbom::{model::details::SbomDetails, service::SbomService};
-use trustify_module_ingestor::service::Format;
+use trustify_module_ingestor::service::{Cache, Format};
 use trustify_test_context::{TrustifyContext, document_bytes};
 
 fn assert_sboms(sbom1: &SbomDetails, sbom2: &SbomDetails) {
@@ -231,7 +231,7 @@ async fn nhc_same_content(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     };
     let result2 = ctx
         .ingestor
-        .ingest(bytes, Format::SBOM, ("source", "test"), None)
+        .ingest(bytes, Format::SBOM, ("source", "test"), None, Cache::Skip)
         .await?;
 
     assert_eq!(

--- a/modules/fundamental/tests/sbom/spdx/aliases.rs
+++ b/modules/fundamental/tests/sbom/spdx/aliases.rs
@@ -19,7 +19,7 @@ async fn cpe_purl(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         bail!("must be an id")
     };
 
-    let service = AnalysisService::new(AnalysisConfig::default());
+    let service = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
 
     let result = service
         .retrieve(

--- a/modules/importer/src/runner/clearly_defined/walker.rs
+++ b/modules/importer/src/runner/clearly_defined/walker.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::bytes::Buf;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::{Cache, Format, IngestorService};
 
 pub struct ClearlyDefinedWalker<P: Progress + Send + 'static> {
     continuation: ClearlyDefinedItemContinuation,
@@ -121,6 +121,7 @@ impl<P: Progress + Send + 'static> ClearlyDefinedWalker<P> {
                 Format::ClearlyDefined,
                 Labels::default(),
                 Some("ClearlyDefined".to_string()),
+                Cache::Skip,
             )
             .await
         {

--- a/modules/importer/src/runner/clearly_defined_curation/mod.rs
+++ b/modules/importer/src/runner/clearly_defined_curation/mod.rs
@@ -15,6 +15,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
+use trustify_module_ingestor::service::Cache;
 use trustify_module_ingestor::{
     graph::Graph,
     service::{Format, IngestorService},
@@ -43,6 +44,7 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
+                    Cache::Skip,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/csaf/storage.rs
+++ b/modules/importer/src/runner/csaf/storage.rs
@@ -6,7 +6,7 @@ use csaf_walker::{
 use parking_lot::Mutex;
 use std::sync::Arc;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::{Cache, Format, IngestorService};
 use walker_common::utils::url::Urlify;
 
 pub struct StorageVisitor<C: RunContext> {
@@ -44,6 +44,7 @@ impl<C: RunContext, S: Source> ValidatedVisitor<S> for StorageVisitor<C> {
                     .add("file", file)
                     .extend(&self.labels.0),
                 None, /* CSAF tracks issuer internally */
+                Cache::Skip,
             )
             .await
             .map_err(StorageError::Storage)?;

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -15,6 +15,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
+use trustify_module_ingestor::service::Cache;
 use trustify_module_ingestor::{
     graph::Graph,
     service::{Format, IngestorService},
@@ -43,6 +44,7 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
+                    Cache::Skip,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/cwe/walker.rs
+++ b/modules/importer/src/runner/cwe/walker.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 use tokio_util::bytes::Buf;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::{Cache, Format, IngestorService};
 use zip::ZipArchive;
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -85,6 +85,7 @@ impl CweWalker {
                     .add("source", &self.source)
                     .add("importer", "CWE Catalog"),
                 None,
+                Cache::Skip,
             )
             .await
         {

--- a/modules/importer/src/runner/osv/mod.rs
+++ b/modules/importer/src/runner/osv/mod.rs
@@ -17,6 +17,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::runtime::Handle;
 use tracing::instrument;
 use trustify_entity::labels::Labels;
+use trustify_module_ingestor::service::Cache;
 use trustify_module_ingestor::{
     graph::Graph,
     service::{Format, IngestorService, advisory::osv::parse},
@@ -70,6 +71,7 @@ impl<C: RunContext> Context<C> {
                         .add("file", path.to_string_lossy())
                         .extend(&self.labels.0),
                     None,
+                    Cache::Skip,
                 )
                 .await
         })?;

--- a/modules/importer/src/runner/sbom/storage.rs
+++ b/modules/importer/src/runner/sbom/storage.rs
@@ -11,7 +11,7 @@ use sbom_walker::{
 };
 use std::sync::Arc;
 use trustify_entity::labels::Labels;
-use trustify_module_ingestor::service::{Format, IngestorService};
+use trustify_module_ingestor::service::{Cache, Format, IngestorService};
 use walker_common::utils::url::Urlify;
 use walker_common::{compression::decompress_opt, validate::ValidationError};
 
@@ -78,6 +78,7 @@ impl<C: RunContext> ValidatedVisitor<HttpSource> for StorageVisitor<C> {
                     .add("file", &file)
                     .extend(&self.labels.0),
                 None,
+                Cache::Skip,
             )
             .await
             .map_err(StorageError::Storage)?;

--- a/modules/ingestor/src/service/format.rs
+++ b/modules/ingestor/src/service/format.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 use trustify_common::hashing::Digests;
 use trustify_entity::labels::Labels;
 
-#[derive(Clone, Copy, Debug, strum::EnumString, utoipa::ToSchema)]
+#[derive(Clone, Copy, Debug, strum::EnumString, utoipa::ToSchema, PartialEq, Eq)]
 #[strum(serialize_all = "camelCase")]
 #[schema(rename_all = "camelCase")]
 pub enum Format {

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -13,11 +13,11 @@ use anyhow::anyhow;
 use parking_lot::Mutex;
 use sbom_walker::report::ReportSink;
 use sea_orm::error::DbErr;
-use std::sync::Arc;
-use std::{fmt::Debug, time::Instant};
+use std::{fmt::Debug, sync::Arc, time::Instant};
 use tokio::task::JoinError;
 use tokio_util::io::ReaderStream;
 use tracing::instrument;
+use trustify_common::id::Id;
 use trustify_common::{error::ErrorInformation, id::IdError};
 use trustify_entity::labels::Labels;
 use trustify_module_analysis::service::AnalysisService;
@@ -212,12 +212,12 @@ impl IngestorService {
         if let Some(analysis) = &self.analysis {
             match fmt {
                 Format::SPDX | Format::CycloneDX => {
-                    if result.id.to_string().starts_with("urn:uuid:") {
+                    if let Id::Uuid(id) = result.id {
                         match analysis
                             .load_graphs(
                                 &self.graph.db,
                                 // TODO: today we chop off 'urn:uuid:' prefix using .split_off on result.id
-                                &vec![result.id.to_string().split_off("urn:uuid:".len())],
+                                &[&id.to_string()],
                             )
                             .await
                         {

--- a/modules/ingestor/src/service/mod.rs
+++ b/modules/ingestor/src/service/mod.rs
@@ -147,7 +147,7 @@ impl ResponseError for Error {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, serde::Deserialize, utoipa::ToSchema)]
-#[serde(rename_all = "snake_case")]
+#[schema(rename_all = "camelCase")]
 pub enum Cache {
     /// Skip loading into cache
     #[default]

--- a/modules/ingestor/src/service/sbom/clearly_defined.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined.rs
@@ -97,7 +97,7 @@ impl<'g> ClearlyDefinedLoader<'g> {
 #[cfg(test)]
 mod test {
     use crate::graph::Graph;
-    use crate::service::{Error, Format, IngestorService};
+    use crate::service::{Cache, Error, Format, IngestorService};
     use anyhow::anyhow;
     use test_context::test_context;
     use test_log::test;
@@ -169,7 +169,13 @@ mod test {
         let data = document_bytes("clearly-defined/aspnet.mvc-4.0.40804.json").await?;
 
         ingestor
-            .ingest(&data, Format::ClearlyDefined, ("source", "test"), None)
+            .ingest(
+                &data,
+                Format::ClearlyDefined,
+                ("source", "test"),
+                None,
+                Cache::Skip,
+            )
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
+++ b/modules/ingestor/src/service/sbom/clearly_defined_curation.rs
@@ -60,7 +60,7 @@ impl<'g> ClearlyDefinedCurationLoader<'g> {
 #[cfg(test)]
 mod test {
     use crate::graph::Graph;
-    use crate::service::{Format, IngestorService};
+    use crate::service::{Cache, Format, IngestorService};
     use test_context::test_context;
     use test_log::test;
     use trustify_test_context::TrustifyContext;
@@ -80,6 +80,7 @@ mod test {
                 Format::ClearlyDefinedCuration,
                 ("source", "test"),
                 None,
+                Cache::Skip,
             )
             .await
             .expect("must ingest");

--- a/modules/ingestor/src/service/sbom/cyclonedx.rs
+++ b/modules/ingestor/src/service/sbom/cyclonedx.rs
@@ -77,7 +77,7 @@ impl<'g> CyclonedxLoader<'g> {
 
 #[cfg(test)]
 mod test {
-    use crate::service::IngestorService;
+    use crate::service::{Cache, IngestorService};
     use crate::{graph::Graph, service::Format};
     use test_context::test_context;
     use test_log::test;
@@ -93,7 +93,13 @@ mod test {
         let ingestor = IngestorService::new(graph, ctx.storage.clone(), Default::default());
 
         ingestor
-            .ingest(&data, Format::CycloneDX, ("source", "test"), None)
+            .ingest(
+                &data,
+                Format::CycloneDX,
+                ("source", "test"),
+                None,
+                Cache::Skip,
+            )
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/src/service/sbom/spdx.rs
+++ b/modules/ingestor/src/service/sbom/spdx.rs
@@ -75,7 +75,7 @@ impl<'g> SpdxLoader<'g> {
 
 #[cfg(test)]
 mod test {
-    use crate::service::IngestorService;
+    use crate::service::{Cache, IngestorService};
     use crate::{graph::Graph, service::Format};
     use test_context::test_context;
     use test_log::test;
@@ -90,7 +90,7 @@ mod test {
         let ingestor = IngestorService::new(graph, ctx.storage.clone(), Default::default());
 
         ingestor
-            .ingest(&data, Format::SPDX, ("source", "test"), None)
+            .ingest(&data, Format::SPDX, ("source", "test"), None, Cache::Skip)
             .await
             .expect("must ingest");
 

--- a/modules/ingestor/tests/common.rs
+++ b/modules/ingestor/tests/common.rs
@@ -1,5 +1,4 @@
-use trustify_module_analysis::config::AnalysisConfig;
-use trustify_module_analysis::service::AnalysisService;
+use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
 use trustify_module_ingestor::endpoints::{Config, configure};
 use trustify_test_context::{
     TrustifyContext,
@@ -10,7 +9,7 @@ pub async fn caller_with(
     ctx: &TrustifyContext,
     config: Config,
 ) -> anyhow::Result<impl CallService + '_> {
-    let analysis = AnalysisService::new(AnalysisConfig::default());
+    let analysis = AnalysisService::new(AnalysisConfig::default(), ctx.db.clone());
     call::caller(|svc| {
         configure(
             svc,

--- a/modules/ingestor/tests/parallel.rs
+++ b/modules/ingestor/tests/parallel.rs
@@ -8,6 +8,7 @@ use test_context::{futures, test_context};
 use test_log::test;
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, purl::Purl, sbom::spdx::parse_spdx};
+use trustify_module_ingestor::service::Cache;
 use trustify_module_ingestor::{
     graph::{
         cpe::CpeCreator,
@@ -42,7 +43,9 @@ async fn sbom_parallel(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         let service = ctx.ingestor.clone();
 
         tasks.push(async move {
-            service.ingest(&next, Format::SPDX, (), None).await?;
+            service
+                .ingest(&next, Format::SPDX, (), None, Cache::Skip)
+                .await?;
 
             Ok::<_, anyhow::Error>(())
         });
@@ -123,7 +126,9 @@ async fn csaf_parallel(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         let service = ctx.ingestor.clone();
 
         tasks.push(async move {
-            service.ingest(&next, Format::CSAF, (), None).await?;
+            service
+                .ingest(&next, Format::CSAF, (), None, Cache::Skip)
+                .await?;
 
             Ok::<_, anyhow::Error>(())
         });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -101,6 +101,24 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/Labels'
+      - name: format
+        in: query
+        description: The format of the uploaded document.
+        required: false
+        schema:
+          type: string
+          enum:
+          - oSV
+          - cSAF
+          - cVE
+          - sPDX
+          - cycloneDX
+          - clearlyDefinedCuration
+          - clearlyDefined
+          - cweCatalog
+          - advisory
+          - sBOM
+          - unknown
       requestBody:
         content:
           application/json:
@@ -1307,6 +1325,34 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/Labels'
+      - name: format
+        in: query
+        description: The format of the uploaded document.
+        required: false
+        schema:
+          type: string
+          enum:
+          - oSV
+          - cSAF
+          - cVE
+          - sPDX
+          - cycloneDX
+          - clearlyDefinedCuration
+          - clearlyDefined
+          - cweCatalog
+          - advisory
+          - sBOM
+          - unknown
+      - name: cache
+        in: query
+        description: Await loading the document into the analysis graph cache
+        required: false
+        schema:
+          type: string
+          enum:
+          - skip
+          - queue
+          - wait
       requestBody:
         content:
           application/octet-stream:

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -13,7 +13,7 @@ use utoipa_actix_web::AppExt;
 pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
     let (db, postgresql) = db::embedded::create().await?;
     let (storage, _temp) = FileSystemBackend::for_test().await?;
-    let analysis = AnalysisService::new(AnalysisConfig::default());
+    let analysis = AnalysisService::new(AnalysisConfig::default(), db.clone());
 
     let (_, mut openapi) = App::new()
         .into_utoipa_app()

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -295,7 +295,7 @@ impl InitData {
         };
 
         Ok(InitData {
-            analysis: AnalysisService::new(run.analysis),
+            analysis: AnalysisService::new(run.analysis, db.clone()),
             authenticator,
             authorizer,
             db,
@@ -507,7 +507,7 @@ mod test {
         let db = ctx.db;
         let (storage, _) = FileSystemBackend::for_test().await?;
         let ui = Arc::new(UiResources::new(&UI::default())?);
-        let analysis = AnalysisService::new(AnalysisConfig::default());
+        let analysis = AnalysisService::new(AnalysisConfig::default(), db.clone());
         let app = actix_web::test::init_service(
             App::new()
                 .into_utoipa_app()


### PR DESCRIPTION
This PR has a few improvements for SBOM ingestion, which also should improve other documents ingestion with it.

* [x] Allow providing a format during the upload, working around "auto detection"
* [x] Don't push work on the worker thread pool if there is none (decompression)
* [x] Queue analysis graph loading after ingestion, instead of waiting for it
