### PR TITLE
chore: deprecate vulnerability delete endpoint (TC-2519) [Backport release/0.2.z]

### DIFF
--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -9,6 +9,7 @@ pub mod product;
 pub mod purl;
 pub mod sbom;
 pub mod source_document;
+#[allow(deprecated)]
 pub mod vulnerability;
 pub mod weakness;
 

--- a/modules/fundamental/src/vulnerability/endpoints/mod.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/mod.rs
@@ -3,7 +3,6 @@ mod test;
 
 use crate::{
     Error,
-    Error::Internal,
     endpoints::Deprecation,
     vulnerability::{
         model::{VulnerabilityDetails, VulnerabilitySummary},
@@ -11,7 +10,6 @@ use crate::{
     },
 };
 use actix_web::{HttpResponse, Responder, delete, get, web};
-use sea_orm::TransactionTrait;
 use trustify_auth::{DeleteVulnerability, ReadAdvisory, authorizer::Require};
 use trustify_common::{
     db::{Database, query::Query},
@@ -93,42 +91,20 @@ pub async fn get(
         ("id", Path, description = "ID of the vulnerability")
     ),
     responses(
-        (status = 200, description = "Specified vulnerability", body = VulnerabilityDetails),
-        (status = 404, description = "Specified vulnerability not found"),
+        (status = 501, description = "Method not yet implemented"),
     ),
 )]
 #[delete("/v2/vulnerability/{id}")]
+#[deprecated(
+    since = "0.2.19",
+    note = "This endpoint is deprecated and will be removed in a future version."
+)]
 /// Delete vulnerability
 pub async fn delete(
-    state: web::Data<VulnerabilityService>,
-    db: web::Data<Database>,
-    id: web::Path<String>,
+    _state: web::Data<VulnerabilityService>,
+    _db: web::Data<Database>,
+    _id: web::Path<String>,
     _: Require<DeleteVulnerability>,
 ) -> Result<impl Responder, Error> {
-    let tx = db.begin().await?;
-
-    let vuln = state
-        // we ignore deprecated advisories, as we delete the vulnerability anyway.
-        .fetch_vulnerability(
-            &id,
-            trustify_module_ingestor::common::Deprecation::Ignore,
-            &tx,
-        )
-        .await?;
-
-    if let Some(vuln) = vuln {
-        let rows_affected = state
-            .delete_vulnerability(&vuln.head.identifier, &tx)
-            .await?;
-        match rows_affected {
-            0 => Ok(HttpResponse::NotFound().finish()),
-            1 => {
-                tx.commit().await?;
-                Ok(HttpResponse::Ok().json(vuln))
-            }
-            _ => Err(Internal("Unexpected number of rows affected".into())),
-        }
-    } else {
-        Ok(HttpResponse::NotFound().finish())
-    }
+    Ok(HttpResponse::NotImplemented().finish())
 }

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -294,21 +294,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
         .call_service(TestRequest::delete().uri(uri).to_request())
         .await;
     log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // we should not be able to get the vulnerability again
-    let response = app
-        .call_service(TestRequest::get().uri(uri).to_request())
-        .await;
-    log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-    // we should not be able to delete the vulnerability again
-    let response = app
-        .call_service(TestRequest::delete().uri(uri).to_request())
-        .await;
-    log::debug!("Code: {}", response.status());
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2871,14 +2871,9 @@ paths:
         schema:
           type: string
       responses:
-        '200':
-          description: Specified vulnerability
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VulnerabilityDetails'
-        '404':
-          description: Specified vulnerability not found
+        '501':
+          description: Method not yet implemented
+      deprecated: true
   /api/v2/weakness:
     get:
       tags:


### PR DESCRIPTION
# Description
Backport of #1619 to `release/0.2.z`.