### PR TITLE
fix: remove advisory_vulnerability gist index

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -23,6 +23,7 @@ mod m0001020_alter_pythonver_cmp;
 mod m0001030_perf_adv_gin_index;
 mod m0001040_alter_pythonver_cmp;
 mod m0001050_foreign_key_cascade;
+mod m0001060_advisory_vulnerability_indexes;
 mod m0001100_remove_get_purl;
 
 pub struct Migrator;
@@ -50,6 +51,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001030_perf_adv_gin_index::Migration),
             Box::new(m0001040_alter_pythonver_cmp::Migration),
             Box::new(m0001050_foreign_key_cascade::Migration),
+            Box::new(m0001060_advisory_vulnerability_indexes::Migration),
             Box::new(m0001100_remove_get_purl::Migration),
         ]
     }

--- a/migration/src/m0001060_advisory_vulnerability_indexes.rs
+++ b/migration/src/m0001060_advisory_vulnerability_indexes.rs
@@ -1,0 +1,76 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+#[allow(deprecated)]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop the old GiST index
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name(Indexes::AdvisoryVulnerabilityVulnerabilityIdGist.to_string())
+                    .table(AdvisoryVulnerability::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Create the new B-tree index
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .table(AdvisoryVulnerability::Table)
+                    .name(Indexes::AdvisoryVulnerabilityVulnerabilityIdIdx.to_string())
+                    .col(AdvisoryVulnerability::VulnerabilityId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop the new B-tree index
+        manager
+            .drop_index(
+                Index::drop()
+                    .if_exists()
+                    .name(Indexes::AdvisoryVulnerabilityVulnerabilityIdIdx.to_string())
+                    .table(AdvisoryVulnerability::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Recreate the GiST index
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE INDEX IF NOT EXISTS advisory_vulnerability_vulnerability_id_gist
+                ON advisory_vulnerability
+                USING GIST (vulnerability_id gist_trgm_ops);
+                "#,
+            )
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Indexes {
+    AdvisoryVulnerabilityVulnerabilityIdGist,
+    AdvisoryVulnerabilityVulnerabilityIdIdx,
+}
+
+#[derive(DeriveIden)]
+pub enum AdvisoryVulnerability {
+    Table,
+    VulnerabilityId,
+}


### PR DESCRIPTION
The gist index on advisory_vulnerability(vulnerability_id) slows down significantly (4-5x) any join with that table on vulnerability_id. The database chooses to use gist index over btree one no matter what I tried.
As a result the correlating advisories with a large SBOM is now much faster (e.g. 260s -> 60s). It's still not great, but it's a big improvement.
On the other hand I don't see slowdown in other endpoints when this index is dropped. I don't think we ever directly search this table.

