### PR TITLE
ci: allow backports with comments

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -6,12 +6,30 @@ on:
       - main
     types:
       - closed
+  issue_comment:
+    types:
+      - created
 
 jobs:
   cherry_pick_job:
     permissions:
       pull-requests: write
       contents: write
-    if: github.event.pull_request.merged == true
+    
+    # Only run when pull request is merged
+    # or when a comment starting with `/backport` is created by someone other than the
+    # https://github.com/apps/trustification-ci-bot bot user (user id: 199085543). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
+    # To get Github App user id we can do: 'curl -H "Authorization: Bearer token" -s https://api.github.com/users/trustification-ci-bot%5Bbot%5D'
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 199085543 &&
+        startsWith(github.event.comment.body, '/backport')
+      )
     secrets: inherit
     uses: trustification/release-tools/.github/workflows/backport.yaml@main


### PR DESCRIPTION
The main branch backport.yaml workflow requires the appropriate label to be added before the PR is merged.

If for any reason we forgot to add the label and we still need to backport a PR after it has been merged then:
- Add the appropriate label to indicate to which branch we need to backport
- Add a comment with `/backport` and it should trigger a backport even though the PR has been merged already.

Since the PR has been merged already hence CLOSED I think it is better for the user to make a conscious decision typing `/backport` to trigger a backport