### PR TITLE
chore: otelcol internal telemetry

### DIFF
--- a/etc/telemetry/compose.yaml
+++ b/etc/telemetry/compose.yaml
@@ -40,6 +40,7 @@ services:
       - './config-collector.yaml:/otel-collector-config.yaml:z'
     ports:
       - "4317:4317"
+      - "8888:8888"
     depends_on: [tempo]
 
   # NOTE: Database part to avoid opening two more terminals for extra commands.

--- a/etc/telemetry/config-collector.yaml
+++ b/etc/telemetry/config-collector.yaml
@@ -24,6 +24,14 @@ processors:
   batch: {}
 
 service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 8888
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
Long story... to summarize, and without pointing to upstream OTEL PRs.. 

* They have this page where they are keeping updates related to the collector's internal telemetry:
https://opentelemetry.io/docs/collector/internal-telemetry/

* I used this to ensure that my node.js example was sending traces and that those were being received by the collector:
https://github.com/obs-nebula/check-traces/tree/main/scripts
  * They changed things and will continue changing, since some parts are still marked as [alpha].

* These changes don't impact our dev env (compose.yaml workflow etc), but:
  * During development, if I see that `otelcol_receiver_accepted_metric_points` and/or `otelcol_receiver_accepted_spans` are greater than zero, it means traces and metrics are being sent to the collector without need to check the Grafana dashboard, etc.
  * We can monitor the collector itself in case needed (future) during development
  * @queria can monitor the collector in case needed or use those metrics I shared to try to have some sort of quick test [some parts still marked as [alpha]]
  
* We can see the metrics accessing localhost:8888/metrics 