### PR TITLE
chore: clean up labels API, add tests, handle removing, add docs

### DIFF
--- a/modules/fundamental/README.md
+++ b/modules/fundamental/README.md
@@ -2,7 +2,6 @@
 
 ## Get all SBOMs for a package
 
-
 By PURL:
 
 ```bash
@@ -13,4 +12,47 @@ By package ID (as returned by other APIs):
 
 ```bash
 http localhost:8080/api/v2/sbom/by-purl id==6cfff15d-ee06-4cb7-be37-a835aed2af82
+```
+
+## Labels
+
+**NOTE:** The allowing examples use SBOMs. It works the same way with advisories.
+
+All examples in this section expect the environment variable `ID`
+to point to an SBOM/advisory in the form of `urn:uuid:<id>`.
+
+## Get labels
+
+```bash
+http localhost:8080/api/v2/sbom/$ID | jq .labels
+```
+
+## Mutate labels
+
+Replace all labels:
+
+```bash
+http PUT localhost:8080/api/v2/sbom/$ID/label foo=bar bar=baz baz= 
+```
+
+This will replace all existing labels with the following labels:
+
+| Key   | Value   |
+|-------|---------|
+| `foo` | `bar`   |
+| `bar` | `baz`   |
+| `baz` | *empty* |
+
+Update (patch) labels:
+
+```bash
+http PATCH localhost:8080/api/v2/sbom/$ID/label foo=bar bar=
+```
+
+This will set `foo` to `bar` and remove the label `bar`.
+
+## Search by labels
+
+```bash
+http GET localhost:8080/api/v2/sbom 'q==label:foo=bar' | jq '.items[] | {id, name, labels}'
 ```

--- a/modules/fundamental/src/advisory/endpoints/label.rs
+++ b/modules/fundamental/src/advisory/endpoints/label.rs
@@ -1,9 +1,8 @@
 use crate::advisory::service::AdvisoryService;
 use actix_web::{HttpResponse, Responder, patch, put, web};
 use trustify_auth::{UpdateAdvisory, authorizer::Require};
-use trustify_common::db::Database;
-use trustify_common::id::Id;
-use trustify_entity::labels::Labels;
+use trustify_common::{db::Database, id::Id};
+use trustify_entity::labels::{Labels, Update};
 
 /// Replace the labels of an advisory
 #[utoipa::path(
@@ -41,7 +40,7 @@ pub async fn set(
 #[utoipa::path(
     tag = "advisory",
     operation_id = "patchAdvisoryLabels",
-    request_body = Labels,
+    request_body = Update,
     params(
         ("id" = Id, Path, description = "Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'"),
     ),
@@ -54,12 +53,12 @@ pub async fn set(
 pub async fn update(
     advisory: web::Data<AdvisoryService>,
     id: web::Path<Id>,
-    web::Json(update): web::Json<Labels>,
+    web::Json(update): web::Json<Update>,
     _: Require<UpdateAdvisory>,
 ) -> actix_web::Result<impl Responder> {
     Ok(
         match advisory
-            .update_labels(id.into_inner(), |labels| labels.apply(update))
+            .update_labels(id.into_inner(), |labels| update.apply_to(labels))
             .await?
         {
             Some(()) => HttpResponse::NoContent(),

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1,6 +1,6 @@
 use crate::{
     sbom::model::{SbomPackage, SbomSummary},
-    test::caller,
+    test::{caller, label::Api},
 };
 use actix_http::StatusCode;
 use actix_web::test::TestRequest;
@@ -10,11 +10,9 @@ use std::io::Read;
 use test_context::test_context;
 use test_log::test;
 use trustify_common::{id::Id, model::PaginatedResults};
-use trustify_entity::labels::Labels;
 use trustify_module_ingestor::{model::IngestResult, service::Format};
 use trustify_test_context::{TrustifyContext, call::CallService, document_bytes};
 use urlencoding::encode;
-use uuid::Uuid;
 
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
@@ -121,41 +119,29 @@ async fn filter_packages(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Test setting labels
+/// Test updating labels
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn set_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let app = caller(ctx).await?;
-    let result = ctx
-        .ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
-        .await?;
-    let request = TestRequest::patch()
-        .uri(&format!("/api/v2/sbom/{}/label", result.id))
-        .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
-        .to_request();
-    let response = app.call_service(request).await;
-    log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-    Ok(())
+async fn update_labels(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    crate::test::label::update_labels(
+        ctx,
+        Api::Sbom,
+        "quarkus-bom-2.13.8.Final-redhat-00004.json",
+        "spdx",
+    )
+    .await
 }
 
-/// Test setting labels, for a document that does not exists
+/// Test updating labels, for a document that does not exist
 #[test_context(TrustifyContext)]
 #[test(actix_web::test)]
-async fn set_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
-    let app = caller(ctx).await?;
-    ctx.ingest_document("quarkus-bom-2.13.8.Final-redhat-00004.json")
-        .await?;
-    let request = TestRequest::patch()
-        .uri(&format!("/api/v2/sbom/{}/label", Id::Uuid(Uuid::now_v7())))
-        .set_json(Labels::new().extend([("foo", "1"), ("bar", "2")]))
-        .to_request();
-    let response = app.call_service(request).await;
-    log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-    Ok(())
+async fn update_labels_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    crate::test::label::update_labels_not_found(
+        ctx,
+        Api::Sbom,
+        "quarkus-bom-2.13.8.Final-redhat-00004.json",
+    )
+    .await
 }
 
 /// Test deleting an sbom

--- a/modules/fundamental/src/test/label.rs
+++ b/modules/fundamental/src/test/label.rs
@@ -1,0 +1,141 @@
+use crate::test::caller;
+use actix_http::StatusCode;
+use actix_web::test::TestRequest;
+use serde_json::{Value, json};
+use std::fmt::Display;
+use trustify_common::id::Id;
+use trustify_entity::labels::{Labels, Update};
+use trustify_test_context::{TrustifyContext, call::CallService};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Api {
+    Advisory,
+    Sbom,
+}
+
+impl Api {
+    pub fn into_uri(self, id: impl Display, suffix: Option<&str>) -> String {
+        let suffix = suffix.unwrap_or("");
+        match self {
+            Self::Advisory => format!(
+                "/api/v2/advisory/{}{suffix}",
+                urlencoding::encode(&id.to_string())
+            ),
+            Self::Sbom => format!(
+                "/api/v2/sbom/{}{suffix}",
+                urlencoding::encode(&id.to_string())
+            ),
+        }
+    }
+}
+
+/// get labels and assert equality
+pub async fn assert_labels<C: CallService>(
+    app: &C,
+    api: Api,
+    id: impl Display,
+    labels: Value,
+) -> anyhow::Result<()> {
+    let request = TestRequest::get().uri(&api.into_uri(id, None)).to_request();
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = actix_web::test::read_body_json(response).await;
+
+    assert_eq!(labels, json["labels"]);
+
+    Ok(())
+}
+
+/// Test updating labels
+pub async fn update_labels(
+    ctx: &TrustifyContext,
+    api: Api,
+    path: &str,
+    r#type: &str,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let result = ctx.ingest_document(path).await?;
+    let id = &result.id;
+
+    assert_labels(
+        &app,
+        api,
+        id,
+        json!({
+            "source": "TrustifyContext",
+            "type": r#type,
+        }),
+    )
+    .await?;
+
+    // mutate labels, add one, replace one, delete one
+
+    let request = TestRequest::patch()
+        .uri(&api.into_uri(id, Some("/label")))
+        .set_json(Update::new().extend([
+            ("foo", Some("bar")),
+            ("source", Some("different")),
+            ("type", None),
+        ]))
+        .to_request();
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    assert_labels(
+        &app,
+        api,
+        id,
+        json!({
+            "source": "different",
+            "foo": "bar",
+        }),
+    )
+    .await?;
+
+    // not perform a "replace" operation
+
+    let request = TestRequest::put()
+        .uri(&api.into_uri(id, Some("/label")))
+        .set_json(Labels::new().extend([("bar", "foo")]))
+        .to_request();
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    assert_labels(
+        &app,
+        api,
+        id,
+        json!({
+            "bar": "foo",
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Test updating labels, for a document that does not exist
+pub async fn update_labels_not_found(
+    ctx: &TrustifyContext,
+    api: Api,
+    path: &str,
+) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    ctx.ingest_document(path).await?;
+
+    let request = TestRequest::patch()
+        .uri(&api.into_uri(Id::Uuid(Uuid::now_v7()), Some("/label")))
+        .set_json(Update::new().extend([("foo", Some("1")), ("bar", Some("2"))]))
+        .to_request();
+
+    let response = app.call_service(request).await;
+    log::debug!("Code: {}", response.status());
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/modules/fundamental/src/test/mod.rs
+++ b/modules/fundamental/src/test/mod.rs
@@ -1,2 +1,4 @@
+pub mod label;
+
 use crate::endpoints::{Config, configure};
 include!("common.rs");

--- a/modules/importer/src/runner/clearly_defined_curation/mod.rs
+++ b/modules/importer/src/runner/clearly_defined_curation/mod.rs
@@ -42,7 +42,7 @@ impl<C: RunContext> Context<C> {
                         .add("source", &self.source)
                         .add("importer", self.context.name())
                         .add("file", path.to_string_lossy())
-                        .extend(&self.labels.0),
+                        .extend(self.labels.0.clone()),
                     None,
                     Cache::Skip,
                 )

--- a/modules/importer/src/runner/csaf/storage.rs
+++ b/modules/importer/src/runner/csaf/storage.rs
@@ -42,7 +42,7 @@ impl<C: RunContext, S: Source> ValidatedVisitor<S> for StorageVisitor<C> {
                     .add("source", &location)
                     .add("importer", self.context.name())
                     .add("file", file)
-                    .extend(&self.labels.0),
+                    .extend(self.labels.0.clone()),
                 None, /* CSAF tracks issuer internally */
                 Cache::Skip,
             )

--- a/modules/importer/src/runner/cve/mod.rs
+++ b/modules/importer/src/runner/cve/mod.rs
@@ -42,7 +42,7 @@ impl<C: RunContext> Context<C> {
                         .add("source", &self.source)
                         .add("importer", self.context.name())
                         .add("file", path.to_string_lossy())
-                        .extend(&self.labels.0),
+                        .extend(self.labels.0.clone()),
                     None,
                     Cache::Skip,
                 )

--- a/modules/importer/src/runner/osv/mod.rs
+++ b/modules/importer/src/runner/osv/mod.rs
@@ -69,7 +69,7 @@ impl<C: RunContext> Context<C> {
                         .add("source", &self.source)
                         .add("importer", self.context.name())
                         .add("file", path.to_string_lossy())
-                        .extend(&self.labels.0),
+                        .extend(self.labels.0.clone()),
                     None,
                     Cache::Skip,
                 )

--- a/modules/importer/src/runner/sbom/storage.rs
+++ b/modules/importer/src/runner/sbom/storage.rs
@@ -76,7 +76,7 @@ impl<C: RunContext> ValidatedVisitor<HttpSource> for StorageVisitor<C> {
                     .add("source", &self.source)
                     .add("importer", self.context.name())
                     .add("file", &file)
-                    .extend(&self.labels.0),
+                    .extend(self.labels.0.clone()),
                 None,
                 Cache::Skip,
             )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,7 +171,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Labels'
+              $ref: '#/components/schemas/Update'
         required: true
       responses:
         '204':
@@ -1585,7 +1585,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Labels'
+              $ref: '#/components/schemas/Update'
         required: true
       responses:
         '204':
@@ -3633,6 +3633,16 @@ components:
         properties:
           cpe:
             type: string
+    Update:
+      type: object
+      description: |
+        An update set for labels.
+
+        This is a key/value set, where the value can be a string for setting that value, or `null` for removing the label.
+      additionalProperties:
+        oneOf:
+        - type: 'null'
+        - type: string
     VersionedPurlHead:
       type: object
       required:


### PR DESCRIPTION
While documenting some examples, I noted that tags with empty values are a problem when patch-updating. Fixing that, adding tests, align tests between sbom and advisories. And give some examples.