### PR TITLE
fix: set vulnerability score from cve advisory

### DIFF
--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -1,9 +1,10 @@
 use crate::{advisory, advisory_vulnerability, vulnerability};
+use async_graphql::{Enum, SimpleObject};
 use sea_orm::entity::prelude::*;
 use std::fmt::{Display, Formatter};
 use trustify_cvss::cvss3;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, SimpleObject)]
 #[sea_orm(table_name = "cvss3")]
 pub struct Model {
     #[sea_orm(primary_key)]
@@ -91,7 +92,7 @@ impl Related<advisory_vulnerability::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_av")]
 pub enum AttackVector {
     #[sea_orm(string_value = "n")]
@@ -126,7 +127,7 @@ impl From<cvss3::AttackVector> for AttackVector {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ac")]
 pub enum AttackComplexity {
     #[sea_orm(string_value = "l")]
@@ -153,7 +154,7 @@ impl From<cvss3::AttackComplexity> for AttackComplexity {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_pr")]
 pub enum PrivilegesRequired {
     #[sea_orm(string_value = "n")]
@@ -184,7 +185,7 @@ impl From<cvss3::PrivilegesRequired> for PrivilegesRequired {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ui")]
 pub enum UserInteraction {
     #[sea_orm(string_value = "n")]
@@ -211,7 +212,7 @@ impl From<cvss3::UserInteraction> for UserInteraction {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_s")]
 pub enum Scope {
     #[sea_orm(string_value = "u")]
@@ -238,7 +239,7 @@ impl From<cvss3::Scope> for Scope {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_c")]
 pub enum Confidentiality {
     #[sea_orm(string_value = "n")]
@@ -269,7 +270,7 @@ impl From<cvss3::Confidentiality> for Confidentiality {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_i")]
 pub enum Integrity {
     #[sea_orm(string_value = "n")]
@@ -300,7 +301,7 @@ impl From<cvss3::Integrity> for Integrity {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_a")]
 pub enum Availability {
     #[sea_orm(string_value = "n")]
@@ -331,7 +332,7 @@ impl From<cvss3::Availability> for Availability {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_severity")]
 pub enum Severity {
     #[sea_orm(string_value = "none")]

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -1,9 +1,13 @@
-use crate::{advisory, advisory_vulnerability, cvss3, vulnerability_description};
+use crate::{
+    advisory, advisory_vulnerability,
+    cvss3::{self, Severity},
+    vulnerability_description,
+};
 use async_graphql::SimpleObject;
 use sea_orm::entity::prelude::*;
 use time::OffsetDateTime;
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, SimpleObject)]
 #[sea_orm(table_name = "vulnerability")]
 #[graphql(concrete(name = "Vulnerability", params()))]
 pub struct Model {
@@ -15,6 +19,8 @@ pub struct Model {
     pub modified: Option<OffsetDateTime>,
     pub withdrawn: Option<OffsetDateTime>,
     pub cwes: Option<Vec<String>>,
+    pub base_score: Option<f64>,
+    pub base_severity: Option<Severity>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/etc/test-data/cve/CVE-2023-20862.json
+++ b/etc/test-data/cve/CVE-2023-20862.json
@@ -1,0 +1,143 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2023-20862",
+        "assignerOrgId": "dcf2e128-44bd-42ed-91e8-88f912c1401d",
+        "assignerShortName": "vmware",
+        "dateUpdated": "2025-02-05T15:47:05.524Z",
+        "dateReserved": "2022-11-01T00:00:00.000Z",
+        "datePublished": "2023-04-19T00:00:00.000Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "dcf2e128-44bd-42ed-91e8-88f912c1401d",
+                "shortName": "vmware",
+                "dateUpdated": "2023-05-26T00:00:00.000Z"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "In Spring Security, versions 5.7.x prior to 5.7.8, versions 5.8.x prior to 5.8.3, and versions 6.0.x prior to 6.0.3, the logout support does not properly clean the security context if using serialized versions. Additionally, it is not possible to explicitly save an empty security context to the HttpSessionSecurityContextRepository. This vulnerability can keep users authenticated even after they performed logout. Users of affected versions should apply the following mitigation. 5.7.x users should upgrade to 5.7.8. 5.8.x users should upgrade to 5.8.3. 6.0.x users should upgrade to 6.0.3."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "Spring Security",
+                    "versions": [
+                        {
+                            "version": "Spring Security, versions 5.7.x prior to 5.7.8, versions 5.8.x prior to 5.8.3, and versions 6.0.x prior to 6.0.3",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://spring.io/security/cve-2023-20862"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20230526-0002/"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "Empty SecurityContext Is Not Properly Saved Upon Logout"
+                        }
+                    ]
+                }
+            ]
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T09:21:32.378Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://spring.io/security/cve-2023-20862",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20230526-0002/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            },
+            {
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "type": "CWE",
+                                "cweId": "CWE-459",
+                                "lang": "en",
+                                "description": "CWE-459 Incomplete Cleanup"
+                            }
+                        ]
+                    }
+                ],
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "scope": "UNCHANGED",
+                            "version": "3.1",
+                            "baseScore": 6.3,
+                            "attackVector": "NETWORK",
+                            "baseSeverity": "MEDIUM",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+                            "integrityImpact": "LOW",
+                            "userInteraction": "NONE",
+                            "attackComplexity": "LOW",
+                            "availabilityImpact": "LOW",
+                            "privilegesRequired": "LOW",
+                            "confidentialityImpact": "LOW"
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2025-02-05T15:45:51.141064Z",
+                                "id": "CVE-2023-20862",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2025-02-05T15:47:05.524Z"
+                }
+            }
+        ]
+    }
+}

--- a/etc/test-data/cve/CVE-2023-39325.json
+++ b/etc/test-data/cve/CVE-2023-39325.json
@@ -1,0 +1,536 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2023-39325",
+        "assignerOrgId": "1bb62c36-49e3-4200-9d77-64a1400537cc",
+        "state": "PUBLISHED",
+        "assignerShortName": "Go",
+        "dateReserved": "2023-07-27T17:05:55.188Z",
+        "datePublished": "2023-10-11T21:15:02.727Z",
+        "dateUpdated": "2025-02-13T17:02:50.341Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "1bb62c36-49e3-4200-9d77-64a1400537cc",
+                "shortName": "Go",
+                "dateUpdated": "2024-04-28T04:05:57.980Z"
+            },
+            "title": "HTTP/2 rapid reset can cause excessive work in net/http",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "Go standard library",
+                    "product": "net/http",
+                    "collectionURL": "https://pkg.go.dev",
+                    "packageName": "net/http",
+                    "versions": [
+                        {
+                            "version": "0",
+                            "lessThan": "1.20.10",
+                            "status": "affected",
+                            "versionType": "semver"
+                        },
+                        {
+                            "version": "1.21.0-0",
+                            "lessThan": "1.21.3",
+                            "status": "affected",
+                            "versionType": "semver"
+                        }
+                    ],
+                    "programRoutines": [
+                        {
+                            "name": "http2serverConn.serve"
+                        },
+                        {
+                            "name": "http2serverConn.processHeaders"
+                        },
+                        {
+                            "name": "http2serverConn.upgradeRequest"
+                        },
+                        {
+                            "name": "http2serverConn.runHandler"
+                        },
+                        {
+                            "name": "ListenAndServe"
+                        },
+                        {
+                            "name": "ListenAndServeTLS"
+                        },
+                        {
+                            "name": "Serve"
+                        },
+                        {
+                            "name": "ServeTLS"
+                        },
+                        {
+                            "name": "Server.ListenAndServe"
+                        },
+                        {
+                            "name": "Server.ListenAndServeTLS"
+                        },
+                        {
+                            "name": "Server.Serve"
+                        },
+                        {
+                            "name": "Server.ServeTLS"
+                        },
+                        {
+                            "name": "http2Server.ServeConn"
+                        }
+                    ],
+                    "defaultStatus": "unaffected"
+                },
+                {
+                    "vendor": "golang.org/x/net",
+                    "product": "golang.org/x/net/http2",
+                    "collectionURL": "https://pkg.go.dev",
+                    "packageName": "golang.org/x/net/http2",
+                    "versions": [
+                        {
+                            "version": "0",
+                            "lessThan": "0.17.0",
+                            "status": "affected",
+                            "versionType": "semver"
+                        }
+                    ],
+                    "programRoutines": [
+                        {
+                            "name": "serverConn.serve"
+                        },
+                        {
+                            "name": "serverConn.processHeaders"
+                        },
+                        {
+                            "name": "serverConn.upgradeRequest"
+                        },
+                        {
+                            "name": "serverConn.runHandler"
+                        },
+                        {
+                            "name": "Server.ServeConn"
+                        }
+                    ],
+                    "defaultStatus": "unaffected"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "description": "CWE-400: Uncontrolled Resource Consumption"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://go.dev/issue/63417"
+                },
+                {
+                    "url": "https://go.dev/cl/534215"
+                },
+                {
+                    "url": "https://go.dev/cl/534235"
+                },
+                {
+                    "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo/m/UDd7VKQuAAAJ"
+                },
+                {
+                    "url": "https://pkg.go.dev/vuln/GO-2023-2102"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20231110-0008/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OXGWPQOJ3JNDW2XIYKIVJ7N7QUIFNM2Q/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HZQIELEIRSZUYTFFH5KTH2YJ4IIQG2KE/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QF5QSYAOPDOWLY6DUHID56Q4HQFYB45I/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XTNLSL44Y5FB6JWADSZH6DCV4JJAAEQY/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ECRC75BQJP6FJN2L7KCKYZW4DSBD7QSD/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4BUK2ZIAGCULOOYDNH25JPU6JBES5NF2/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YRKEXKANQ7BKJW2YTAMP625LJUJZLJ4P/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/D2BBIDR2ZMB3X5BC7SR4SLQMHRMVPY6L/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/T7N5GV4CHH6WAGX3GFMDD3COEOVCZ4RI/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/REMHVVIBDNKSRKNOTV7EQSB7CYQWOUOU/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UTT7DG3QOF5ZNJLUGHDNLRUIN6OWZARP/"
+                },
+                {
+                    "url": "https://security.gentoo.org/glsa/202311-09"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ULQQONMSCQSH5Z5OWFFQHCGEZ3NL4DRJ/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/R3UETKPUB3V5JS5TLZOF3SMTGT5K5APS/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3SZN67IL7HMGMNAVLOTIXLIHUDXZK4LH/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NG7IMPL55MVWU3LCI4JQJT3K2U5CHDV7/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/GSY7SXFFTPZFWDM6XELSDSHZLVW3AHK7/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WCNCBYKZXLDFGAJUB7ZP5VLC3YTHJNVH/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AVZDNSMVDAQJ64LJC5I5U5LDM5753647/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZSVEMQV5ROY5YW5QE3I57HT3ITWG5GCV/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CHHITS4PUOZAKFIUBQAQZC7JWXMOYE4B/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3OVW5V2DM5K5IC3H7O42YDUGNJ74J35O/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KEOTKBUPZXHE3F352JBYNTSNRXYLWD6P/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MZQYOOKHQDQ57LV2IAG6NRFOVXKHJJ3Z/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5RSKA2II6QTD4YUKUNDVJQSRYSFC4VFR/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FTMJ3NJIDAZFWJQQSP3L22MUFJ3UP2PT/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IPWCNYB5PQ5PCVZ4NJT6G56ZYFZ5QBU6/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W2LZSWTV4NV4SNQARNXG5T6LRHP26EW2/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PJCUNGIQDUMZ4Z6HWVYIMR66A35F5S74/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/L5E5JSJBZLYXOTZWXHJKRVCIXIHVWKJ6/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YJWHBLVZDM5KQSDFRBFRKU5KSSOLIRQ4/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3WJ4QVX2AMUJ2F2S27POOAHRC4K3CHU4/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ODBY7RVMGZCBSTWF2OZGIZS57FNFUL67/"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QXOU2JZUBEBP7GBKAYIJRPRBZSJCD7ST/"
+                }
+            ]
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T18:02:06.746Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://go.dev/issue/63417",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://go.dev/cl/534215",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://go.dev/cl/534235",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo/m/UDd7VKQuAAAJ",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://pkg.go.dev/vuln/GO-2023-2102",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20231110-0008/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OXGWPQOJ3JNDW2XIYKIVJ7N7QUIFNM2Q/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HZQIELEIRSZUYTFFH5KTH2YJ4IIQG2KE/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QF5QSYAOPDOWLY6DUHID56Q4HQFYB45I/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XTNLSL44Y5FB6JWADSZH6DCV4JJAAEQY/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ECRC75BQJP6FJN2L7KCKYZW4DSBD7QSD/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4BUK2ZIAGCULOOYDNH25JPU6JBES5NF2/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YRKEXKANQ7BKJW2YTAMP625LJUJZLJ4P/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/D2BBIDR2ZMB3X5BC7SR4SLQMHRMVPY6L/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/T7N5GV4CHH6WAGX3GFMDD3COEOVCZ4RI/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/REMHVVIBDNKSRKNOTV7EQSB7CYQWOUOU/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UTT7DG3QOF5ZNJLUGHDNLRUIN6OWZARP/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.gentoo.org/glsa/202311-09",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ULQQONMSCQSH5Z5OWFFQHCGEZ3NL4DRJ/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/R3UETKPUB3V5JS5TLZOF3SMTGT5K5APS/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3SZN67IL7HMGMNAVLOTIXLIHUDXZK4LH/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NG7IMPL55MVWU3LCI4JQJT3K2U5CHDV7/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/GSY7SXFFTPZFWDM6XELSDSHZLVW3AHK7/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WCNCBYKZXLDFGAJUB7ZP5VLC3YTHJNVH/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/AVZDNSMVDAQJ64LJC5I5U5LDM5753647/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZSVEMQV5ROY5YW5QE3I57HT3ITWG5GCV/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CHHITS4PUOZAKFIUBQAQZC7JWXMOYE4B/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3OVW5V2DM5K5IC3H7O42YDUGNJ74J35O/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KEOTKBUPZXHE3F352JBYNTSNRXYLWD6P/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MZQYOOKHQDQ57LV2IAG6NRFOVXKHJJ3Z/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5RSKA2II6QTD4YUKUNDVJQSRYSFC4VFR/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FTMJ3NJIDAZFWJQQSP3L22MUFJ3UP2PT/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IPWCNYB5PQ5PCVZ4NJT6G56ZYFZ5QBU6/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W2LZSWTV4NV4SNQARNXG5T6LRHP26EW2/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PJCUNGIQDUMZ4Z6HWVYIMR66A35F5S74/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/L5E5JSJBZLYXOTZWXHJKRVCIXIHVWKJ6/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/YJWHBLVZDM5KQSDFRBFRKU5KSSOLIRQ4/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3WJ4QVX2AMUJ2F2S27POOAHRC4K3CHU4/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ODBY7RVMGZCBSTWF2OZGIZS57FNFUL67/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QXOU2JZUBEBP7GBKAYIJRPRBZSJCD7ST/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/etc/test-data/cve/CVE-2023-39326.json
+++ b/etc/test-data/cve/CVE-2023-39326.json
@@ -1,0 +1,138 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2023-39326",
+        "assignerOrgId": "1bb62c36-49e3-4200-9d77-64a1400537cc",
+        "state": "PUBLISHED",
+        "assignerShortName": "Go",
+        "dateReserved": "2023-07-27T17:05:55.188Z",
+        "datePublished": "2023-12-06T16:27:53.832Z",
+        "dateUpdated": "2025-02-13T17:02:50.990Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "1bb62c36-49e3-4200-9d77-64a1400537cc",
+                "shortName": "Go",
+                "dateUpdated": "2024-01-20T04:06:26.754Z"
+            },
+            "title": "Denial of service via chunk extensions in net/http",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A malicious HTTP sender can use chunk extensions to cause a receiver reading from a request or response body to read many more bytes from the network than are in the body. A malicious HTTP client can further exploit this to cause a server to automatically read a large amount of data (up to about 1GiB) when a handler fails to read the entire body of a request. Chunk extensions are a little-used HTTP feature which permit including additional metadata in a request or response body sent using the chunked encoding. The net/http chunked encoding reader discards this metadata. A sender can exploit this by inserting a large metadata segment with each byte transferred. The chunk reader now produces an error if the ratio of real body to encoded bytes grows too small."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "Go standard library",
+                    "product": "net/http/internal",
+                    "collectionURL": "https://pkg.go.dev",
+                    "packageName": "net/http/internal",
+                    "versions": [
+                        {
+                            "version": "0",
+                            "lessThan": "1.20.12",
+                            "status": "affected",
+                            "versionType": "semver"
+                        },
+                        {
+                            "version": "1.21.0-0",
+                            "lessThan": "1.21.5",
+                            "status": "affected",
+                            "versionType": "semver"
+                        }
+                    ],
+                    "programRoutines": [
+                        {
+                            "name": "chunkedReader.beginChunk"
+                        },
+                        {
+                            "name": "readChunkLine"
+                        },
+                        {
+                            "name": "chunkedReader.Read"
+                        }
+                    ],
+                    "defaultStatus": "unaffected"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "description": "CWE-400: Uncontrolled Resource Consumption"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://go.dev/issue/64433"
+                },
+                {
+                    "url": "https://go.dev/cl/547335"
+                },
+                {
+                    "url": "https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ"
+                },
+                {
+                    "url": "https://pkg.go.dev/vuln/GO-2023-2382"
+                },
+                {
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UIU6HOGV6RRIKWM57LOXQA75BGZSIH6G/"
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "value": "Bartek Nowotarski"
+                }
+            ]
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T18:02:06.808Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://go.dev/issue/64433",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://go.dev/cl/547335",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://groups.google.com/g/golang-dev/c/6ypN5EjibjM/m/KmLVYH_uAgAJ",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://pkg.go.dev/vuln/GO-2023-2382",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UIU6HOGV6RRIKWM57LOXQA75BGZSIH6G/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/etc/test-data/cve/CVE-2023-42282.json
+++ b/etc/test-data/cve/CVE-2023-42282.json
@@ -1,0 +1,170 @@
+{
+    "dataType": "CVE_RECORD",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2023-42282",
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "dateUpdated": "2025-05-15T19:42:13.205Z",
+        "dateReserved": "2023-09-08T00:00:00.000Z",
+        "datePublished": "2024-02-08T00:00:00.000Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre",
+                "dateUpdated": "2024-07-03T21:53:10.340Z"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "The ip package before 1.1.9 for Node.js might allow SSRF because some IP addresses (such as 0x7f.1) are improperly categorized as globally routable via isPublic."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://cosmosofcyberspace.github.io/npm_ip_cve/npm_ip_cve.html"
+                },
+                {
+                    "url": "https://github.com/indutny/node-ip/commit/6a3ada9b471b09d5f0f5be264911ab564bf67894"
+                },
+                {
+                    "url": "https://huntr.com/bounties/bfc3b23f-ddc0-4ee7-afab-223b07115ed3/"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20240315-0008/"
+                },
+                {
+                    "url": "https://www.bleepingcomputer.com/news/security/dev-rejects-cve-severity-makes-his-github-repo-read-only/"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "n/a"
+                        }
+                    ]
+                }
+            ]
+        },
+        "adp": [
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-02T19:16:51.020Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://cosmosofcyberspace.github.io/npm_ip_cve/npm_ip_cve.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/indutny/node-ip/commit/6a3ada9b471b09d5f0f5be264911ab564bf67894",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://huntr.com/bounties/bfc3b23f-ddc0-4ee7-afab-223b07115ed3/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240315-0008/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.bleepingcomputer.com/news/security/dev-rejects-cve-severity-makes-his-github-repo-read-only/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    }
+                ]
+            },
+            {
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "type": "CWE",
+                                "cweId": "CWE-918",
+                                "lang": "en",
+                                "description": "CWE-918 Server-Side Request Forgery (SSRF)"
+                            }
+                        ]
+                    }
+                ],
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "scope": "UNCHANGED",
+                            "version": "3.1",
+                            "baseScore": 9.8,
+                            "attackVector": "NETWORK",
+                            "baseSeverity": "CRITICAL",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                            "integrityImpact": "HIGH",
+                            "userInteraction": "NONE",
+                            "attackComplexity": "LOW",
+                            "availabilityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "confidentialityImpact": "HIGH"
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2025-05-08T15:58:36.885808Z",
+                                "id": "CVE-2023-42282",
+                                "options": [
+                                    {
+                                        "Exploitation": "poc"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "total"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2025-05-15T19:42:13.205Z"
+                }
+            }
+        ]
+    },
+    "dataVersion": "5.1"
+}

