### PR TITLE
build: add feature flag for graphql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,17 +165,17 @@ trustify-cvss = { path = "cvss" }
 trustify-entity = { path = "entity" }
 trustify-infrastructure = { path = "common/infrastructure" }
 trustify-migration = { path = "migration" }
+trustify-module-analysis = { path = "modules/analysis" }
 trustify-module-fundamental = { path = "modules/fundamental" }
+trustify-module-graphql = { path = "modules/graphql" }
 trustify-module-importer = { path = "modules/importer" }
-trustify-module-ui = { path = "modules/ui", default-features = false }
-trustify-server = { path = "server", default-features = false }
-trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/main" }
 trustify-module-ingestor = { path = "modules/ingestor" }
 trustify-module-storage = { path = "modules/storage" }
-trustify-module-graphql = { path = "modules/graphql" }
-trustify-test-context = { path = "test-context" }
-trustify-module-analysis = { path = "modules/analysis" }
+trustify-module-ui = { path = "modules/ui", default-features = false }
 trustify-module-user = { path = "modules/user" }
+trustify-server = { path = "server", default-features = false }
+trustify-test-context = { path = "test-context" }
+trustify-ui = { git = "https://github.com/trustification/trustify-ui.git", branch = "publish/main" }
 
 # These dependencies are active during both the build time and the run time. So they are normal dependencies
 # as well as build-dependencies. However, we can't control feature flags for build dependencies the way we do

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -5,26 +5,24 @@ edition.workspace = true
 publish.workspace = true
 license.workspace = true
 
+[features]
+graphql = ["async-graphql"]
+
 [dependencies]
 trustify-common = { workspace = true }
 trustify-cvss = { workspace = true }
 
-async-graphql = { workspace = true, features = ["uuid", "time"] }
 cpe = { workspace = true }
 deepsize = { workspace = true }
 schemars = { workspace = true }
