### PR TITLE
task: align UI removal of Analytics prop [Backport release/0.3.z]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Frelease%2F0.3.z#de1b54f89b411a5f503992df2020144126b56cdc"
+source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Frelease%2F0.3.z#3fb02f1019905228f000df34edc0c8c3f76e4b08"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -165,9 +165,6 @@ pub struct UiConfig {
     /// Scopes to request
     #[arg(id = "ui-scope", long, env = "UI_SCOPE", default_value = "openid")]
     pub scope: String,
-    /// The write-key for the analytics system.
-    #[arg(id = "analytics-write-key", long, env = "UI_ANALYTICS_WRITE_KEY")]
-    pub analytics_write_key: Option<String>,
 }
 
 const SERVICE_ID: &str = "trustify";
@@ -294,8 +291,6 @@ impl InitData {
             oidc_server_url: run.ui.issuer_url,
             oidc_client_id: run.ui.client_id,
             oidc_scope: run.ui.scope,
-            analytics_enabled: run.ui.analytics_write_key.is_some().to_string(),
-            analytics_write_key: run.ui.analytics_write_key.unwrap_or_default(),
         };
 
         let config = ModuleConfig {


### PR DESCRIPTION
Backport of https://github.com/trustification/trustify/pull/1699 to `release/0.3.z`.

- The auto Cherry-pick failed therefore I created the backport manually
- Also this PR points to the latest commit in the UI branch `release/0.3.z` 