--- a/etc/test-data/cve/CVE-2023-44487.json
+++ b/etc/test-data/cve/CVE-2023-44487.json
@@ -1,0 +1,1659 @@
+{
+    "dataType": "CVE_RECORD",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2023-44487",
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "dateUpdated": "2024-08-19T07:48:04.546Z",
+        "dateReserved": "2023-09-29T00:00:00",
+        "datePublished": "2023-10-10T00:00:00"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre",
+                "dateUpdated": "2024-06-21T19:08:34.967324"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73"
+                },
+                {
+                    "url": "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/"
+                },
+                {
+                    "url": "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/"
+                },
+                {
+                    "url": "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack"
+                },
+                {
+                    "url": "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/"
+                },
+                {
+                    "url": "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/"
+                },
+                {
+                    "url": "https://news.ycombinator.com/item?id=37831062"
+                },
+                {
+                    "url": "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/"
+                },
+                {
+                    "url": "https://www.phoronix.com/news/HTTP2-Rapid-Reset-Attack"
+                },
+                {
+                    "url": "https://github.com/envoyproxy/envoy/pull/30055"
+                },
+                {
+                    "url": "https://github.com/haproxy/haproxy/issues/2312"
+                },
+                {
+                    "url": "https://github.com/eclipse/jetty.project/issues/10679"
+                },
+                {
+                    "url": "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764"
+                },
+                {
+                    "url": "https://github.com/nghttp2/nghttp2/pull/1961"
+                },
+                {
+                    "url": "https://github.com/netty/netty/commit/58f75f665aa81a8cbcf6ffa74820042a285c5e61"
+                },
+                {
+                    "url": "https://github.com/alibaba/tengine/issues/1872"
+                },
+                {
+                    "url": "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2"
+                },
+                {
+                    "url": "https://news.ycombinator.com/item?id=37830987"
+                },
+                {
+                    "url": "https://news.ycombinator.com/item?id=37830998"
+                },
+                {
+                    "url": "https://github.com/caddyserver/caddy/issues/5877"
+                },
+                {
+                    "url": "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/"
+                },
+                {
+                    "url": "https://github.com/bcdannyboy/CVE-2023-44487"
+                },
+                {
+                    "url": "https://github.com/grpc/grpc-go/pull/6703"
+                },
+                {
+                    "url": "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244"
+                },
+                {
+                    "url": "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0"
+                },
+                {
+                    "url": "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html"
+                },
+                {
+                    "url": "https://my.f5.com/manage/s/article/K000137106"
+                },
+                {
+                    "url": "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/"
+                },
+                {
+                    "url": "https://bugzilla.proxmox.com/show_bug.cgi?id=4988"
+                },
+                {
+                    "url": "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9"
+                },
+                {
+                    "url": "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected"
+                },
+                {
+                    "url": "https://github.com/microsoft/CBL-Mariner/pull/6381"
+                },
+                {
+                    "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo"
+                },
+                {
+                    "url": "https://github.com/facebook/proxygen/pull/466"
+                },
+                {
+                    "url": "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088"
+                },
+                {
+                    "url": "https://github.com/micrictor/http2-rst-stream"
+                },
+                {
+                    "url": "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve"
+                },
+                {
+                    "url": "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/"
+                },
+                {
+                    "url": "https://github.com/h2o/h2o/security/advisories/GHSA-2m7v-gc89-fjqf"
+                },
+                {
+                    "url": "https://github.com/h2o/h2o/pull/3291"
+                },
+                {
+                    "url": "https://github.com/nodejs/node/pull/50121"
+                },
+                {
+                    "url": "https://github.com/dotnet/announcements/issues/277"
+                },
+                {
+                    "url": "https://github.com/golang/go/issues/63417"
+                },
+                {
+                    "url": "https://github.com/advisories/GHSA-vx74-f528-fxqg"
+                },
+                {
+                    "url": "https://github.com/apache/trafficserver/pull/10564"
+                },
+                {
+                    "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487"
+                },
+                {
+                    "url": "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14"
+                },
+                {
+                    "url": "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q"
+                },
+                {
+                    "url": "https://www.openwall.com/lists/oss-security/2023/10/10/6"
+                },
+                {
+                    "url": "https://www.haproxy.com/blog/haproxy-is-not-affected-by-the-http-2-rapid-reset-attack-cve-2023-44487"
+                },
+                {
+                    "url": "https://github.com/opensearch-project/data-prepper/issues/3474"
+                },
+                {
+                    "url": "https://github.com/kubernetes/kubernetes/pull/121120"
+                },
+                {
+                    "url": "https://github.com/oqtane/oqtane.framework/discussions/3367"
+                },
+                {
+                    "url": "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p"
+                },
+                {
+                    "url": "https://netty.io/news/2023/10/10/4-1-100-Final.html"
+                },
+                {
+                    "url": "https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487"
+                },
+                {
+                    "url": "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/"
+                },
+                {
+                    "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack"
+                },
+                {
+                    "url": "https://news.ycombinator.com/item?id=37837043"
+                },
+                {
+                    "url": "https://github.com/kazu-yamamoto/http2/issues/93"
+                },
+                {
+                    "url": "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html"
+                },
+                {
+                    "url": "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1"
+                },
+                {
+                    "url": "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113"
+                },
+                {
+                    "name": "DSA-5522",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5522"
+                },
+                {
+                    "name": "DSA-5521",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5521"
+                },
+                {
+                    "url": "https://access.redhat.com/security/cve/cve-2023-44487"
+                },
+                {
+                    "url": "https://github.com/ninenines/cowboy/issues/1615"
+                },
+                {
+                    "url": "https://github.com/varnishcache/varnish-cache/issues/3996"
+                },
+                {
+                    "url": "https://github.com/tempesta-tech/tempesta/issues/1986"
+                },
+                {
+                    "url": "https://blog.vespa.ai/cve-2023-44487/"
+                },
+                {
+                    "url": "https://github.com/etcd-io/etcd/issues/16740"
+                },
+                {
+                    "url": "https://www.darkreading.com/cloud/internet-wide-zero-day-bug-fuels-largest-ever-ddos-event"
+                },
+                {
+                    "url": "https://istio.io/latest/news/security/istio-security-2023-004/"
+                },
+                {
+                    "url": "https://github.com/junkurihara/rust-rpxy/issues/97"
+                },
+                {
+                    "url": "https://bugzilla.suse.com/show_bug.cgi?id=1216123"
+                },
+                {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803"
+                },
+                {
+                    "url": "https://ubuntu.com/security/CVE-2023-44487"
+                },
+                {
+                    "url": "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125"
+                },
+                {
+                    "url": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3"
+                },
+                {
+                    "url": "https://github.com/apache/httpd-site/pull/10"
+                },
+                {
+                    "url": "https://github.com/projectcontour/contour/pull/5826"
+                },
+                {
+                    "url": "https://github.com/linkerd/website/pull/1695/commits/4b9c6836471bc8270ab48aae6fd2181bc73fd632"
+                },
+                {
+                    "url": "https://github.com/line/armeria/pull/5232"
+                },
+                {
+                    "url": "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/"
+                },
+                {
+                    "url": "https://security.paloaltonetworks.com/CVE-2023-44487"
+                },
+                {
+                    "url": "https://github.com/akka/akka-http/issues/4323"
+                },
+                {
+                    "url": "https://github.com/openresty/openresty/issues/930"
+                },
+                {
+                    "url": "https://github.com/apache/apisix/issues/10320"
+                },
+                {
+                    "url": "https://github.com/Azure/AKS/issues/3947"
+                },
+                {
+                    "url": "https://github.com/Kong/kong/discussions/11741"
+                },
+                {
+                    "url": "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487"
+                },
+                {
+                    "url": "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/"
+                },
+                {
+                    "url": "https://github.com/caddyserver/caddy/releases/tag/v2.7.5"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231013 [SECURITY] [DLA 3617-1] tomcat9 security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html"
+                },
+                {
+                    "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/13/4"
+                },
+                {
+                    "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/13/9"
+                },
+                {
+                    "url": "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/"
+                },
+                {
+                    "url": "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html"
+                },
+                {
+                    "name": "FEDORA-2023-ed2642fd58",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/"
+                },
+                {
+                    "url": "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3621-1] nghttp2 security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20231016-0001/"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3617-2] tomcat9 regression update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html"
+                },
+                {
+                    "name": "[oss-security] 20231018 Vulnerability in Jenkins",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/18/4"
+                },
+                {
+                    "name": "[oss-security] 20231018 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/18/8"
+                },
+                {
+                    "name": "[oss-security] 20231019 CVE-2023-45802: Apache HTTP Server: HTTP/2 stream memory not reclaimed right away on RST",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/19/6"
+                },
+                {
+                    "name": "FEDORA-2023-54fadada12",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3/"
+                },
+                {
+                    "name": "FEDORA-2023-5ff7bf1dd8",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ/"
+                },
+                {
+                    "name": "[oss-security] 20231020 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/10/20/8"
+                },
+                {
+                    "name": "FEDORA-2023-17efd3f2cd",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH/"
+                },
+                {
+                    "name": "FEDORA-2023-d5030c983c",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5/"
+                },
+                {
+                    "name": "FEDORA-2023-0259c3f26f",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ/"
+                },
+                {
+                    "name": "FEDORA-2023-2a9214af5f",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4/"
+                },
+                {
+                    "name": "FEDORA-2023-e9c04d81c1",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y/"
+                },
+                {
+                    "name": "FEDORA-2023-f66fc0f62a",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG/"
+                },
+                {
+                    "name": "FEDORA-2023-4d2fd884ea",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU/"
+                },
+                {
+                    "name": "FEDORA-2023-b2c50535cb",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL/"
+                },
+                {
+                    "name": "FEDORA-2023-fe53e13b5b",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+                },
+                {
+                    "name": "FEDORA-2023-4bf641255e",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231030 [SECURITY] [DLA 3641-1] jetty9 security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00045.html"
+                },
+                {
+                    "name": "DSA-5540",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5540"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231031 [SECURITY] [DLA 3638-1] h2o security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00047.html"
+                },
+                {
+                    "url": "https://discuss.hashicorp.com/t/hcsec-2023-32-vault-consul-and-boundary-affected-by-http-2-rapid-reset-denial-of-service-vulnerability-cve-2023-44487/59715"
+                },
+                {
+                    "name": "FEDORA-2023-1caffb88af",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU/"
+                },
+                {
+                    "name": "FEDORA-2023-3f70b8d406",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK/"
+                },
+                {
+                    "name": "FEDORA-2023-7b52921cae",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A/"
+                },
+                {
+                    "name": "FEDORA-2023-7934802344",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT/"
+                },
+                {
+                    "name": "FEDORA-2023-dbe64661af",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ/"
+                },
+                {
+                    "name": "FEDORA-2023-822aab0a5a",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231105 [SECURITY] [DLA 3645-1] trafficserver security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00001.html"
+                },
+                {
+                    "name": "DSA-5549",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5549"
+                },
+                {
+                    "name": "FEDORA-2023-c0c6a91330",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2MBEPPC36UBVOZZNAXFHKLFGSLCMN5LI/"
+                },
+                {
+                    "name": "FEDORA-2023-492b7be466",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WE2I52RHNNU42PX6NZ2RBUHSFFJ2LVZX/"
+                },
+                {
+                    "name": "DSA-5558",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5558"
+                },
+                {
+                    "name": "[debian-lts-announce] 20231119 [SECURITY] [DLA 3656-1] netty security update",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00012.html"
+                },
+                {
+                    "name": "GLSA-202311-09",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://security.gentoo.org/glsa/202311-09"
+                },
+                {
+                    "name": "DSA-5570",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.debian.org/security/2023/dsa-5570"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20240426-0007/"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20240621-0006/"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20240621-0007/"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "n/a"
+                        }
+                    ]
+                }
+            ]
+        },
+        "adp": [
+            {
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "type": "CWE",
+                                "cweId": "CWE-400",
+                                "lang": "en",
+                                "description": "CWE-400 Uncontrolled Resource Consumption"
+                            }
+                        ]
+                    }
+                ],
+                "affected": [
+                    {
+                        "vendor": "ietf",
+                        "product": "http",
+                        "cpes": [
+                            "cpe:2.3:a:ietf:http:2.0:*:*:*:*:*:*:*"
+                        ],
+                        "defaultStatus": "unknown",
+                        "versions": [
+                            {
+                                "version": "2.0",
+                                "status": "affected"
+                            }
+                        ]
+                    }
+                ],
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "scope": "UNCHANGED",
+                            "version": "3.1",
+                            "baseScore": 7.5,
+                            "attackVector": "NETWORK",
+                            "baseSeverity": "HIGH",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                            "integrityImpact": "NONE",
+                            "userInteraction": "NONE",
+                            "attackComplexity": "LOW",
+                            "availabilityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "confidentialityImpact": "NONE"
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-07-23T20:34:21.334116Z",
+                                "id": "CVE-2023-44487",
+                                "options": [
+                                    {
+                                        "Exploitation": "active"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    },
+                    {
+                        "other": {
+                            "type": "kev",
+                            "content": {
+                                "dateAdded": "2023-10-10",
+                                "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog?search_api_fulltext=CVE-2023-44487"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-07-23T20:35:03.253Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2024-08-19T07:48:04.546Z"
+                },
+                "title": "CVE Program Container",
+                "references": [
+                    {
+                        "url": "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://news.ycombinator.com/item?id=37831062",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.phoronix.com/news/HTTP2-Rapid-Reset-Attack",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/envoyproxy/envoy/pull/30055",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/haproxy/haproxy/issues/2312",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/eclipse/jetty.project/issues/10679",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/nghttp2/nghttp2/pull/1961",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/netty/netty/commit/58f75f665aa81a8cbcf6ffa74820042a285c5e61",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/alibaba/tengine/issues/1872",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://news.ycombinator.com/item?id=37830987",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://news.ycombinator.com/item?id=37830998",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/caddyserver/caddy/issues/5877",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/bcdannyboy/CVE-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/grpc/grpc-go/pull/6703",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://my.f5.com/manage/s/article/K000137106",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.proxmox.com/show_bug.cgi?id=4988",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/microsoft/CBL-Mariner/pull/6381",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/facebook/proxygen/pull/466",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/micrictor/http2-rst-stream",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/h2o/h2o/security/advisories/GHSA-2m7v-gc89-fjqf",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/h2o/h2o/pull/3291",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/nodejs/node/pull/50121",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/dotnet/announcements/issues/277",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/golang/go/issues/63417",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/advisories/GHSA-vx74-f528-fxqg",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/apache/trafficserver/pull/10564",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.openwall.com/lists/oss-security/2023/10/10/6",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.haproxy.com/blog/haproxy-is-not-affected-by-the-http-2-rapid-reset-attack-cve-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/opensearch-project/data-prepper/issues/3474",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/kubernetes/kubernetes/pull/121120",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/oqtane/oqtane.framework/discussions/3367",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://netty.io/news/2023/10/10/4-1-100-Final.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://news.ycombinator.com/item?id=37837043",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/kazu-yamamoto/http2/issues/93",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "DSA-5522",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5522"
+                    },
+                    {
+                        "name": "DSA-5521",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5521"
+                    },
+                    {
+                        "url": "https://access.redhat.com/security/cve/cve-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/ninenines/cowboy/issues/1615",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/varnishcache/varnish-cache/issues/3996",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/tempesta-tech/tempesta/issues/1986",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://blog.vespa.ai/cve-2023-44487/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/etcd-io/etcd/issues/16740",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.darkreading.com/cloud/internet-wide-zero-day-bug-fuels-largest-ever-ddos-event",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://istio.io/latest/news/security/istio-security-2023-004/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/junkurihara/rust-rpxy/issues/97",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.suse.com/show_bug.cgi?id=1216123",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://ubuntu.com/security/CVE-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/apache/httpd-site/pull/10",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/projectcontour/contour/pull/5826",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/linkerd/website/pull/1695/commits/4b9c6836471bc8270ab48aae6fd2181bc73fd632",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/line/armeria/pull/5232",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.paloaltonetworks.com/CVE-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/akka/akka-http/issues/4323",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/openresty/openresty/issues/930",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/apache/apisix/issues/10320",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/Azure/AKS/issues/3947",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/Kong/kong/discussions/11741",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://github.com/caddyserver/caddy/releases/tag/v2.7.5",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231013 [SECURITY] [DLA 3617-1] tomcat9 security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html"
+                    },
+                    {
+                        "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/13/4"
+                    },
+                    {
+                        "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/13/9"
+                    },
+                    {
+                        "url": "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "FEDORA-2023-ed2642fd58",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/"
+                    },
+                    {
+                        "url": "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3621-1] nghttp2 security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html"
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20231016-0001/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3617-2] tomcat9 regression update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html"
+                    },
+                    {
+                        "name": "[oss-security] 20231018 Vulnerability in Jenkins",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/18/4"
+                    },
+                    {
+                        "name": "[oss-security] 20231018 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/18/8"
+                    },
+                    {
+                        "name": "[oss-security] 20231019 CVE-2023-45802: Apache HTTP Server: HTTP/2 stream memory not reclaimed right away on RST",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/19/6"
+                    },
+                    {
+                        "name": "FEDORA-2023-54fadada12",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3/"
+                    },
+                    {
+                        "name": "FEDORA-2023-5ff7bf1dd8",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ/"
+                    },
+                    {
+                        "name": "[oss-security] 20231020 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2023/10/20/8"
+                    },
+                    {
+                        "name": "FEDORA-2023-17efd3f2cd",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH/"
+                    },
+                    {
+                        "name": "FEDORA-2023-d5030c983c",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5/"
+                    },
+                    {
+                        "name": "FEDORA-2023-0259c3f26f",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ/"
+                    },
+                    {
+                        "name": "FEDORA-2023-2a9214af5f",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4/"
+                    },
+                    {
+                        "name": "FEDORA-2023-e9c04d81c1",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y/"
+                    },
+                    {
+                        "name": "FEDORA-2023-f66fc0f62a",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG/"
+                    },
+                    {
+                        "name": "FEDORA-2023-4d2fd884ea",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU/"
+                    },
+                    {
+                        "name": "FEDORA-2023-b2c50535cb",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL/"
+                    },
+                    {
+                        "name": "FEDORA-2023-fe53e13b5b",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+                    },
+                    {
+                        "name": "FEDORA-2023-4bf641255e",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231030 [SECURITY] [DLA 3641-1] jetty9 security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00045.html"
+                    },
+                    {
+                        "name": "DSA-5540",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5540"
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231031 [SECURITY] [DLA 3638-1] h2o security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00047.html"
+                    },
+                    {
+                        "url": "https://discuss.hashicorp.com/t/hcsec-2023-32-vault-consul-and-boundary-affected-by-http-2-rapid-reset-denial-of-service-vulnerability-cve-2023-44487/59715",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "name": "FEDORA-2023-1caffb88af",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU/"
+                    },
+                    {
+                        "name": "FEDORA-2023-3f70b8d406",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK/"
+                    },
+                    {
+                        "name": "FEDORA-2023-7b52921cae",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A/"
+                    },
+                    {
+                        "name": "FEDORA-2023-7934802344",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT/"
+                    },
+                    {
+                        "name": "FEDORA-2023-dbe64661af",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ/"
+                    },
+                    {
+                        "name": "FEDORA-2023-822aab0a5a",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231105 [SECURITY] [DLA 3645-1] trafficserver security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00001.html"
+                    },
+                    {
+                        "name": "DSA-5549",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5549"
+                    },
+                    {
+                        "name": "FEDORA-2023-c0c6a91330",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2MBEPPC36UBVOZZNAXFHKLFGSLCMN5LI/"
+                    },
+                    {
+                        "name": "FEDORA-2023-492b7be466",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WE2I52RHNNU42PX6NZ2RBUHSFFJ2LVZX/"
+                    },
+                    {
+                        "name": "DSA-5558",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5558"
+                    },
+                    {
+                        "name": "[debian-lts-announce] 20231119 [SECURITY] [DLA 3656-1] netty security update",
+                        "tags": [
+                            "mailing-list",
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00012.html"
+                    },
+                    {
+                        "name": "GLSA-202311-09",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://security.gentoo.org/glsa/202311-09"
+                    },
+                    {
+                        "name": "DSA-5570",
+                        "tags": [
+                            "vendor-advisory",
+                            "x_transferred"
+                        ],
+                        "url": "https://www.debian.org/security/2023/dsa-5570"
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240426-0007/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240621-0006/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://security.netapp.com/advisory/ntap-20240621-0007/",
+                        "tags": [
+                            "x_transferred"
+                        ]
+                    },
+                    {
+                        "url": "https://www.vicarius.io/vsociety/posts/rapid-reset-cve-2023-44487-dos-in-http2-understanding-the-root-cause"
+                    }
+                ]
+            }
+        ]
+    },
+    "dataVersion": "5.1"
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -24,6 +24,7 @@ mod m0001030_perf_adv_gin_index;
 mod m0001040_alter_pythonver_cmp;
 mod m0001050_foreign_key_cascade;
 mod m0001060_advisory_vulnerability_indexes;
