### PR TITLE
ci: set non-blocking codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
We get the benefit of the report without the annoyance of a failed build.