### PR TITLE
feat(analysis): reduce memory consumption by 10-15%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9232,6 +9232,7 @@ dependencies = [
  "test-context",
  "test-log",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",

--- a/modules/analysis/Cargo.toml
+++ b/modules/analysis/Cargo.toml
@@ -30,9 +30,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 spdx-rs = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
-utoipa = { workspace = true, features = ["actix_extras", "uuid"] }
+utoipa = { workspace = true, features = ["actix_extras", "uuid", "time", "rc_schema"] }
 utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
 

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -160,10 +160,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
             Some(graph::Node::Package(current_node)) => {
                 // collect external sbom ancestor nodes
                 let current_sbom_id = &current_node.sbom_id;
-                let current_sbom_uuid = Uuid::parse_str(current_sbom_id).unwrap_or_else(|err| {
-                    log::warn!("Error parsing UUID: {}", err);
-                    Uuid::nil()
-                });
+                let current_sbom_uuid = *current_sbom_id;
                 let current_node_id = &current_node.node_id;
                 let mut resolved_external_nodes: Vec<Node> = vec![];
                 let find_sbom_externals = resolve_rh_external_sbom_ancestors(
@@ -174,7 +171,7 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                 .await;
 
                 for sbom_external_node in find_sbom_externals {
-                    if &sbom_external_node.sbom_id.to_string() == current_sbom_id {
+                    if &sbom_external_node.sbom_id == current_sbom_id {
                         continue;
                     }
                     // check this is a valid external relationship

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -614,8 +614,9 @@ impl AnalysisService {
                     }
                     _ => vec![],
                 };
+                let sbom_id = node.sbom_id.to_string();
                 let mut context = ValueContext::from([
-                    ("sbom_id", Value::String(&node.sbom_id)),
+                    ("sbom_id", Value::String(&sbom_id)),
                     ("node_id", Value::String(&node.node_id)),
                     ("name", Value::String(&node.name)),
                 ]);

--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -343,7 +343,7 @@ async fn test_status_service(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
     let analysis_status = service.status(&ctx.db, false).await?;
     assert_eq!(analysis_status.sbom_count, 1);
     assert_eq!(analysis_status.graph_count, 1);
-    assert_eq!(analysis_status.graph_memory, 6894);
+    assert_eq!(analysis_status.graph_memory, 6564);
     assert!(analysis_status.details.is_none());
 
     service.clear_all_graphs()?;
@@ -386,8 +386,8 @@ async fn test_cache_size_used(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     assert_eq!(all_graphs.len(), 2);
 
     let big_sbom_size = service.cache_size_used() - small_sbom_size;
-    assert!(big_sbom_size > 950 * kb);
-    assert!(big_sbom_size < 960 * kb);
+    assert!(big_sbom_size > 800 * kb);
+    assert!(big_sbom_size < 810 * kb);
 
     // Now lets try it with small cache that can at least fit the small bom
     let service = AnalysisService::new(


### PR DESCRIPTION
Using non-string types and interning strings results in around ~15% less memory usage of the cache:

Before:

```json
[
  {
    "edges": 67665,
    "nodes": 62888,
    "sbom_id": "0195bae4-1d7b-7591-8564-2c635b272d80",
    "size": 56543379,
    "size_human": "53.9 MiB"
  },
  {
    "edges": 82240,
    "nodes": 65647,
    "sbom_id": "0195bae3-0629-74b0-ad5b-82f184882e71",
    "size": 54225990,
    "size_human": "51.7 MiB"
  },
  {
    "edges": 38711,
    "nodes": 20147,
    "sbom_id": "0195baf0-9534-7132-be80-55fd926a6b52",
    "size": 15488838,
    "size_human": "14.8 MiB"
  },
  {
    "edges": 76008,
    "nodes": 68337,
    "sbom_id": "0195bae4-6fc9-7ac0-9e1e-7459211ae095",
    "size": 61641210,
    "size_human": "58.8 MiB"
  },
  {
    "edges": 111086,
    "nodes": 81906,
    "sbom_id": "0195bae2-2edd-7f21-929e-c23fb2eb54bb",
    "size": 66205830,
    "size_human": "63.1 MiB"
  }
]
```

After:

```json
[
  {
    "edges": 67665,
    "nodes": 62888,
    "sbom_id": "0195bae4-1d7b-7591-8564-2c635b272d80",
    "size": 50191838,
    "size_human": "47.9 MiB"
  },
  {
    "edges": 82240,
    "nodes": 65647,
    "sbom_id": "0195bae3-0629-74b0-ad5b-82f184882e71",
    "size": 46676746,
    "size_human": "44.5 MiB"
  },
  {
    "edges": 38711,
    "nodes": 20147,
    "sbom_id": "0195baf0-9534-7132-be80-55fd926a6b52",
    "size": 13454138,
    "size_human": "12.8 MiB"
  },
  {
    "edges": 111086,
    "nodes": 81906,
    "sbom_id": "0195bae2-2edd-7f21-929e-c23fb2eb54bb",
    "size": 56950611,
    "size_human": "54.3 MiB"
  },
  {
    "edges": 76008,
    "nodes": 68337,
    "sbom_id": "0195bae4-6fc9-7ac0-9e1e-7459211ae095",
    "size": 53030920,
    "size_human": "50.6 MiB"
  }
]
```