+mod m0001070_vulnerability_scores;
 mod m0001100_remove_get_purl;
 
 pub struct Migrator;
@@ -52,6 +53,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001040_alter_pythonver_cmp::Migration),
             Box::new(m0001050_foreign_key_cascade::Migration),
             Box::new(m0001060_advisory_vulnerability_indexes::Migration),
+            Box::new(m0001070_vulnerability_scores::Migration),
             Box::new(m0001100_remove_get_purl::Migration),
         ]
     }

--- a/migration/src/m0001070_vulnerability_scores.rs
+++ b/migration/src/m0001070_vulnerability_scores.rs
@@ -1,0 +1,84 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .add_column(ColumnDef::new(Vulnerability::BaseScore).double())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .add_column(ColumnDef::new(Vulnerability::BaseSeverity).enumeration(
+                        Cvss3Severity::Cvss3Severity,
+                        [
+                            Cvss3Severity::None,
+                            Cvss3Severity::Low,
+                            Cvss3Severity::Medium,
+                            Cvss3Severity::High,
+                            Cvss3Severity::Critical,
+                        ],
+                    ))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0001070_vulnerability_scores.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .drop_column(Vulnerability::BaseScore)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Vulnerability::Table)
+                    .drop_column(Vulnerability::BaseSeverity)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Vulnerability {
+    Table,
+    BaseScore,
+    BaseSeverity,
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(DeriveIden)]
+pub enum Cvss3Severity {
+    Cvss3Severity,
+    None,
+    Low,
+    Medium,
+    High,
+    Critical,
+}

