### PR TITLE
fix: env variable name typo

### DIFF
--- a/common/src/db/embedded.rs
+++ b/common/src/db/embedded.rs
@@ -7,7 +7,7 @@ use tracing::{Instrument, info_span};
 /// Create common default settings for the embedded database
 fn default_settings() -> anyhow::Result<Settings> {
     // **NOTE:** Changing the default version here, one should also change the env-var in the CI job
-    let version = VersionReq::parse(option_env!("POSTGRES_VERSION").unwrap_or("=17.2.0"))
+    let version = VersionReq::parse(option_env!("POSTGRESQL_VERSION").unwrap_or("=17.2.0"))
         .context("valid psql version")?;
     Ok(Settings {
         version,


### PR DESCRIPTION
There was a typo in the fix in https://github.com/trustification/trustify/pull/1691 so env variable name doesn't match the one set up