### PR TITLE
fix: align the embedded postgres version with the CI

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Build | Build
         shell: bash
         env:
-          POSTGRESQL_VERSION: 16
+          POSTGRESQL_VERSION: "=17.2"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for retrieving postgres
         run: |
           set -x

--- a/common/src/db/embedded.rs
+++ b/common/src/db/embedded.rs
@@ -6,7 +6,9 @@ use tracing::{Instrument, info_span};
 
 /// Create common default settings for the embedded database
 fn default_settings() -> anyhow::Result<Settings> {
-    let version = VersionReq::parse("=17.2.0").context("valid psql version")?;
+    // **NOTE:** Changing the default version here, one should also change the env-var in the CI job
+    let version = VersionReq::parse(option_env!("POSTGRES_VERSION").unwrap_or("=17.2.0"))
+        .context("valid psql version")?;
     Ok(Settings {
         version,
         username: "postgres".to_string(),
@@ -35,6 +37,8 @@ pub async fn create_in(base: impl AsRef<Path>) -> anyhow::Result<(Database, Post
 
 /// Create a new, embedded database instance, using the provided settings
 async fn create_for(settings: Settings) -> anyhow::Result<(Database, PostgreSQL)> {
+    log::info!("creating embedded database - version: {}", settings.version);
+
     let postgresql = async {
         let mut postgresql = PostgreSQL::new(settings);
         postgresql


### PR DESCRIPTION
In PM mode, the postgresql binary will be embedded. This requires the build to know which version to download. However, this didn't align with the code requesting a database.

This change prefers the use of the CI version, but falls back to the locally (code) provided value. This ensures that if the CI builds with a provided version, it will be used during runtime.

Closes: #1674