--- a/migration/src/m0001070_vulnerability_scores.sql
+++ b/migration/src/m0001070_vulnerability_scores.sql
@@ -1,0 +1,7 @@
+UPDATE vulnerability
+SET base_score = cvss3.score,
+    base_severity = cvss3.severity
+FROM cvss3
+JOIN advisory ON advisory.id = cvss3.advisory_id
+WHERE advisory.labels->>'type' = 'cve'
+  AND vulnerability.id = cvss3.vulnerability_id;

--- a/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
+++ b/modules/fundamental/src/advisory/model/details/advisory_vulnerability.rs
@@ -2,8 +2,8 @@ use crate::{Error, vulnerability::model::VulnerabilityHead};
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
+use trustify_cvss::cvss3::Cvss3Base;
 use trustify_cvss::cvss3::severity::Severity;
-use trustify_cvss::{cvss3::Cvss3Base, cvss3::score::Score};
 use trustify_entity::{advisory, advisory_vulnerability, cvss3, vulnerability};
 use utoipa::ToSchema;
 
@@ -34,18 +34,6 @@ impl AdvisoryVulnerabilityHead {
         vulnerability: &vulnerability::Model,
         tx: &C,
     ) -> Result<Self, Error> {
-        let cvss3 = cvss3::Entity::find()
-            .filter(cvss3::Column::AdvisoryId.eq(advisory.id))
-            .filter(cvss3::Column::VulnerabilityId.eq(&vulnerability.id))
-            .all(tx)
-            .await?;
-
-        let score = if cvss3.is_empty() {
-            None
-        } else {
-            Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
-        };
-
         let advisory_vuln = advisory_vulnerability::Entity::find()
             .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
             .filter(advisory_vulnerability::Column::VulnerabilityId.eq(&vulnerability.id))
@@ -61,8 +49,8 @@ impl AdvisoryVulnerabilityHead {
             };
             Ok(AdvisoryVulnerabilityHead {
                 head,
-                severity: score.map(|s| s.severity()),
-                score: score.map(|s| s.value()),
+                severity: vulnerability.base_severity.map(|s| s.into()),
+                score: vulnerability.base_score,
             })
         } else {
             Err(Error::Data(
@@ -76,22 +64,9 @@ impl AdvisoryVulnerabilityHead {
         vulnerabilities: &[vulnerability::Model],
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
-        let cvss3s = vulnerabilities
-            .load_many(
-                cvss3::Entity::find().filter(cvss3::Column::AdvisoryId.eq(advisory.id)),
-                tx,
-            )
-            .await?;
-
         let mut heads = Vec::new();
 
-        for (vuln, cvss3) in vulnerabilities.iter().zip(cvss3s.iter()) {
-            let score = if cvss3.is_empty() {
-                None
-            } else {
-                Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
-            };
-
+        for vuln in vulnerabilities.iter() {
             let advisory_vuln = advisory_vulnerability::Entity::find()
                 .filter(advisory_vulnerability::Column::AdvisoryId.eq(advisory.id))
                 .filter(advisory_vulnerability::Column::VulnerabilityId.eq(&vuln.id))
@@ -106,8 +81,8 @@ impl AdvisoryVulnerabilityHead {
                 };
                 heads.push(AdvisoryVulnerabilityHead {
                     head,
-                    severity: score.map(|s| s.severity()),
-                    score: score.map(|s| s.value()),
+                    severity: vuln.base_severity.map(|s| s.into()),
+                    score: vuln.base_score,
                 });
             }
         }

--- a/modules/fundamental/src/ai/service/tools/cve_info.rs
+++ b/modules/fundamental/src/ai/service/tools/cve_info.rs
@@ -198,8 +198,8 @@ mod tests {
   "identifier": "CVE-2021-32714",
   "title": "Integer Overflow in Chunked Transfer-Encoding",
   "description": "hyper is an HTTP library for Rust. In versions prior to 0.14.10, hyper's HTTP server and client code had a flaw that could trigger an integer overflow when decoding chunk sizes that are too big. This allows possible data loss, or if combined with an upstream HTTP proxy that allows chunk sizes larger than hyper does, can result in \"request smuggling\" or \"desync attacks.\" The vulnerability is patched in version 0.14.10. Two possible workarounds exist. One may reject requests manually that contain a `Transfer-Encoding` header or ensure any upstream proxy rejects `Transfer-Encoding` chunk sizes greater than what fits in 64-bit unsigned integers.",
-  "severity": 7.5,
-  "score": 7.5,
+  "severity": 5.9,
+  "score": 5.9,
   "released": null,
   "affected_packages": [
     {

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -199,6 +199,8 @@ impl PurlAdvisory {
                 modified: None,
                 withdrawn: None,
                 cwes: None,
+                base_severity: None,
+                base_score: None,
             });
 
             if let Some(advisory) = advisory {

--- a/modules/fundamental/src/vulnerability/endpoints/test.rs
+++ b/modules/fundamental/src/vulnerability/endpoints/test.rs
@@ -182,6 +182,8 @@ async fn one_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
                 modified: None,
                 withdrawn: None,
                 cwes: None,
+                base_score: None,
+                base_severity: None,
             },
             &ctx.db,
         )
@@ -277,6 +279,8 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
                 modified: None,
                 withdrawn: None,
                 cwes: None,
+                base_score: None,
+                base_severity: None,
             },
             &ctx.db,
         )

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -6,7 +6,7 @@ use crate::{Error, vulnerability::model::VulnerabilityHead};
 use sea_orm::{ConnectionTrait, ModelTrait};
 use serde::{Deserialize, Serialize};
 use trustify_common::memo::Memo;
-use trustify_cvss::cvss3::{Cvss3Base, score::Score, severity::Severity};
+use trustify_cvss::cvss3::severity::Severity;
 use trustify_entity::{advisory_vulnerability, cvss3, vulnerability};
 use trustify_module_ingestor::common::{Deprecation, DeprecationForExt};
 use utoipa::ToSchema;
@@ -41,11 +41,6 @@ impl VulnerabilityDetails {
             .await?;
 
         let cvss3 = vulnerability.find_related(cvss3::Entity).all(tx).await?;
-        let score = if cvss3.is_empty() {
-            None
-        } else {
-            Some(Score::from_iter(cvss3.iter().map(Cvss3Base::from)))
-        };
 
         let advisories = VulnerabilityAdvisorySummary::from_entities(
             vulnerability,
@@ -62,8 +57,8 @@ impl VulnerabilityDetails {
                 tx,
             )
             .await?,
-            average_severity: score.map(|v| v.severity()),
-            average_score: score.map(|v| v.value()),
+            average_severity: vulnerability.base_severity.map(|s| s.into()),
+            average_score: vulnerability.base_score,
             advisories,
         })
     }

--- a/modules/fundamental/src/vulnerability/model/summary.rs
+++ b/modules/fundamental/src/vulnerability/model/summary.rs
@@ -32,7 +32,6 @@ pub struct VulnerabilitySummary {
 impl VulnerabilitySummary {
     pub async fn from_entities<C: ConnectionTrait>(
         vulnerabilities: &[vulnerability::Model],
-        averages: &[(Option<f64>, Option<Severity>)],
         deprecation: Deprecation,
         tx: &C,
     ) -> Result<Vec<Self>, Error> {
@@ -56,13 +55,11 @@ impl VulnerabilitySummary {
 
         let mut summaries = Vec::new();
 
-        for ((((vuln, advisories), (average_score, average_severity)), vuln_cvss3s), description) in
-            vulnerabilities
-                .iter()
-                .zip(advisories.iter())
-                .zip(averages.iter())
-                .zip(vuln_cvss3s.iter())
-                .zip(descriptions.iter())
+        for (((vuln, advisories), vuln_cvss3s), description) in vulnerabilities
+            .iter()
+            .zip(advisories.iter())
+            .zip(vuln_cvss3s.iter())
+            .zip(descriptions.iter())
         {
             summaries.push(VulnerabilitySummary {
                 head: VulnerabilityHead::from_vulnerability_entity(
@@ -71,8 +68,8 @@ impl VulnerabilitySummary {
                     tx,
                 )
                 .await?,
-                average_severity: *average_severity,
-                average_score: *average_score,
+                average_severity: vuln.base_severity.map(|s| s.into()),
+                average_score: vuln.base_score,
                 advisories: VulnerabilityAdvisoryHead::from_entities(
                     vuln,
                     advisories,

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -5,24 +5,16 @@ use crate::{
     vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
 };
 use futures_util::{TryFutureExt, TryStreamExt};
-use sea_orm::{
-    EntityTrait, FromQueryResult, IntoIdentity, QuerySelect, QueryTrait, Statement, StreamTrait,
-    prelude::*,
-};
-use sea_query::{ColumnRef, Func, IntoColumnRef, IntoIden, SimpleExpr};
+use sea_orm::{EntityTrait, Statement, StreamTrait, prelude::*};
 use trustify_common::{
     db::{
-        limiter::LimiterAsModelTrait,
-        multi_model::{FromQueryResultMultiModel, SelectIntoMultiModel},
+        limiter::LimiterTrait,
         query::{Columns, Filtering, Query},
     },
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
 };
-use trustify_entity::{
-    cvss3::{self, Severity},
-    vulnerability,
-};
+use trustify_entity::vulnerability;
 use trustify_module_ingestor::common::Deprecation;
 
 #[derive(Default)]
@@ -40,95 +32,17 @@ impl VulnerabilityService {
         deprecation: Deprecation,
         connection: &C,
     ) -> Result<PaginatedResults<VulnerabilitySummary>, Error> {
-        let inner_query = vulnerability::Entity::find()
-            .left_join(cvss3::Entity)
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                    trustify_entity::cvss3::Column::Score.into_column_ref(),
-                ))),
-                "average_score",
-            )
-            .expr_as_(
-                SimpleExpr::FunctionCall(Func::cust("cvss3_severity".into_identity()).arg(
-                    SimpleExpr::FunctionCall(Func::avg(SimpleExpr::Column(
-                        trustify_entity::cvss3::Column::Score.into_column_ref(),
-                    ))),
-                )),
-                "average_severity",
-            )
-            .group_by(vulnerability::Column::Id);
-
-        let mut outer_query = vulnerability::Entity::find();
-
-        // Alias the inner query as exactly the table the entity is expecting
-        // so that column aliases link up correctly.
-        QueryTrait::query(&mut outer_query)
-            .from_clear()
-            .from_subquery(inner_query.into_query(), "vulnerability".into_identity());
-
-        let limiter = outer_query
-            .column_as(
-                SimpleExpr::Column(ColumnRef::Column(
-                    "average_score".into_identity().into_iden(),
-                )),
-                "average_score",
-            )
-            .column_as(
-                SimpleExpr::Column(ColumnRef::Column(
-                    "average_severity".into_identity().into_iden(),
-                ))
-                .cast_as("TEXT".into_identity()),
-                "average_severity",
-            )
-            .filtering_with(
-                search,
-                Columns::from_entity::<vulnerability::Entity>()
-                    .add_column("average_score", ColumnType::Decimal(None))
-                    .add_column(
-                        "average_severity",
-                        ColumnType::Enum {
-                            name: "cvss3_severity".into_identity().into_iden(),
-                            variants: vec![
-                                "none".into_identity().into_iden(),
-                                "low".into_identity().into_iden(),
-                                "medium".into_identity().into_iden(),
-                                "high".into_identity().into_iden(),
-                                "critical".into_identity().into_iden(),
-                            ],
-                        },
-                    )
-                    .translator(|f, op, v| match (f, v) {
-                        // v = "" for all sort fields
-                        ("average_severity", "") => Some(format!("average_score:{op}")),
-                        _ => None,
-                    }),
-            )?
-            .try_limiting_as_multi_model::<VulnerabilityCatcher>(
-                connection,
-                paginated.offset,
-                paginated.limit,
-            )?;
+        let limiter = vulnerability::Entity::find()
+            .filtering_with(search, Columns::from_entity::<vulnerability::Entity>())?
+            .limiting(connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;
-        let caught = limiter.fetch().await?;
-        let vulnerabilities = caught
-            .iter()
-            .map(|e| e.vulnerability.clone())
-            .collect::<Vec<_>>();
-        let averages = caught
-            .iter()
-            .map(|e| (e.average_score, e.average_severity.map(|s| s.into())))
-            .collect::<Vec<_>>();
+        let vulnerabilities = limiter.fetch().await?;
 
         Ok(PaginatedResults {
             total,
-            items: VulnerabilitySummary::from_entities(
-                &vulnerabilities,
-                &averages,
-                deprecation,
-                connection,
-            )
-            .await?,
+            items: VulnerabilitySummary::from_entities(&vulnerabilities, deprecation, connection)
+                .await?,
         })
     }
 
@@ -249,6 +163,8 @@ impl VulnerabilityService {
             modified: row.try_get("", "modified")?,
             withdrawn: row.try_get("", "withdrawn")?,
             cwes: row.try_get("", "cwes")?,
+            base_score: row.try_get("", "base_score")?,
+            base_severity: row.try_get("", "base_severity")?,
         };
         let vuln_details =
             VulnerabilityDetails::from_entity(&vulnerability, Deprecation::Ignore, connection)
@@ -257,29 +173,6 @@ impl VulnerabilityService {
             Ok(details) => Ok((requested_purl, details)),
             Err(e) => Err(e),
         }
-    }
-}
-
-#[derive(Debug)]
-struct VulnerabilityCatcher {
-    pub vulnerability: vulnerability::Model,
-    pub average_score: Option<f64>,
-    pub average_severity: Option<Severity>,
-}
-
-impl FromQueryResult for VulnerabilityCatcher {
-    fn from_query_result(res: &QueryResult, _pre: &str) -> Result<Self, DbErr> {
-        Ok(Self {
-            vulnerability: Self::from_query_result_multi_model(res, "", vulnerability::Entity)?,
-            average_score: res.try_get("", "average_score")?,
-            average_severity: res.try_get("", "average_severity")?,
-        })
-    }
-}
-
-impl FromQueryResultMultiModel for VulnerabilityCatcher {
-    fn try_into_multi_model<E: EntityTrait>(select: Select<E>) -> Result<Select<E>, DbErr> {
-        select.try_model_columns(vulnerability::Entity)
     }
 }
 

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -359,8 +359,13 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 
     ctx.ingest_documents([
         "csaf/CVE-2023-20862.json",
+        "cve/CVE-2023-20862.json",
+        "cve/CVE-2023-42282.json",
         "csaf/RHBA-2024_1440.json",
+        "cve/CVE-2023-39326.json",
         "csaf/rhsa-2023_5835.json",
+        "cve/CVE-2023-39325.json",
+        "cve/CVE-2023-44487.json",
     ])
     .await?;
 
@@ -370,7 +375,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert_eq!(5, vulns.items.len());
     let vulns = service
         .fetch_vulnerabilities(
-            q("average_score>9"),
+            q("base_score>9"),
             Paginated::default(),
             Default::default(),
             &ctx.db,
@@ -380,7 +385,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-42282");
     let vulns = service
         .fetch_vulnerabilities(
-            q("average_severity=critical"),
+            q("base_severity=critical"),
             Paginated::default(),
             Default::default(),
             &ctx.db,
@@ -390,7 +395,21 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-42282");
     let vulns = service
         .fetch_vulnerabilities(
-            q("average_severity<high"),
+            q("base_severity<high"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
+        .await?;
+    tracing::debug!(test = "", "{vulns:#?}");
+    assert_eq!(1, vulns.items.len());
+    assert_eq!(
+        *vulns.items[0].average_severity.as_ref().unwrap(),
+        trustify_cvss::cvss3::severity::Severity::Medium
+    );
+    let vulns = service
+        .fetch_vulnerabilities(
+            q("base_severity>=high"),
             Paginated::default(),
             Default::default(),
             &ctx.db,
@@ -398,20 +417,6 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .await?;
     tracing::debug!(test = "", "{vulns:#?}");
     assert_eq!(2, vulns.items.len());
-    assert_eq!(
-        *vulns.items[0].average_severity.as_ref().unwrap(),
-        trustify_cvss::cvss3::severity::Severity::Medium
-    );
-    let vulns = service
-        .fetch_vulnerabilities(
-            q("average_severity>=high"),
-            Paginated::default(),
-            Default::default(),
-            &ctx.db,
-        )
-        .await?;
-    tracing::debug!(test = "", "{vulns:#?}");
-    assert_eq!(3, vulns.items.len());
     let vulns = service
         .fetch_vulnerabilities(
             q("20862"),

--- a/modules/graphql/src/vulnerability.rs
+++ b/modules/graphql/src/vulnerability.rs
@@ -27,6 +27,8 @@ impl VulnerabilityQuery {
                 modified: vulnerability.vulnerability.modified,
                 withdrawn: vulnerability.vulnerability.withdrawn,
                 cwes: vulnerability.vulnerability.cwes,
+                base_score: vulnerability.vulnerability.base_score,
+                base_severity: vulnerability.vulnerability.base_severity,
             }),
             Ok(None) => Err(FieldError::new("Vulnerability not found")),
             Err(err) => Err(FieldError::from(err)),
@@ -52,6 +54,8 @@ impl VulnerabilityQuery {
                     modified: vulnerability.vulnerability.modified,
                     withdrawn: vulnerability.vulnerability.withdrawn,
                     cwes: vulnerability.vulnerability.cwes,
+                    base_score: vulnerability.vulnerability.base_score,
+                    base_severity: vulnerability.vulnerability.base_severity,
                 })
             })
             .collect()

--- a/modules/ingestor/src/graph/vulnerability/mod.rs
+++ b/modules/ingestor/src/graph/vulnerability/mod.rs
@@ -11,6 +11,7 @@ use std::fmt::{Debug, Formatter};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::db::chunk::EntityChunkedIter;
+use trustify_entity::cvss3::Severity;
 use trustify_entity::{advisory, advisory_vulnerability, vulnerability, vulnerability_description};
 use uuid::Uuid;
 
@@ -22,6 +23,8 @@ pub struct VulnerabilityInformation {
     pub modified: Option<OffsetDateTime>,
     pub withdrawn: Option<OffsetDateTime>,
     pub cwes: Option<Vec<String>>,
+    pub base_score: Option<f64>,
+    pub base_severity: Option<Severity>,
 }
 
 impl VulnerabilityInformation {
@@ -32,6 +35,8 @@ impl VulnerabilityInformation {
             || self.modified.is_some()
             || self.withdrawn.is_some()
             || self.cwes.is_some()
+            || self.base_score.is_some()
+            || self.base_severity.is_some()
     }
 }
 
@@ -44,6 +49,8 @@ impl From<()> for VulnerabilityInformation {
             modified: None,
             withdrawn: None,
             cwes: None,
+            base_score: None,
+            base_severity: None,
         }
     }
 }
@@ -67,6 +74,8 @@ impl Graph {
                 vulnerability::Column::Modified,
                 vulnerability::Column::Withdrawn,
                 vulnerability::Column::Cwes,
+                vulnerability::Column::BaseScore,
+                vulnerability::Column::BaseSeverity,
             ]),
             false => {
                 // we "update" the ID column (which actually stays the same) so that we can use the
@@ -84,6 +93,8 @@ impl Graph {
             modified: Set(information.modified),
             withdrawn: Set(information.withdrawn),
             cwes: Set(information.cwes),
+            base_score: Set(information.base_score),
+            base_severity: Set(information.base_severity),
         };
 
         let result = vulnerability::Entity::insert(entity)


### PR DESCRIPTION
This PR changes how vulnerability scoring is set. Instead of calculating an average
from all advisories, it is now parsed from the CVE file. The score and severity values
are stored in the vulnerability database.
I tried at first looking for an cve advisory and retrieving the value, but the query gets even more complicated and slow than calculating an average. And as it is the integral part of the vulnerability, I think the value belongs in the table.
With this PR I didn't change the current API, so it's still called `average_score` and `average_severity`. I will tackle that in a separate PR (I need to think of how deprecating current values will work).
The search query is changed though. Please see the comment below for the details.