### PR TITLE
Compile dependencies with no debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,11 @@ postgresql_archive = { version = "0.18.0", default-features = false, features = 
 postgresql_embedded = { version = "0.18.0", default-features = false, features = ["theseus", "rustls"] }
 postgresql_commands = { version = "0.18.0", default-features = false, features = ["tokio"] }
 
+# Do not generate debuginfo for dependencies in `dev` and `test` profiles. This
+# save us some disk space
+[profile.dev.package."*"]
+debug = false
+
 [patch.crates-io]
 #csaf-walker = { git = "https://github.com/ctron/csaf-walker", rev = "7b6e64dd56e4be79e184b053ef754a42e1496fe0" }
 #sbom-walker = { git = "https://github.com/ctron/csaf-walker", rev = "7b6e64dd56e4be79e184b053ef754a42e1496fe0" }


### PR DESCRIPTION
See https://github.com/trustification/guac-rs/commit/265fba20fb1f359b311029a348e9be73f406a266

This should save us a few gigabytes of disk space on GitHub runners, moving `ldd: no space left on device` error a bit further.