### PR TITLE
task: align UI removal of Analytics prop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#b4c71d5db37e39ef46792ec54af2bda21426d958"
+source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#95872c3c1bb24e874f723497940b92477c383d1f"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -165,9 +165,6 @@ pub struct UiConfig {
     /// Scopes to request
     #[arg(id = "ui-scope", long, env = "UI_SCOPE", default_value = "openid")]
     pub scope: String,
-    /// The write-key for the analytics system.
-    #[arg(id = "analytics-write-key", long, env = "UI_ANALYTICS_WRITE_KEY")]
-    pub analytics_write_key: Option<String>,
 }
 
 const SERVICE_ID: &str = "trustify";
@@ -294,8 +291,6 @@ impl InitData {
             oidc_server_url: run.ui.issuer_url,
             oidc_client_id: run.ui.client_id,
             oidc_scope: run.ui.scope,
-            analytics_enabled: run.ui.analytics_write_key.is_some().to_string(),
-            analytics_write_key: run.ui.analytics_write_key.unwrap_or_default(),
         };
 
         let config = ModuleConfig {


### PR DESCRIPTION
Related to https://github.com/trustification/trustify-ui/pull/498

The UI repository removed the `analytics` option as it was never used nor implemented.
Originally it was supposed to be used for Segment.io analytics due to v1 compatibility. But it was decided that it was not needed and removed from the requirements. So it never worked.

This PR removes the `analytics` parameters passed to the UI and point to the latest available UI version in the main branch.