### PR TITLE
Revert "ci: set non-blocking codecov status checks (#1725)"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true


### PR DESCRIPTION
This reverts commit 1bb18f5e712c9eb7d56ee901b5e28d1eebd39489.

As discussed in today's handover call with @PhilipCattanach, this will be reverted. The check was never blocking anything, just reporting. Furthermore, such PRs should be discussed first.