### PR TITLE
feat: start exctracting vulnerability scores from cvss v4 and v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,14 +2393,13 @@ dependencies = [
 
 [[package]]
 name = "cve"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6589e09d072d12278e8c143abc41535833cdf76e45647dbae62254b454b4f308"
+checksum = "bba109f3a468c9e2cd871c259040cf11ca95caaaed10427c6c8879515ae87896"
 dependencies = [
  "serde",
  "serde_json",
  "time",
- "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ criterion = "0.6.0"
 csaf = { version = "0.5.0", default-features = false }
 csaf-walker = { version = "0.13.0", default-features = false }
 csv = "1.3.0"
-cve = "0.3.1"
+cve = "0.4.0"
 deepsize = "0.2.0"
 env_logger = "0.11.0"
 fixedbitset = "0.5.7"

--- a/etc/test-data/cve/CVE-2017-20197.json
+++ b/etc/test-data/cve/CVE-2017-20197.json
@@ -1,0 +1,187 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2017-20197",
+        "assignerOrgId": "1af790b2-7ee1-4545-860a-a788eba489b5",
+        "state": "PUBLISHED",
+        "assignerShortName": "VulDB",
+        "dateReserved": "2025-04-07T07:27:08.418Z",
+        "datePublished": "2025-04-09T11:00:16.705Z",
+        "dateUpdated": "2025-04-09T13:17:18.497Z"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "1af790b2-7ee1-4545-860a-a788eba489b5",
+                "shortName": "VulDB",
+                "dateUpdated": "2025-04-09T11:00:16.705Z"
+            },
+            "title": "propanetank Roommate-Bill-Tracking login.php sql injection",
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "CWE",
+                            "cweId": "CWE-89",
+                            "lang": "en",
+                            "description": "SQL Injection"
+                        }
+                    ]
+                },
+                {
+                    "descriptions": [
+                        {
+                            "type": "CWE",
+                            "cweId": "CWE-74",
+                            "lang": "en",
+                            "description": "Injection"
+                        }
+                    ]
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "propanetank",
+                    "product": "Roommate-Bill-Tracking",
+                    "versions": [
+                        {
+                            "version": "288437f658fc9ee7d4b92a9da12557024d8bc55c",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A vulnerability was found in propanetank Roommate-Bill-Tracking up to 288437f658fc9ee7d4b92a9da12557024d8bc55c. It has been declared as critical. This vulnerability affects unknown code of the file /includes/login.php. The manipulation of the argument Username leads to sql injection. The attack can be initiated remotely. The name of the patch is b32bb1b940f82d38fb9310cd66ebe349e20a1d0a. It is recommended to apply a patch to fix this issue."
+                },
+                {
+                    "lang": "de",
+                    "value": "In propanetank Roommate-Bill-Tracking bis 288437f658fc9ee7d4b92a9da12557024d8bc55c wurde eine Schwachstelle ausgemacht. Sie wurde als kritisch eingestuft. Es geht um eine nicht näher bekannte Funktion der Datei /includes/login.php. Durch das Manipulieren des Arguments Username mit unbekannten Daten kann eine sql injection-Schwachstelle ausgenutzt werden. Der Angriff kann über das Netzwerk erfolgen. Der Patch wird als b32bb1b940f82d38fb9310cd66ebe349e20a1d0a bezeichnet. Als bestmögliche Massnahme wird Patching empfohlen."
+                }
+            ],
+            "metrics": [
+                {
+                    "cvssV4_0": {
+                        "version": "4.0",
+                        "baseScore": 6.9,
+                        "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+                        "baseSeverity": "MEDIUM"
+                    }
+                },
+                {
+                    "cvssV3_1": {
+                        "version": "3.1",
+                        "baseScore": 7.3,
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                        "baseSeverity": "HIGH"
+                    }
+                },
+                {
+                    "cvssV3_0": {
+                        "version": "3.0",
+                        "baseScore": 7.3,
+                        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+                        "baseSeverity": "HIGH"
+                    }
+                },
+                {
+                    "cvssV2_0": {
+                        "version": "2.0",
+                        "baseScore": 7.5,
+                        "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+                    }
+                }
+            ],
+            "timeline": [
+                {
+                    "time": "2017-11-08T00:00:00.000Z",
+                    "lang": "en",
+                    "value": "Advisory disclosed"
+                },
+                {
+                    "time": "2017-11-08T00:00:00.000Z",
+                    "lang": "en",
+                    "value": "Countermeasure disclosed"
+                },
+                {
+                    "time": "2025-04-07T02:00:00.000Z",
+                    "lang": "en",
+                    "value": "VulDB entry created"
+                },
+                {
+                    "time": "2025-04-07T09:32:52.000Z",
+                    "lang": "en",
+                    "value": "VulDB entry last update"
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "value": "VulDB GitHub Commit Analyzer",
+                    "type": "tool"
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://vuldb.com/?id.303640",
+                    "name": "VDB-303640 | propanetank Roommate-Bill-Tracking login.php sql injection",
+                    "tags": [
+                        "vdb-entry",
+                        "technical-description"
+                    ]
+                },
+                {
+                    "url": "https://vuldb.com/?ctiid.303640",
+                    "name": "VDB-303640 | CTI Indicators (IOB, IOC, TTP, IOA)",
+                    "tags": [
+                        "signature",
+                        "permissions-required"
+                    ]
+                },
+                {
+                    "url": "https://github.com/propanetank/Roommate-Bill-Tracking/commit/b32bb1b940f82d38fb9310cd66ebe349e20a1d0a",
+                    "tags": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2025-04-09T13:15:55.366847Z",
+                                "id": "CVE-2017-20197",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2025-04-09T13:17:18.497Z"
+                }
+            }
+        ]
+    }
+}

