### PR TITLE
fix: remove duplicate UNION in gc_purls SELECT

### DIFF
--- a/modules/fundamental/src/purl/service/gc_purls.sql
+++ b/modules/fundamental/src/purl/service/gc_purls.sql
@@ -62,7 +62,7 @@ WITH
         (
             SELECT * from deleted_base_purl
         ) UNION (
-            SELECT * from deleted_base_purl
+            SELECT * from deleted_versioned_purl
         ) UNION (
             SELECT * from deleted_qualified_purl
         )

--- a/modules/fundamental/src/purl/service/test.rs
+++ b/modules/fundamental/src/purl/service/test.rs
@@ -782,7 +782,7 @@ async fn gc_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // running the gc, should delete those orphaned purls
     let deleted_records_count = purl_service.gc_purls(&ctx.db).await?;
-    assert_eq!(792, deleted_records_count);
+    assert_eq!(978, deleted_records_count);
 
     let result = purl_service
         .purls(Query::default(), Paginated::default(), &ctx.db)
@@ -801,7 +801,7 @@ async fn gc_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     // running the gc, should delete those orphaned purls
     let deleted_records_count = purl_service.gc_purls(&ctx.db).await?;
-    assert_eq!(1759, deleted_records_count);
+    assert_eq!(2639, deleted_records_count);
 
     let result = purl_service
         .purls(Query::default(), Paginated::default(), &ctx.db)


### PR DESCRIPTION
Note: This does not address the performance issue described in https://github.com/trustification/trustify/issues/1589, but the duplication still needed to be resolved.