### PR TITLE
fix: prevent dumping massive amounts of log info

### DIFF
--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -121,6 +121,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             // we've already seen this
             return None;
         }
+
         match self.graph.node_weight(self.node) {
             Some(graph::Node::External(external_node)) => {
                 // we know this is an external node, so retrieve external sbom descendant nodes

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -414,7 +414,7 @@ impl AnalysisService {
     }
 
     /// Collect nodes from the graph
-    #[instrument(skip(self, create))]
+    #[instrument(skip(self, create, graphs))]
     async fn collect_graph<'a, C>(
         &self,
         query: impl Into<GraphQuery<'a>> + Debug,
@@ -444,7 +444,7 @@ impl AnalysisService {
         .await
     }
 
-    #[instrument(skip(self, connection, graph_cache))]
+    #[instrument(skip(self, connection, graphs, graph_cache))]
     pub async fn run_graph_query<'a, C: ConnectionTrait>(
         &self,
         query: impl Into<GraphQuery<'a>> + Debug,


### PR DESCRIPTION
Having the `graphs` variable logged dumps out an enormous amount of data, not adding any value. Blocking the log file, having an impact on performance.

I believe this has an impact on: https://issues.redhat.com/browse/TC-2567