--- a/etc/test-data/cve/CVE-2024-7826.json
+++ b/etc/test-data/cve/CVE-2024-7826.json
@@ -1,0 +1,157 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2024-7826",
+        "assignerOrgId": "f81092c5-7f14-476d-80dc-24857f90be84",
+        "state": "PUBLISHED",
+        "assignerShortName": "OpenText",
+        "dateReserved": "2024-08-14T21:48:57.268Z",
+        "datePublished": "2024-10-03T17:05:33.461Z",
+        "dateUpdated": "2024-10-03T17:46:18.210Z"
+    },
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "defaultStatus": "unaffected",
+                    "modules": [
+                        "wrURL.dll"
+                    ],
+                    "platforms": [
+                        "Windows",
+                        "ARM",
+                        "64 bit",
+                        "32 bit"
+                    ],
+                    "product": "SecureAnywhere - Web Shield",
+                    "vendor": "Webroot",
+                    "versions": [
+                        {
+                            "lessThan": "2.1.2.3",
+                            "status": "affected",
+                            "version": "0",
+                            "versionType": "custom"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "value": "Exodus Intelligence (exodusintel.com)"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "Improper Check for Unusual or Exceptional Conditions vulnerability in Webroot SecureAnywhere - Web Shield on Windows, ARM, 64 bit, 32 bit (wrURL.Dll modules) allows Functionality Misuse.<p>This issue affects SecureAnywhere - Web Shield: before 2.1.2.3.</p>"
+                        }
+                    ],
+                    "value": "Improper Check for Unusual or Exceptional Conditions vulnerability in Webroot SecureAnywhere - Web Shield on Windows, ARM, 64 bit, 32 bit (wrURL.Dll modules) allows Functionality Misuse.This issue affects SecureAnywhere - Web Shield: before 2.1.2.3."
+                }
+            ],
+            "impacts": [
+                {
+                    "capecId": "CAPEC-212",
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "value": "CAPEC-212 Functionality Misuse"
+                        }
+                    ]
+                }
+            ],
+            "metrics": [
+                {
+                    "cvssV2_0": {
+                        "accessComplexity": "LOW",
+                        "accessVector": "LOCAL",
+                        "authentication": "SINGLE",
+                        "availabilityImpact": "COMPLETE",
+                        "baseScore": 6.2,
+                        "confidentialityImpact": "COMPLETE",
+                        "integrityImpact": "NONE",
+                        "vectorString": "AV:L/AC:L/Au:S/C:C/I:N/A:C",
+                        "version": "2.0"
+                    },
+                    "format": "CVSS",
+                    "scenarios": [
+                        {
+                            "lang": "en",
+                            "value": "GENERAL"
+                        }
+                    ]
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-754",
+                            "description": "CWE-754 Improper Check for Unusual or Exceptional Conditions",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "f81092c5-7f14-476d-80dc-24857f90be84",
+                "shortName": "OpenText",
+                "dateUpdated": "2024-10-03T17:05:33.461Z"
+            },
+            "references": [
+                {
+                    "url": "https://answers.webroot.com/Webroot/ukp.aspx?pid=12&app=vw&vw=1&login=1&json=1&solutionid=4275"
+                }
+            ],
+            "source": {
+                "discovery": "EXTERNAL"
+            },
+            "title": "Unhandled exception vulnerability that can cause the WRSA.exe service to crash and generate a crash dump",
+            "x_generator": {
+                "engine": "Vulnogram 0.2.0"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-10-03T17:44:16.415734Z",
+                                "id": "CVE-2024-7826",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-10-03T17:46:18.210Z"
+                }
+            }
+        ]
+    }
+}

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -8,6 +8,7 @@ use test_log::test;
 use trustify_common::db::query::{Query, q};
 use trustify_common::model::Paginated;
 use trustify_common::purl::Purl;
