### PR TITLE
chore: add 'async-graphql' feature flag to prevent unused_imports warnings

### DIFF
--- a/entity/src/advisory.rs
+++ b/entity/src/advisory.rs
@@ -1,11 +1,11 @@
 use crate::{advisory_vulnerability, cvss3, labels::Labels, organization, vulnerability};
 use sea_orm::{Condition, entity::prelude::*, sea_query::IntoCondition};
+#[cfg(feature = "async-graphql")]
 use std::sync::Arc;
 use time::OffsetDateTime;
-use trustify_common::{
-    db,
-    id::{Id, IdError, TryFilterForId},
-};
+#[cfg(feature = "async-graphql")]
+use trustify_common::db;
+use trustify_common::id::{Id, IdError, TryFilterForId};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[cfg_attr(feature = "async-graphql", derive(async_graphql::SimpleObject))]


### PR DESCRIPTION
Running tests locally while developing, I experienced these warnings that confused me:
```
warning: unused import: `std::sync::Arc`
 --> entity/src/advisory.rs:4:5
  |
4 | use std::sync::Arc;
  |     ^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `trustify_common::db`
 --> entity/src/advisory.rs:7:5
  |
7 | use trustify_common::db;
  |  
```
so I've added the `"async-graphql` feature flag to properly manage these `use` statements.