### PR TITLE
fix: show null severity in vulnerability when it's null in advisory

### DIFF
--- a/etc/test-data/cve/CVE-1999-0001.json
+++ b/etc/test-data/cve/CVE-1999-0001.json
@@ -1,0 +1,162 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "product": "n/a",
+                    "vendor": "n/a",
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "n/a"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "ip_input.c in BSD-derived TCP/IP implementations allows remote attackers to cause a denial of service (crash or hang) via crafted packets."
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "description": "n/a",
+                            "lang": "en",
+                            "type": "text"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "dateUpdated": "2005-12-17T00:00:00",
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "x_refsource_CONFIRM"
+                    ],
+                    "url": "http://www.openbsd.org/errata23.html#tcpfix"
+                },
+                {
+                    "name": "5707",
+                    "tags": [
+                        "vdb-entry",
+                        "x_refsource_OSVDB"
+                    ],
+                    "url": "http://www.osvdb.org/5707"
+                }
+            ],
+            "x_legacyV4Record": {
+                "CVE_data_meta": {
+                    "ASSIGNER": "cve@mitre.org",
+                    "ID": "CVE-1999-0001",
+                    "STATE": "PUBLIC"
+                },
+                "affects": {
+                    "vendor": {
+                        "vendor_data": [
+                            {
+                                "product": {
+                                    "product_data": [
+                                        {
+                                            "product_name": "n/a",
+                                            "version": {
+                                                "version_data": [
+                                                    {
+                                                        "version_value": "n/a"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "vendor_name": "n/a"
+                            }
+                        ]
+                    }
+                },
+                "data_format": "MITRE",
+                "data_type": "CVE",
+                "data_version": "4.0",
+                "description": {
+                    "description_data": [
+                        {
+                            "lang": "eng",
+                            "value": "ip_input.c in BSD-derived TCP/IP implementations allows remote attackers to cause a denial of service (crash or hang) via crafted packets."
+                        }
+                    ]
+                },
+                "problemtype": {
+                    "problemtype_data": [
+                        {
+                            "description": [
+                                {
+                                    "lang": "eng",
+                                    "value": "n/a"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "references": {
+                    "reference_data": [
+                        {
+                            "name": "http://www.openbsd.org/errata23.html#tcpfix",
+                            "refsource": "CONFIRM",
+                            "url": "http://www.openbsd.org/errata23.html#tcpfix"
+                        },
+                        {
+                            "name": "5707",
+                            "refsource": "OSVDB",
+                            "url": "http://www.osvdb.org/5707"
+                        }
+                    ]
+                }
+            }
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-01T16:03:04.917Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "tags": [
+                            "x_refsource_CONFIRM",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openbsd.org/errata23.html#tcpfix"
+                    },
+                    {
+                        "name": "5707",
+                        "tags": [
+                            "vdb-entry",
+                            "x_refsource_OSVDB",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.osvdb.org/5707"
+                    }
+                ]
+            }
+        ]
+    },
+    "cveMetadata": {
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "cveId": "CVE-1999-0001",
+        "datePublished": "2000-02-04T05:00:00",
+        "dateReserved": "1999-06-07T00:00:00",
+        "dateUpdated": "2024-08-01T16:03:04.917Z",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1"
+}

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -21,11 +21,11 @@ pub struct AdvisoryVulnerabilityHead {
     /// Medium: 4.0–6.9
     /// Low: 0.1–3.9
     /// None: 0
-    pub severity: Severity,
+    pub severity: Option<Severity>,
 
     /// The average (arithmetic mean) score this advisory assigns to
     /// the particular vulnerability.
-    pub score: f64,
+    pub score: Option<f64>,
 }
 
 impl AdvisoryVulnerabilityHead {
@@ -40,7 +40,11 @@ impl AdvisoryVulnerabilityHead {
             .all(tx)
             .await?;
 
-        let score = Score::from_iter(cvss3.iter().map(Cvss3Base::from));
+        let score = if cvss3.is_empty() {
+            None
+        } else {
+            Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
+        };
 
         let advisory_vuln = advisory_vulnerability::Entity::find()
             .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
@@ -57,8 +61,8 @@ impl AdvisoryVulnerabilityHead {
             };
             Ok(AdvisoryVulnerabilityHead {
                 head,
-                severity: score.severity(),
-                score: score.value(),
+                severity: score.map(|s| s.severity()),
+                score: score.map(|s| s.value()),
             })
         } else {
             Err(Error::Data(
@@ -82,7 +86,11 @@ impl AdvisoryVulnerabilityHead {
         let mut heads = Vec::new();
 
         for (vuln, cvss3) in vulnerabilities.iter().zip(cvss3s.iter()) {
-            let score = Score::from_iter(cvss3.iter().map(Cvss3Base::from));
+            let score = if cvss3.is_empty() {
+                None
+            } else {
+                Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
+            };
 
             let advisory_vuln = advisory_vulnerability::Entity::find()
                 .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
@@ -98,8 +106,8 @@ impl AdvisoryVulnerabilityHead {
                 };
                 heads.push(AdvisoryVulnerabilityHead {
                     head,
-                    severity: score.severity(),
-                    score: score.value(),
+                    severity: score.map(|s| s.severity()),
+                    score: score.map(|s| s.value()),
                 });
             }
         }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2150,28 +2150,29 @@ components:
       allOf:
       - $ref: '#/components/schemas/VulnerabilityHead'
       - type: object
-        required:
-        - severity
-        - score
         properties:
           score:
-            type: number
+            type:
+            - number
+            - 'null'
             format: double
             description: |-
               The average (arithmetic mean) score this advisory assigns to
               the particular vulnerability.
           severity:
-            $ref: '#/components/schemas/Severity'
-            description: |-
-              The English-language word description of the severity of the given
-              vulnerability, as asserted by the advisory, using the CVSS bucketing
-              ranges.
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Severity'
+              description: |-
+                The English-language word description of the severity of the given
+                vulnerability, as asserted by the advisory, using the CVSS bucketing
+                ranges.
 
-              Critical: 9.0–10.0
-              High: 7.0–8.9
-              Medium: 4.0–6.9
-              Low: 0.1–3.9
-              None: 0
+                Critical: 9.0–10.0
+                High: 7.0–8.9
+                Medium: 4.0–6.9
+                Low: 0.1–3.9
+                None: 0
     AdvisoryVulnerabilitySummary:
       allOf:
       - $ref: '#/components/schemas/AdvisoryVulnerabilityHead'


### PR DESCRIPTION
Fixes #1374