+use trustify_cvss::cvss3::severity::Severity;
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
@@ -366,13 +367,15 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         "csaf/rhsa-2023_5835.json",
         "cve/CVE-2023-39325.json",
         "cve/CVE-2023-44487.json",
+        "cve/CVE-2024-7826.json",
+        "cve/CVE-2017-20197.json",
     ])
     .await?;
 
     let vulns = service
         .fetch_vulnerabilities(q(""), Paginated::default(), Default::default(), &ctx.db)
         .await?;
-    assert_eq!(5, vulns.items.len());
+    assert_eq!(7, vulns.items.len());
     let vulns = service
         .fetch_vulnerabilities(
             q("base_score>9"),
@@ -402,7 +405,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         )
         .await?;
     tracing::debug!(test = "", "{vulns:#?}");
-    assert_eq!(1, vulns.items.len());
+    assert_eq!(3, vulns.items.len());
     assert_eq!(
         *vulns.items[0].average_severity.as_ref().unwrap(),
         trustify_cvss::cvss3::severity::Severity::Medium
@@ -427,6 +430,30 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
         .await?;
     assert_eq!(1, vulns.items.len());
     assert_eq!(vulns.items[0].head.identifier, "CVE-2023-20862");
+
+    let vulns = service
+        .fetch_vulnerabilities(
+            q("CVE-2024-7826"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
+        .await?;
+    assert_eq!(1, vulns.items.len());
+    assert_eq!(vulns.items[0].average_score, Some(6.2));
+    assert_eq!(vulns.items[0].average_severity, Some(Severity::Medium));
+
+    let vulns = service
+        .fetch_vulnerabilities(
+            q("CVE-2017-20197"),
+            Paginated::default(),
+            Default::default(),
+            &ctx.db,
+        )
+        .await?;
+    assert_eq!(1, vulns.items.len());
+    assert_eq!(vulns.items[0].average_score, Some(6.9));
+    assert_eq!(vulns.items[0].average_severity, Some(Severity::Medium));
 
     Ok(())
 }


### PR DESCRIPTION
Currently we only extract base score and severity values. There's need to be more work done to properly save all scores of all versions for vulnerabilities and advisories. The base score used for the vulnerability will be picked from the highest cvss version available. Since base severity was not standardized in cvss v2.0 it is recalculated from the score.