### PR TITLE
fix: delete advisory performance

### DIFF
--- a/modules/fundamental/src/purl/service/gc_purls.sql
+++ b/modules/fundamental/src/purl/service/gc_purls.sql
@@ -1,12 +1,12 @@
 WITH
     alive_qualified_purl AS (
-        SELECT t2.id, t2.versioned_purl_id
+        SELECT DISTINCT t2.id, t2.versioned_purl_id
         FROM sbom_package_purl_ref AS t1
                  INNER JOIN qualified_purl AS t2
                             ON t2.id = t1.qualified_purl_id
     ),
     alive_versioned_purl AS (
-        SELECT t2.id, t2.base_purl_id
+        SELECT DISTINCT t2.id, t2.base_purl_id
         FROM alive_qualified_purl AS t1
                  INNER JOIN versioned_purl AS t2
                             ON t2.id = t1.versioned_purl_id
@@ -17,7 +17,7 @@ WITH
             FROM alive_versioned_purl AS t1
                      INNER JOIN base_purl AS t2 ON t2.id = t1.base_purl_id
         ) UNION (
-            SELECT t2.id
+            SELECT DISTINCT t2.id
             FROM purl_status AS t1
                      INNER JOIN base_purl AS t2 ON t2.id = t1.base_purl_id
         )


### PR DESCRIPTION
Fixes #1589 

```
2025-05-19T11:40:16.267101Z  INFO ThreadId(01) actix_server::server: Tokio runtime found; starting in existing Tokio runtime
2025-05-19T11:40:16.267113Z  INFO ThreadId(01) actix_server::server: starting service: "actix-web-service-[::1]:8080", workers: 12, listening on: [::1]:8080
2025-05-19T11:43:38.203811Z  WARN ThreadId(30) gc_purls: sqlx::query: slow statement: execution time exceeded alert threshold summary="WITH alive_qualified_purl AS ( …" db.statement="\n\nWITH\n    alive_qualified_purl AS (\n        SELECT DISTINCT t2.id, t2.versioned_purl_id\n        FROM sbom_package_purl_ref AS t1\n                 INNER JOIN qualified_purl AS t2\n                            ON t2.id = t1.qualified_purl_id\n    ),\n    alive_versioned_purl AS (\n        SELECT DISTINCT t2.id, t2.base_purl_id\n        FROM alive_qualified_purl AS t1\n                 INNER JOIN versioned_purl AS t2\n                            ON t2.id = t1.versioned_purl_id\n    ),\n    alive_base_purl AS (\n        (\n            SELECT t2.id\n            FROM alive_versioned_purl AS t1\n                     INNER JOIN base_purl AS t2 ON t2.id = t1.base_purl_id\n        ) UNION (\n            SELECT DISTINCT t2.id\n            FROM purl_status AS t1\n                     INNER JOIN base_purl AS t2 ON t2.id = t1.base_purl_id\n        )\n    ),\n    dead_base_purl AS(\n        (\n            SELECT id FROM base_purl\n        ) EXCEPT (\n            SELECT id FROM alive_base_purl\n        )\n    ),\n    dead_versioned_purl AS(\n        (\n            SELECT id FROM versioned_purl\n        ) EXCEPT (\n            SELECT id FROM alive_versioned_purl\n        )\n    ),\n    dead_qualified_purl AS(\n        (\n            SELECT id FROM qualified_purl\n        ) EXCEPT (\n            SELECT id FROM alive_qualified_purl\n        )\n    ),\n    deleted_base_purl AS (\n        DELETE from base_purl\n            WHERE id in (select id from dead_base_purl)\n            returning 'base_purl', id\n    ),\n    deleted_versioned_purl AS (\n        DELETE from versioned_purl\n            WHERE id in (select id from dead_versioned_purl)\n            returning 'versioned_purl', id\n    ),\n    deleted_qualified_purl AS (\n        DELETE from qualified_purl\n            WHERE id in (select id from dead_qualified_purl)\n            returning 'qualified_purl', id\n    ),\n    deleted_records AS(\n        (\n            SELECT * from deleted_base_purl\n        ) UNION (\n            SELECT * from deleted_versioned_purl\n        ) UNION (\n            SELECT * from deleted_qualified_purl\n        )\n    )\nSELECT * FROM deleted_records;\n\n" rows_affected=0 rows_returned=0 elapsed=4.756616418s elapsed_secs=4.756616418 slow_threshold=1s
2025-05-19T11:43:38.204645Z  INFO ThreadId(30) actix_web::middleware::logger: ::1 "DELETE /api/v2/advisory/urn:uuid:ed944a21-a2a2-4d4d-811b-f4427318b6c2 HTTP/1.1" 200 1812 "-" "hurl/6.1.1" 5.266619
```

```
hurl --test --jobs 1 --variables-file .env h/advisory.hurl
h/advisory.hurl: Success (1 request(s) in 5267 ms)
--------------------------------------------------------------------------------
Executed files:    1
Executed requests: 1 (0.2/s)
Succeeded files:   1 (100.0%)
Failed files:      0 (0.0%)
Duration:          5268 ms
```