-sea-orm = { workspace = true, features = [
-    "sqlx-postgres",
-    "runtime-tokio-rustls",
-    "macros",
-    "with-json",
-    "postgres-array",
-] }
+sea-orm = { workspace = true, features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "with-json", "postgres-array"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 time = { workspace = true }
 utoipa = { workspace = true }
+
+async-graphql = { workspace = true, features = ["uuid", "time"], optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/entity/src/cvss3.rs
+++ b/entity/src/cvss3.rs
@@ -1,10 +1,10 @@
 use crate::{advisory, advisory_vulnerability, vulnerability};
-use async_graphql::{Enum, SimpleObject};
 use sea_orm::entity::prelude::*;
 use std::fmt::{Display, Formatter};
 use trustify_cvss::cvss3;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
 #[sea_orm(table_name = "cvss3")]
 pub struct Model {
     #[sea_orm(primary_key)]
@@ -92,7 +92,8 @@ impl Related<advisory_vulnerability::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_av")]
 pub enum AttackVector {
     #[sea_orm(string_value = "n")]
@@ -127,7 +128,8 @@ impl From<cvss3::AttackVector> for AttackVector {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ac")]
 pub enum AttackComplexity {
     #[sea_orm(string_value = "l")]
@@ -154,7 +156,8 @@ impl From<cvss3::AttackComplexity> for AttackComplexity {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_pr")]
 pub enum PrivilegesRequired {
     #[sea_orm(string_value = "n")]
@@ -185,7 +188,8 @@ impl From<cvss3::PrivilegesRequired> for PrivilegesRequired {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_ui")]
 pub enum UserInteraction {
     #[sea_orm(string_value = "n")]
@@ -212,7 +216,8 @@ impl From<cvss3::UserInteraction> for UserInteraction {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_s")]
 pub enum Scope {
     #[sea_orm(string_value = "u")]
@@ -239,7 +244,8 @@ impl From<cvss3::Scope> for Scope {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_c")]
 pub enum Confidentiality {
     #[sea_orm(string_value = "n")]
@@ -270,7 +276,8 @@ impl From<cvss3::Confidentiality> for Confidentiality {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_i")]
 pub enum Integrity {
     #[sea_orm(string_value = "n")]
@@ -301,7 +308,8 @@ impl From<cvss3::Integrity> for Integrity {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_a")]
 pub enum Availability {
     #[sea_orm(string_value = "n")]
@@ -332,7 +340,8 @@ impl From<cvss3::Availability> for Availability {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Enum)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "cvss3_severity")]
 pub enum Severity {
     #[sea_orm(string_value = "none")]

--- a/entity/src/labels.rs
+++ b/entity/src/labels.rs
@@ -1,4 +1,3 @@
-use async_graphql::scalar;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -39,7 +38,8 @@ impl PartialSchema for Labels {
     }
 }
 
-scalar!(Labels);
+#[cfg(feature = "async-graphql")]
+async_graphql::scalar!(Labels);
 
 impl Labels {
     pub fn new() -> Self {

--- a/entity/src/organization.rs
+++ b/entity/src/organization.rs
@@ -1,9 +1,12 @@
 use crate::{advisory, product};
-use async_graphql::*;
 use sea_orm::entity::prelude::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SimpleObject)]
-#[graphql(concrete(name = "Organization", params()))]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+#[cfg_attr(
+    feature = "async-graphql",
+    graphql(concrete(name = "Organization", params()))
+)]
 #[sea_orm(table_name = "organization")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/entity/src/sbom.rs
+++ b/entity/src/sbom.rs
@@ -1,12 +1,12 @@
 use crate::labels::Labels;
-use async_graphql::SimpleObject;
 use sea_orm::{Condition, LinkDef, entity::prelude::*, sea_query::IntoCondition};
 use time::OffsetDateTime;
 use trustify_common::id::{Id, IdError, TryFilterForId};
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+#[cfg_attr(feature = "async-graphql", graphql(concrete(name = "Sbom", params())))]
 #[sea_orm(table_name = "sbom")]
-#[graphql(concrete(name = "Sbom", params()))]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub sbom_id: Uuid,
@@ -21,7 +21,10 @@ pub struct Model {
 
     pub source_document_id: Option<Uuid>,
 
-    #[graphql(derived(owned, into = "HashMap<String,String>", with = "Labels::from"))]
+    #[cfg_attr(
+        feature = "async-graphql",
+        graphql(derived(owned, into = "HashMap<String,String>", with = "Labels::from"))
+    )]
     pub labels: Labels,
 }
 

--- a/entity/src/vulnerability.rs
+++ b/entity/src/vulnerability.rs
@@ -3,13 +3,16 @@ use crate::{
     cvss3::{self, Severity},
     vulnerability_description,
 };
-use async_graphql::SimpleObject;
 use sea_orm::entity::prelude::*;
 use time::OffsetDateTime;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, SimpleObject)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
 #[sea_orm(table_name = "vulnerability")]
-#[graphql(concrete(name = "Vulnerability", params()))]
+#[cfg_attr(
+    feature = "async-graphql",
+    graphql(concrete(name = "Vulnerability", params()))
+)]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: String,

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [features]
 default = []
 ai = [ "trustify-common/ai" ]
+graphql = [ "async-graphql" ]
 
 [dependencies]
 trustify-auth = { workspace = true }
@@ -21,7 +22,6 @@ trustify-module-storage = { workspace = true }
 actix-http = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-async-graphql = { workspace = true, features = ["uuid", "time"] }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 cpe = { workspace = true }
@@ -49,6 +49,8 @@ tracing-futures = { workspace = true, features = ["futures-03"] }
 utoipa = { workspace = true, features = ["actix_extras", "uuid", "time"] }
 utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
+
+async-graphql = { workspace = true, features = ["uuid", "time"], optional = true }
 
 [dev-dependencies]
 actix-http = { workspace = true }

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -5,7 +5,6 @@ use super::service::SbomService;
 use crate::{
     Error, purl::model::summary::purl::PurlSummary, source_document::model::SourceDocument,
 };
-use async_graphql::SimpleObject;
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -101,8 +100,12 @@ impl SbomSummary {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject, Default)]
-#[graphql(concrete(name = "SbomPackage", params()))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, Default)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
+#[cfg_attr(
+    feature = "async-graphql",
+    graphql(concrete(name = "SbomPackage", params()))
+)]
 pub struct SbomPackage {
     /// The SBOM internal ID of a package
     pub id: String,
@@ -113,7 +116,7 @@ pub struct SbomPackage {
     /// An optional version for an SBOM package
     pub version: Option<String>,
     /// PURLs identifying the package
-    #[graphql(skip)]
+    #[cfg_attr(feature = "async-graphql", graphql(skip))]
     pub purl: Vec<PurlSummary>,
     /// CPEs identifying the package
     pub cpe: Vec<String>,

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,21 +1,20 @@
 mod details;
 mod summary;
 
-use std::{collections::HashMap, ops::Deref};
-
-use async_graphql::SimpleObject;
 pub use details::*;
-use sea_orm::{ColumnTrait, ConnectionTrait, ModelTrait, QueryFilter};
 pub use summary::*;
 
 use crate::Error;
+use sea_orm::{ColumnTrait, ConnectionTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, ops::Deref};
 use time::OffsetDateTime;
 use trustify_common::memo::Memo;
 use trustify_entity::{advisory_vulnerability, vulnerability, vulnerability_description};
 use utoipa::ToSchema;
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq, Eq, SimpleObject)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, ToSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]
 pub struct VulnerabilityHead {
     #[schema(required)]
     pub normative: bool,

--- a/modules/graphql/Cargo.toml
+++ b/modules/graphql/Cargo.toml
@@ -6,12 +6,12 @@ publish.workspace = true
 license.workspace = true
 
 [dependencies]
-trustify-entity = { workspace = true }
+trustify-entity = { workspace = true, features = ["graphql"] }
 trustify-common = { workspace = true }
-trustify-module-fundamental = { workspace = true }
+trustify-module-fundamental = { workspace = true, features = ["graphql"] }
 trustify-module-ingestor = { workspace = true }
 
-async-graphql = { workspace = true }
+async-graphql = { workspace = true, features = ["uuid"] }
 async-graphql-actix-web = { workspace = true }
 actix-web = { workspace = true }
 uuid = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [features]
 ai = ["trustify-module-fundamental/ai"]
+graphql = ["trustify-module-graphql"]
 
 [dependencies]
 trustify-auth = { workspace = true }
@@ -14,7 +15,7 @@ trustify-common = { workspace = true }
 trustify-infrastructure = { workspace = true }
 trustify-module-analysis = { workspace = true }
 trustify-module-fundamental = { workspace = true }
-trustify-module-graphql = { workspace = true }
+trustify-module-graphql = { workspace = true, optional = true }
 trustify-module-importer = { workspace = true }
 trustify-module-ingestor = { workspace = true }
 trustify-module-storage = { workspace = true }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,8 +1,7 @@
 use crate::profile::api::{Config, ModuleConfig, configure, default_openapi_info};
 use actix_web::App;
 use trustify_common::{config::Database, db};
-use trustify_module_analysis::config::AnalysisConfig;
-use trustify_module_analysis::service::AnalysisService;
+use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
 use trustify_module_storage::service::{dispatch::DispatchBackend, fs::FileSystemBackend};
 use utoipa::{
     Modify, OpenApi,
@@ -26,6 +25,7 @@ pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
                     storage: storage.into(),
                     auth: None,
                     analysis,
+                    #[cfg(feature = "graphql")]
                     with_graphql: true,
                 },
             );

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -36,7 +36,6 @@ use trustify_infrastructure::{
     otel::{Metrics as OtelMetrics, Tracing},
 };
 use trustify_module_analysis::{config::AnalysisConfig, service::AnalysisService};
-use trustify_module_graphql::RootQuery;
 use trustify_module_importer::server::importer;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_storage::{
@@ -60,6 +59,7 @@ pub struct Run {
     #[arg(long, env)]
     pub sample_data: bool,
 
+    #[cfg(feature = "graphql")]
     /// Allows enabling the GraphQL endpoint
     #[arg(long, env = "TRUSTD_WITH_GRAPHQL", default_value_t = false)]
     pub with_graphql: bool,
@@ -172,6 +172,7 @@ struct InitData {
     #[cfg(feature = "garage-door")]
     embedded_oidc: Option<embedded_oidc::EmbeddedOidc>,
     ui: UI,
+    #[cfg(feature = "graphql")]
     with_graphql: bool,
     config: ModuleConfig,
     analysis: AnalysisService,
@@ -308,6 +309,7 @@ impl InitData {
             #[cfg(feature = "garage-door")]
             embedded_oidc,
             ui,
+            #[cfg(feature = "graphql")]
             with_graphql: run.with_graphql,
         })
     }
@@ -333,7 +335,7 @@ impl InitData {
                             storage: self.storage.clone(),
                             auth: self.authenticator.clone(),
                             analysis: self.analysis.clone(),
-
+                            #[cfg(feature = "graphql")]
                             with_graphql: self.with_graphql,
                         },
                     );
@@ -381,6 +383,7 @@ pub(crate) struct Config {
     pub(crate) storage: DispatchBackend,
     pub(crate) analysis: AnalysisService,
     pub(crate) auth: Option<Arc<Authenticator>>,
+    #[cfg(feature = "graphql")]
     pub(crate) with_graphql: bool,
 }
 
@@ -395,6 +398,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
         auth,
         analysis,
 
+        #[cfg(feature = "graphql")]
         with_graphql,
     } = config;
 
@@ -407,6 +411,7 @@ pub(crate) fn configure(svc: &mut utoipa_actix_web::service_config::ServiceConfi
 
     // register GraphQL API and UI
 
+    #[cfg(feature = "graphql")]
     if with_graphql {
         svc.service(
             utoipa_actix_web::scope("/graphql")
@@ -521,6 +526,7 @@ mod test {
                             storage: DispatchBackend::Filesystem(storage),
                             auth: None,
                             analysis,
+                            #[cfg(feature = "graphql")]
                             with_graphql: true,
                         },
                     );
@@ -565,11 +571,13 @@ mod test {
         assert!(text.contains("<title>Swagger UI</title>"));
 
         // GraphQL UI
-
-        let req = TestRequest::get().uri("/graphql").to_request();
-        let body = call_and_read_body(&app, req).await;
-        let text = std::str::from_utf8(&body)?;
-        assert!(text.contains("<title>GraphiQL IDE</title>"));
+        #[cfg(feature = "graphql")]
+        {
+            let req = TestRequest::get().uri("/graphql").to_request();
+            let body = call_and_read_body(&app, req).await;
+            let text = std::str::from_utf8(&body)?;
+            assert!(text.contains("<title>GraphiQL IDE</title>"));
+        }
 
         // API
 

--- a/server/src/profile/importer.rs
+++ b/server/src/profile/importer.rs
@@ -32,7 +32,6 @@ use trustify_infrastructure::{
     health::checks::{Local, Probe},
     otel::Tracing,
 };
-use trustify_module_graphql::RootQuery;
 use trustify_module_importer::server::importer;
 use trustify_module_ingestor::graph::Graph;
 use trustify_module_storage::{


### PR DESCRIPTION
This adds a feature for graphql logic and dependencies. Reducing the number of dependencies when not using graphql, which is the default at the moment.

Removing a bunch of dependencies:

```
3d2
< actix_derive v0.6.2
13d11
< actix-web-actors v4.3.1+deprecated
37d34
< ascii_utils v0.9.3
39d35
< async-channel v2.3.1
42,46d37
< async-graphql-actix-web v7.0.16
< async-graphql-derive v7.0.16
< async-graphql-parser v7.0.16
< async-graphql v7.0.16
< async-graphql-value v7.0.16
208d198
< event-listener-strategy v0.5.4
212d201
< fast_chemail v0.9.6
255d243
< handlebars v5.1.2
369d356
< multer v3.1.0
461d447
< proc-macro-crate v3.3.0
588d573
< static_assertions_next v1.1.2
638,639d622
< toml_datetime v0.6.9
< toml_edit v0.22.26
660d642
< trustify-module-graphql v0.2.19
716d697
< winnow v0.7.10

```