### PR TITLE
Revert #1585

### DIFF
--- a/common/src/db/query.rs
+++ b/common/src/db/query.rs
@@ -278,7 +278,6 @@ pub(crate) mod tests {
             pub published: Option<OffsetDateTime>,
             pub severity: Severity,
             pub score: f64,
-            pub authors: Option<Vec<String>>,
             #[sea_orm(column_type = "JsonBinary")]
             pub purl: CanonicalPurl,
         }

--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 
 use chrono::Local;
 use human_date_parser::{ParseResult, from_human_time};
 use sea_orm::{
-    ColumnTrait, ColumnType, EntityTrait, IntoIdentity, Iterable, Value as SeaValue, sea_query,
+    ColumnTrait, ColumnType, EntityTrait, IntoIdentity, Iterable, Value as SeaValue,
+    entity::ColumnDef, sea_query,
 };
 use sea_query::{
     Alias, ColumnRef, Expr, ExprTrait, Func, IntoColumnRef, IntoIden, SimpleExpr,
@@ -24,6 +25,35 @@ pub struct Columns {
     translator: Option<Translator>,
     json_keys: BTreeMap<&'static str, ColumnRef>,
     exprs: BTreeMap<&'static str, (SimpleExpr, ColumnType)>,
+}
+
+impl Display for Columns {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (r, ty) in &self.columns {
+            writeln!(f)?;
+            match r {
+                ColumnRef::SchemaTableColumn(_, t, c) | ColumnRef::TableColumn(t, c) => {
+                    write!(f, "  \"{}\".\"{}\"", t.to_string(), c.to_string())?
+                }
+                ColumnRef::Column(c) => write!(f, "  \"{}\"", c.to_string())?,
+                _ => write!(f, "  {r:?}")?,
+            }
+            write!(f, " : ")?;
+            match ty {
+                ColumnType::Text | ColumnType::String(_) | ColumnType::Char(_) => {
+                    write!(f, "String")?
+                }
+                ColumnType::Enum { name, variants } => write!(
+                    f,
+                    "Enum({}) {:?}",
+                    name.to_string(),
+                    variants.iter().map(|v| v.to_string()).collect::<Vec<_>>()
+                )?,
+                t => write!(f, "  {t:?}")?,
+            }
+        }
+        Ok(())
+    }
 }
 
 pub trait IntoColumns {
@@ -64,9 +94,11 @@ impl Columns {
     }
 
     /// Add an arbitrary column into the context.
-    pub fn add_column<I: IntoIdentity>(mut self, name: I, ty: ColumnType) -> Self {
-        self.columns
-            .push((name.into_identity().into_column_ref(), ty));
+    pub fn add_column<I: IntoIdentity>(mut self, name: I, def: ColumnDef) -> Self {
+        self.columns.push((
+            name.into_identity().into_column_ref(),
+            def.get_column_type().clone(),
+        ));
         self
     }
 
@@ -313,7 +345,7 @@ mod tests {
     use super::super::tests::*;
     use super::super::*;
     use super::*;
-    use sea_orm::{ColumnType, QuerySelect, QueryTrait};
+    use sea_orm::{ColumnType, ColumnTypeTrait, QuerySelect, QueryTrait};
     use sea_query::{Expr, Func, SimpleExpr};
     use test_log::test;
 
@@ -332,7 +364,7 @@ mod tests {
                 q("location_len>10"),
                 advisory::Entity
                     .columns()
-                    .add_column("location_len", ColumnType::Integer),
+                    .add_column("location_len", ColumnType::Integer.def()),
             )?
             .build(sea_orm::DatabaseBackend::Postgres)
             .to_string();
@@ -347,11 +379,11 @@ mod tests {
 
     #[test(tokio::test)]
     async fn filters_extra_columns() -> Result<(), anyhow::Error> {
-        let test = |s: &str, expected: &str, ty: ColumnType| {
+        let test = |s: &str, expected: &str, def: ColumnDef| {
             let stmt = advisory::Entity::find()
                 .select_only()
                 .column(advisory::Column::Id)
-                .filtering_with(q(s), advisory::Entity.columns().add_column("len", ty))
+                .filtering_with(q(s), advisory::Entity.columns().add_column("len", def))
                 .unwrap()
                 .build(sea_orm::DatabaseBackend::Postgres)
                 .to_string()
@@ -363,14 +395,14 @@ mod tests {
         };
 
         use ColumnType::*;
-        test("len=42", r#""len" = 42"#, Integer);
-        test("len!=42", r#""len" <> 42"#, Integer);
-        test("len~42", r#""len" ILIKE '%42%'"#, Text);
-        test("len!~42", r#""len" NOT ILIKE '%42%'"#, Text);
-        test("len>42", r#""len" > 42"#, Integer);
-        test("len>=42", r#""len" >= 42"#, Integer);
-        test("len<42", r#""len" < 42"#, Integer);
-        test("len<=42", r#""len" <= 42"#, Integer);
+        test("len=42", r#""len" = 42"#, Integer.def());
+        test("len!=42", r#""len" <> 42"#, Integer.def());
+        test("len~42", r#""len" ILIKE '%42%'"#, Text.def());
+        test("len!~42", r#""len" NOT ILIKE '%42%'"#, Text.def());
+        test("len>42", r#""len" > 42"#, Integer.def());
+        test("len>=42", r#""len" >= 42"#, Integer.def());
+        test("len<42", r#""len" < 42"#, Integer.def());
+        test("len<=42", r#""len" <= 42"#, Integer.def());
 
         Ok(())
     }

--- a/common/src/db/query/columns.rs
+++ b/common/src/db/query/columns.rs
@@ -8,7 +8,7 @@ use sea_orm::{
     entity::ColumnDef, sea_query,
 };
 use sea_query::{
-    Alias, ColumnRef, Expr, ExprTrait, Func, IntoColumnRef, IntoIden, SimpleExpr,
+    Alias, ColumnRef, Expr, ExprTrait, IntoColumnRef, IntoIden, SimpleExpr,
     extension::postgres::PgExpr,
 };
 use time::{
@@ -190,18 +190,12 @@ impl Columns {
         value: &str,
     ) -> Result<SimpleExpr, Error> {
         self.for_field(field).and_then(|(lhs, ct)| {
-            match (value.to_lowercase().as_str(), operator, &ct) {
-                ("null", Operator::Equal, _) => Ok(lhs.is_null()),
-                ("null", Operator::NotEqual, _) => Ok(lhs.is_not_null()),
-                (v, op, ColumnType::Array(_)) => match op {
-                    Operator::Like => Ok(array_to_string(lhs).ilike(like(v))),
-                    Operator::NotLike => Ok(array_to_string(lhs).not_ilike(like(v))),
-                    Operator::NotEqual => Ok(Expr::val(value).binary(op, all(lhs))),
-                    _ => Ok(Expr::val(value).binary(op, any(lhs))),
-                },
-                (v, Operator::Like, _) => Ok(lhs.ilike(like(v))),
-                (v, Operator::NotLike, _) => Ok(lhs.not_ilike(like(v))),
-                (_, _, ct) => parse(value, ct).map(|rhs| lhs.binary(operator, rhs)),
+            match (value.to_lowercase().as_str(), operator) {
+                ("null", Operator::Equal) => Ok(lhs.is_null()),
+                ("null", Operator::NotEqual) => Ok(lhs.is_not_null()),
+                (_, Operator::Like) => Ok(lhs.ilike(like(value))),
+                (_, Operator::NotLike) => Ok(lhs.not_ilike(like(value))),
+                _ => parse(value, &ct).map(|rhs| lhs.binary(operator, rhs)),
             }
         })
     }
@@ -289,20 +283,6 @@ impl Columns {
 
 fn like(s: &str) -> String {
     format!("%{}%", s.replace('%', r"\%").replace('_', r"\_"))
-}
-
-fn array_to_string(expr: SimpleExpr) -> SimpleExpr {
-    SimpleExpr::FunctionCall(
-        Func::cust("array_to_string".into_identity())
-            .arg(expr)
-            .arg("|"),
-    )
-}
-fn any(expr: SimpleExpr) -> SimpleExpr {
-    SimpleExpr::FunctionCall(Func::cust("ANY".into_identity()).arg(expr))
-}
-fn all(expr: SimpleExpr) -> SimpleExpr {
-    SimpleExpr::FunctionCall(Func::cust("ALL".into_identity()).arg(expr))
 }
 
 fn parse(s: &str, ct: &ColumnType) -> Result<SimpleExpr, Error> {
@@ -591,47 +571,6 @@ mod tests {
         );
         assert!(clause(q("missing:name=log4j")).is_err());
         assert!(clause(q("").sort(r"missing:name")).is_err());
-
-        Ok(())
-    }
-
-    #[test(tokio::test)]
-    async fn array_queries() -> Result<(), anyhow::Error> {
-        let clause = |query: Query| -> Result<String, Error> {
-            Ok(advisory::Entity::find()
-                .filtering(query)?
-                .build(sea_orm::DatabaseBackend::Postgres)
-                .to_string()
-                .split("WHERE ")
-                .last()
-                .unwrap()
-                .to_string())
-        };
-
-        assert_eq!(
-            clause(q("authors=null"))?,
-            r#""advisory"."authors" IS NULL"#
-        );
-        assert_eq!(
-            clause(q("authors~foo"))?,
-            r#"array_to_string("advisory"."authors", '|') ILIKE '%foo%'"#
-        );
-        assert_eq!(
-            clause(q("authors~foo|bar"))?,
-            r#"(array_to_string("advisory"."authors", '|') ILIKE '%foo%') OR (array_to_string("advisory"."authors", '|') ILIKE '%bar%')"#
-        );
-        assert_eq!(
-            clause(q("authors!~foo"))?,
-            r#"array_to_string("advisory"."authors", '|') NOT ILIKE '%foo%'"#
-        );
-        assert_eq!(
-            clause(q("authors=Foo"))?,
-            r#"'Foo' = ANY("advisory"."authors")"#
-        );
-        assert_eq!(
-            clause(q("authors!=FOO"))?,
-            r#"'FOO' <> ALL("advisory"."authors")"#
-        );
 
         Ok(())
     }

--- a/common/src/db/query/filtering.rs
+++ b/common/src/db/query/filtering.rs
@@ -18,7 +18,7 @@ pub trait Filtering<T: EntityTrait> {
     {
         let Query { ref q, ref sort } = search;
         let columns = context.columns();
-        log::debug!("Query: q='{q}' sort='{sort}' columns={columns:#?}");
+        log::debug!("Query: q='{q}' sort='{sort}' columns={columns}");
 
         let stmt = if q.is_empty() {
             self

--- a/common/src/db/query/sort.rs
+++ b/common/src/db/query/sort.rs
@@ -37,7 +37,7 @@ pub(crate) mod tests {
     use super::super::*;
     use super::*;
 
-    use sea_orm::ColumnType;
+    use sea_orm::{ColumnType, ColumnTypeTrait};
     use sea_query::StringLen;
     use test_log::test;
 
@@ -76,7 +76,7 @@ pub(crate) mod tests {
                 "foo",
                 &advisory::Entity
                     .columns()
-                    .add_column("foo", ColumnType::String(StringLen::None))
+                    .add_column("foo", ColumnType::String(StringLen::None).def())
             )
             .is_ok()
         );
@@ -87,7 +87,7 @@ pub(crate) mod tests {
                 "bar",
                 &advisory::Entity
                     .columns()
-                    .add_column("foo", ColumnType::String(StringLen::None))
+                    .add_column("foo", ColumnType::String(StringLen::None).def())
             )
             .is_err()
         );

--- a/modules/fundamental/src/advisory/service/mod.rs
+++ b/modules/fundamental/src/advisory/service/mod.rs
@@ -3,11 +3,13 @@ use crate::{
     advisory::model::{AdvisoryDetails, AdvisorySummary},
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait,
-    FromQueryResult, IntoActiveModel, IntoIdentity, QueryResult, QuerySelect, QueryTrait,
-    RelationTrait, Select, Statement, TransactionTrait,
+    ActiveModelTrait, ActiveValue::Set, ConnectionTrait,
+    DatabaseBackend, DbErr, EntityTrait, FromQueryResult, IntoActiveModel, IntoIdentity,
+    QueryResult, QuerySelect, QueryTrait, RelationTrait, Select, Statement, TransactionTrait,
 };
-use sea_query::{ColumnRef, ColumnType, Expr, Func, IntoColumnRef, IntoIden, JoinType, SimpleExpr};
+use sea_query::{
+    ColumnRef, ColumnType, Expr, Func, IntoColumnRef, IntoIden, JoinType, SimpleExpr,
+};
 use trustify_common::{
     db::{
         Database, UpdateDeprecatedAdvisory,

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -83,7 +83,7 @@ impl VulnerabilityService {
             .filtering_with(
                 search,
                 Columns::from_entity::<vulnerability::Entity>()
-                    .add_column("average_score", ColumnType::Decimal(None))
+                    .add_column("average_score", ColumnType::Decimal(None).def())
                     .add_column(
                         "average_severity",
                         ColumnType::Enum {
@@ -95,7 +95,8 @@ impl VulnerabilityService {
                                 "high".into_identity().into_iden(),
                                 "critical".into_identity().into_iden(),
                             ],
-                        },
+                        }
+                        .def(),
                     )
                     .translator(|f, op, v| match (f, v) {
                         // v = "" for all sort fields


### PR DESCRIPTION
Tonight's performance regression seems to be cause by #1585:

```
HEAD: 
 3: test                 
   1: logon               |        6.90 |          6 |           9 |          7
   2: search_advisory     |        4919 |      4,769 |       5,173 |      4,769

minus b27418b4306f458e23665c70869a1b19ae1abd99,d914a349bc2342ad2f659c5c370f903561acf2d6:
 3: test                 
   1: logon               |        6.98 |          6 |          17 |          7
   2: search_advisory     |      301.93 |        193 |         460 |        300
```

