### PR TITLE
fix: ensure latest cpe query returns latest roots

### DIFF
--- a/entity/src/sbom_node.rs
+++ b/entity/src/sbom_node.rs
@@ -20,6 +20,12 @@ pub enum Relation {
     )]
     Package,
     #[sea_orm(
+        belongs_to = "super::sbom_package::Entity",
+        from = "Column::SbomId",
+        to = "super::sbom_package::Column::SbomId"
+    )]
+    PackageBySbomId,
+    #[sea_orm(
         belongs_to = "super::sbom_file::Entity",
         from = "(Column::SbomId, Column::NodeId)",
         to = "(super::sbom_file::Column::SbomId, super::sbom_file::Column::NodeId)"

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_amd64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_amd64.json
@@ -30,7 +30,7 @@
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256%3A601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285?arch=amd64&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8",
       "type": "container",
-      "bom-ref": "2da3b0bd11fcb379",
+      "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_amd64",
       "version": "sha256:601cc46bdc24d6c432f51ce4aa8745d1a18ff07e2b0a1bb8ecad6bc091e98285",
       "hashes": [
         {
@@ -14133,7 +14133,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "2da3b0bd11fcb379",
+      "ref": "ose-openstack-cinder-csi-driver-operator-container_amd64",
       "dependsOn": [
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=d9a5accf56f24c33&upstream=acl-2.2.53-3.el8.src.rpm",
         "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=x86_64&distro=rhel-8.10&package-id=3daa175bec117741&upstream=audit-3.1.2-1.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_arm64.json
@@ -30,7 +30,7 @@
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256%3A0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f?arch=arm64&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8",
       "type": "container",
-      "bom-ref": "fb61cd6dd75398fb",
+      "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_arm64",
       "version": "sha256:0e72df1e6f4b356282576efaed99915fa7fb8c22718b67b1f82f89be6722b24f",
       "hashes": [
         {
@@ -14133,7 +14133,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "fb61cd6dd75398fb",
+      "ref": "ose-openstack-cinder-csi-driver-operator-container_arm64",
       "dependsOn": [
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=a7917c72826610a9&upstream=acl-2.2.53-3.el8.src.rpm",
         "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=aarch64&distro=rhel-8.10&package-id=7523ddbf31d32fd5&upstream=audit-3.1.2-1.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_ppc.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_ppc.json
@@ -30,7 +30,7 @@
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256%3A64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f?arch=ppc64le&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8",
       "type": "container",
-      "bom-ref": "1739dbbd9af5cdd8",
+      "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_ppc64le",
       "version": "sha256:64b4e6d6c18556f9f9dad1a9e6185c37d6ad07c72e515c475304a3a16b9eb51f",
       "hashes": [
         {
@@ -14133,7 +14133,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "1739dbbd9af5cdd8",
+      "ref": "ose-openstack-cinder-csi-driver-operator-container_ppc64le",
       "dependsOn": [
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=ppc64le&distro=rhel-8.10&package-id=42a9641944f38485&upstream=acl-2.2.53-3.el8.src.rpm",
         "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=ppc64le&distro=rhel-8.10&package-id=12d81eb282e64ccb&upstream=audit-3.1.2-1.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_s390x.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/example_container_variant_s390x.json
@@ -30,7 +30,7 @@
       "name": "openshift/ose-openstack-cinder-csi-driver-operator",
       "purl": "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256%3Ad3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d?arch=s390x&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8",
       "type": "container",
-      "bom-ref": "2b8dc6da540ea58f",
+      "bom-ref": "ose-openstack-cinder-csi-driver-operator-container_s390x",
       "version": "sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d",
       "hashes": [
         {
@@ -14082,7 +14082,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "2b8dc6da540ea58f",
+      "ref": "ose-openstack-cinder-csi-driver-operator-container_s390x",
       "dependsOn": [
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=s390x&distro=rhel-8.10&package-id=d17560a43a02bf80&upstream=acl-2.2.53-3.el8.src.rpm",
         "pkg:rpm/redhat/audit-libs@3.1.2-1.el8?arch=s390x&distro=rhel-8.10&package-id=4a22d6fe7a8e3b8c&upstream=audit-3.1.2-1.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_amd64.json
@@ -44,7 +44,7 @@
       "name": "quarkus/mandrel-for-jdk-21-rhel8",
       "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da?arch=amd64&os=linux&tag=23.1-19.1739757566",
       "type": "container",
-      "bom-ref": "1c4abceaa349a8c2",
+      "bom-ref": "quarkus-mandrel-231-rhel8-container_amd64",
       "version": "sha256:6545d1ae562899d6eb902f81be46a9fc6a8bd60f2b6b874f470722bca25fc0da",
       "hashes": [
         {
@@ -18085,7 +18085,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "1c4abceaa349a8c2",
+      "ref": "quarkus-mandrel-231-rhel8-container_amd64",
       "dependsOn": [
         "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=x86_64&distro=rhel-8.10&package-id=d9a5accf56f24c33&upstream=acl-2.2.53-3.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
+++ b/etc/test-data/cyclonedx/rh/image_index_variants/imagevariant_quarkus_mandrel_arm64.json
@@ -44,7 +44,7 @@
       "name": "quarkus/mandrel-for-jdk-21-rhel8",
       "purl": "pkg:oci/mandrel-for-jdk-21-rhel8@sha256%3A0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2?arch=arm64&os=linux&tag=23.1-19.1739757566",
       "type": "container",
-      "bom-ref": "b2d5dcab2ab572d7",
+      "bom-ref": "quarkus-mandrel-231-rhel8-container_arm64",
       "version": "sha256:0dba39e3c6db8f7a097798d7898bb0362c32c642561b819cb02a475d596ff2a2",
       "hashes": [
         {
@@ -18237,7 +18237,7 @@
   "specVersion": "1.6",
   "dependencies": [
     {
-      "ref": "b2d5dcab2ab572d7",
+      "ref": "quarkus-mandrel-231-rhel8-container_arm64",
       "dependsOn": [
         "pkg:rpm/redhat/abattis-cantarell-fonts@0.0.25-6.el8?arch=noarch&distro=rhel-8.10&package-id=a91121201ed3be00&upstream=abattis-cantarell-fonts-0.0.25-6.el8.src.rpm",
         "pkg:rpm/redhat/acl@2.2.53-3.el8?arch=aarch64&distro=rhel-8.10&package-id=a7917c72826610a9&upstream=acl-2.2.53-3.el8.src.rpm",

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/401A4500E49D44D.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/401A4500E49D44D.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "dev"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 9.4 Extended Update Support",
+      "type": "operating-system",
+      "bom-ref": "RHEL-9.4.0.Z.EUS",
+      "version": "RHEL-9.4.0.Z.EUS",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-06-09T03:29:53Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "150368"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be07351552fb0bb5f50d223cffe5f925b2b85ebe6c64f483de96f99c93a02f22"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9.4.0.Z.EUS",
+      "provides": [
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:b84b0b69-6d39-3b23-86c6-5c258fc730b7"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/74092FCBFD294FC.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/74092FCBFD294FC.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "0ac4c9ef"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 9.4 Extended Update Support",
+      "type": "operating-system",
+      "bom-ref": "RHEL-9.4.0.Z.EUS",
+      "version": "RHEL-9.4.0.Z.EUS",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-03-25T20:42:41Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "147407"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f9a22f77a60d00d59df5749420b5631788e0916b02abb9207d9764aed3ea51e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9.4.0.Z.EUS",
+      "provides": [
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:058458c3-373f-3234-9df0-15971459527e"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/80138DC9368C4D3.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/80138DC9368C4D3.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "dev"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "Red Hat Enterprise Linux 9.4 Extended Update Support",
+      "type": "operating-system",
+      "bom-ref": "RHEL-9.4.0.Z.EUS",
+      "version": "RHEL-9.4.0.Z.EUS",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:rhel_eus:9.4::appstream"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-06-09T10:18:20Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "150481"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "grafana",
+      "purl": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4392b9f2adf2466509af26338857a8ce92bcd00a9b7da02ddaec8280e3c88bf4"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src",
+      "version": "9.2.10-23.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "AGPL-3.0-only"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "RHEL-9.4.0.Z.EUS",
+      "provides": [
+        "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:501c2eae-1514-3252-a7ce-b6beed26fe62"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/B67E38F00200413.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/B67E38F00200413.json
@@ -1,0 +1,8710 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be07351552fb0bb5f50d223cffe5f925b2b85ebe6c64f483de96f99c93a02f22"
+        }
+      ],
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "65486d1d330f076054dcf2d303ac1677"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fd5b76c4f11e1dba27b44880f0af26776c3aa3a2d0f6207cb49bb78730cf11c5"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    "timestamp": "2025-06-02T18:15:17Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "150368"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "be07351552fb0bb5f50d223cffe5f925b2b85ebe6c64f483de96f99c93a02f22"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "dnsname",
+            "purl": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef"
+              }
+            ],
+            "bom-ref": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef",
+            "version": "bdc4ab8",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "dnsname",
+                  "purl": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c",
+                  "version": "bdc4ab8",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "65486d1d330f076054dcf2d303ac1677"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fd5b76c4f11e1dba27b44880f0af26776c3aa3a2d0f6207cb49bb78730cf11c5"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3657969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8e1c44ac3cb72c1fb447e82042697f6c2c9fba54e3aeab92e9a94d46a51e201b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "68adcdac9971f7f0a97c548c1785dc6c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1441892aa71a94bc14a7dcbbe683652d33bdeb7e47e8389ce8d18fcb24408418"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "61fab4a44d8b1f3354ecc5cf51c080c2fa88f94f2dcec48b97b5f0dd1e79b5da"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "bcefc9ead38961975c496cf8ff5f9a1e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "60747d67f15117ba3c9cb133697f40d116dae0c34a203e4219a904fd077c2b80"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a5a43a110cf2a085a79ad42b2a3ca00a1db20da2c40c28abf7dd09cee91dccd1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "42667c708bc1d7a74cf5b271a7f2beeb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1860d577f943116320acc4b1922519240ae170eff19cde6e6d7668f7ac17c111"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e7f5d64c391b54df2016a01b89b10f51822313aad9d3ed7b74fa5863e6a543eb"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "89f67b2997f3f0899fe09e121f749c01"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a6eb089111ab17864237e3df7048d65f165727f6dbda1710647902b30fc31ed2"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "267c8ca027494f21684fd7ab972e39324d6e65945f0345ad4a2868ac67496c69"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ebd82ea0e47d677e685348cedc31451d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e3b67eded858810d6bfee6633275246bf252e8cbdf886dc57f10974c94ae7134"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5ccaf8e7ee4a06301ce31daee939c48f6a13a1432763bd7a79bfd7a44a18fe64"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0ec65a25b010829aa556d13859489596"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8bc873e7d75b3cde5ff8ec3f27b940650bb7748829969e8a1c3b4ef5e354e537"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6764f4102e7656e84bd16fcd8f1913a2c0915f2604ebc654d447e03db360ba02"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5f8e7cf3cb85583ce94c6c6b11ee8a3c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "eaeff03328fb4c66d2321f9d251aa609ccd4d44138031f5d73bdae460504cddf"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-docker",
+      "purl": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6876605d8aadcd7e72c70ffda92e7a193c66b8c01a9f2f6a6a9388845d8d0123"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "1af21d873fbf3bee8f18e8ad686194a8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a4d73aaea41ff7c5789176b23f8ea973cc37730808f5022adaa043b44f3bf4d0"
+        }
+      ],
+      "description": "This package installs a script named docker that emulates the Docker CLI by executes podman commands, it also creates links between all Docker CLI man pages and podman."
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "15dc8138ede2c23124256921df36096f5d1b7d186ed8905c26c130eb3c2dac21"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=aarch64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c34cae68c0c0c33371c95938a92c9aa2"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "231224f53e0e0d09cd6d065f25057147efeb038b4be79fefacacabd5e0618313"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fb9954551c78946b1e8141499b37451290b87d4b5b8c3d42be8fc1988a36432e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9deba0016b551168db3a8de453256adb"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "b614a0f6f3ad27023297d73bc387cf47370e18f21467c1b53208926b8058c6e7"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e7231831e752ffaf25531310027909c64360e821dfef5903ac2a6615eed0cce1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9a853564b30daa7b72488b16786f2b92"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "67db21f07edc0d8b1435e4e96c415bb46ed8cbe22e30840bc492573c84153378"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c44dbcd7049238028f078e9124f19eb7dd2d6b725a34d971988244d9e0a53137"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "52e998cf3899966871734d3a40896dc0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0660afed50fd7af176af0c81a9e165bbbde4bad2d86e2c69fe22a86e77652f71"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1d850e59343d28f2efda9dab15f788ddee5c2662c0b39c2bdfac5267097019e2"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ad877108a3d04cdad006defdedec8b09"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f8766ae03fdcc24036e7c8ca398c902403dc2c1b8294219ed42c0439018435b8"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2195a7cc65180cf82d9fc951e11c46bcec6d1cd76162fc49f71c5f945af67928"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "2d9b30cb26593196aa58eeb3da89a7ae"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "3e4d4798c5b55ebd776308eb24dba87d140ba8d6359d4875298e35bc103e2817"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ca5eb6a18de3d380117813297069999db91d98159039a1d3e39ad7e7ac8bdfae"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "bfd051ba2ed0a99dbc9f82fe4645dba5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "41a8ba040e846cb853d39b4879e2fbe7ef563c89503afa7c542643a856d40900"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eadfb26ad461d56bbb959327faeb2018ecb1235a2d32de9da35a3c59c681c80d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "79fd7fe0871b6537439598b818812ddd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d716fb5aa26bb9d7c5825d015dd3cf91ed302126c2ef03175257882125afbc74"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "22052cd0baf7064c97b498f94ecd1f9d34559ee871051b1c87a85a2fc878e7e1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=ppc64le",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "86bd81c7ea32f1519977446771ae658b"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "725f59971a360af22da32873a75d2913782d9080c9e0d15ea66ccea5c620b114"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf1b27c21019fd198432da4c92842c30e7202a195c2caf46eff8fcad8ba16c78"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "aa2370b3984fe51da9514a7fb269a009"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "13de8c0c00b2756d238f7a9c75fda78ea846f8d2275639967a4be10d3f2af1e9"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ecd518c1082d784390794a59985bc06e1b3bfe6b8c36e49bfda6760a9ebfd8f0"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "360b4749ee6fcf104100fbab9078680e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "badc23b03bc80967f42b97e024aa41e0e25e0b5e1523cc2fb5675124f43b2165"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7e554f700b47a25b2eafe79dff6eed0ce2d4813cc1fdb9dacb6e3e23f5712704"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "99ee879bd34e108b75098af0a7e4377f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6872f24936f6a905c833017992f2b0cc66799a12dda5050d34935bcf1acad041"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e73ebf72d47341a050bb437a0af5e3e3b69798a7b6c22720394ed212ad6d8639"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9c96a5aa9239f3ca7aed6b7957f104a4"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ec962034e9b1ce1db0cae15be88789bfbfcc4c70be3eb2997c81c1c2063b48b5"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2efb6f43c691ef62239db5d0063a9091cd18bf76f4bfb153e450bbba2eefd779"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ada32a943ca227392c2510b362fe3de8"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "06cc39410c2af826c6b5b4239aa324792c5188143384bc0c66ac24a74af8c233"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "73207d32c744c14a23b19b503030d723f085fe4916730c48e3f7ec046e532c36"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "02967fec14cd30d48d442298eed07230"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9caecc578d8009211c811ea51de46f522d3c217cf40acdd5d9f023dca5b4ffe7"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0a40e5d093b8729ea78c948af2dbc8eba21cecfaac52aa6218ccec70b9f3b0bf"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b670f866cefb4b9a4b10d9109c690513"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "a0b18f2cf490af4ac978d92e5b21ed017b273d8543f8b9b7d5010022ae329fd8"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "41a88a9cabaf442ea013e04647e9f6fd56986878033a5c27544531773357aa1a"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a231ffbd7ba1abb7662d13859fc123d5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8574f576fa0857efd85fe7819a3497e15f91eed4aaa32a02cde1d9866bcb5dc2"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c64d3d96a5ad9ec0fd0d348acff56f818ad03c283273b492892c5559c1015f32"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "87bf0087f8272df1fe7f12fcf008f769"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ee60ae804bb9460c667de4d383233f37949ba115849ada52159a3806458646f1"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "544faeadda319f1c9247853678a9096b0c421daa5b297b01abb4d6be95bdd89e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "407e9b853658be483ba9670faa3d8d9e"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "edfeee6313e36f25c7ab0766290cd071787273364bd932a2c18a6259182b4feb"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8ac5f545b895438d3bdf43dc78ed4ee2dfa30b0d044cccdfff4dc81f612e99e9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c7776402c3a77157dbbb4d7a7da9fd8f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "688e00c24df3760b6901636d6046ad2e2fcca6068ecae62f43c152caa077f74b"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6e2237e7bd7ea024002a47942134358329f13f96e71ac0f2de101c2b2f32a48b"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "049eb075060eb35a3e0ae8bf2546d612"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "164447e505cad21f0587f54cdb2bbcbb0aea7d97336b1928f7f6b65b911cb080"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7a95fa2e0755bef121c0a06df8e1fa8cb9bb4e7cf9f06ba6399ae04933c9ad5f"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a1e6e37d769e24e8d26496301a385810"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ec4cc84ab97a075afa7052226321bb29f2810031ade8770b941d269b058737a2"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "66043714bcdc21ba6fa8ef46db7910fa2268598e257cf4fb05734e4b9d3835bb"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f1461d8061f7e6e0eeb6aa09746e3845"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "4aaaf48d6684f1a56863777af46256559418655525b46810aab8e66adaa8a180"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f08e25548be5ef6548b68955fa5807bd6fe1585d9e1d4be1b9fee4607af70e3"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "34e6746655c8c32e574f5a32a7f96d82"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d05e3bfb5602155af514b2b767080fbd4731c6bd9d490018083b74152a9011a3"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e4ae26248db483fa7c530bb008b1ea479b2bb25bb425b713088fd2b553362c84"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=s390x",
+      "version": "4.9.4-18.el9_4.1",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ac108486eefbc56e83adbbc928036d3b"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "021c3cacd5465e8f368ee98b626b1ebea6d52aa955677c6333ea7c308dd79f0f"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "codespell",
+      "purl": "pkg:pypi/codespell@2.2.5",
+      "type": "library",
+      "bom-ref": "pkg:pypi/codespell@2.2.5?package-id=93ce0b8f87334918",
+      "version": "2.2.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/vendor/go.opentelemetry.io/otel/requirements.txt"
+        }
+      ]
+    },
+    {
+      "name": "dario.cat/mergo",
+      "purl": "pkg:golang/dario.cat/mergo@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/dario.cat/mergo@v1.0.0?package-id=830889683f785245",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Azure/go-ansiterm",
+      "purl": "pkg:golang/github.com/Azure/go-ansiterm@v0.0.0-20230124172434-306776ec8161",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/azure/go-ansiterm@v0.0.0-20230124172434-306776ec8161?package-id=e9e7e6d880b91c47",
+      "version": "v0.0.0-20230124172434-306776ec8161",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/BurntSushi/toml",
+      "purl": "pkg:golang/github.com/BurntSushi/toml@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v1.3.2?package-id=1b8d14c0892e99f2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Microsoft/go-winio",
+      "purl": "pkg:golang/github.com/Microsoft/go-winio@v0.6.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/microsoft/go-winio@v0.6.1?package-id=40cf52cbbf85a689",
+      "version": "v0.6.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Microsoft/hcsshim",
+      "purl": "pkg:golang/github.com/Microsoft/hcsshim@v0.12.0-rc.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/microsoft/hcsshim@v0.12.0-rc.1?package-id=70ca0709aa342b6a",
+      "version": "v0.12.0-rc.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Hy+xzYujv7urO5wrgcG58SPMOXNLrj4WCJbySs2XX/A="
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "purl": "pkg:golang/github.com/VividCortex/ewma@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vividcortex/ewma@v1.2.0?package-id=ce702c42537131b2",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow="
+        }
+      ]
+    },
+    {
+      "name": "github.com/acarl005/stripansi",
+      "purl": "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d?package-id=29b6356e75990362",
+      "version": "v0.0.0-20180116102854-5a71ef0e047d",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/aead/serpent",
+      "purl": "pkg:golang/github.com/aead/serpent@v0.0.0-20160714141033-fba169763ea6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/aead/serpent@v0.0.0-20160714141033-fba169763ea6?package-id=c306d9cc564ad003",
+      "version": "v0.0.0-20160714141033-fba169763ea6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:5L8Mj9Co9sJVgW3TpYk2gxGJnDjsYuboNTcRmbtGKGs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2?package-id=6b61f83a371c983b",
+      "version": "v0.0.0-20230301143203-a9d515a09cc2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so="
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver/v4",
+      "purl": "pkg:golang/github.com/blang/semver@v4.0.0#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v4.0.0?package-id=7ff5e24b84ae2c11#v4",
+      "version": "v4.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/buger/goterm",
+      "purl": "pkg:golang/github.com/buger/goterm@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/buger/goterm@v1.0.4?package-id=893020272c15f641",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/bytedance/sonic",
+      "purl": "pkg:golang/github.com/bytedance/sonic@v1.10.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.10.1?package-id=691d0a16f158d1de",
+      "version": "v1.10.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:7a1wuFXL1cMy7a3f7/VFcEtriuXQnUBhtoVfOZiaysc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/checkpoint-restore/checkpointctl",
+      "purl": "pkg:golang/github.com/checkpoint-restore/checkpointctl@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/checkpoint-restore/checkpointctl@v1.1.0?package-id=55c3fdc2e21f8fa0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:plS/2zBzbAXO6DH/H+TqD7ZGhz8iQVb+NLgsOJSTWaw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/checkpoint-restore/go-criu/v7",
+      "purl": "pkg:golang/github.com/checkpoint-restore/go-criu@v7.0.0#v7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/checkpoint-restore/go-criu@v7.0.0?package-id=23ca41634978b1d3#v7",
+      "version": "v7.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:R4UF/njKOuq8ooG7naFGsCeKsjv5j+rIhgFgSSeC2KY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chenzhuoyu/base64x",
+      "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20230717121745-296ad89f973d",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20230717121745-296ad89f973d?package-id=37dd41ecf04410eb",
+      "version": "v0.0.0-20230717121745-296ad89f973d",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chenzhuoyu/iasm",
+      "purl": "pkg:golang/github.com/chenzhuoyu/iasm@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/iasm@v0.9.0?package-id=b1b6e5af6d27d8c2",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chzyer/readline",
+      "purl": "pkg:golang/github.com/chzyer/readline@v1.5.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/readline@v1.5.1?package-id=6a6f66fab4da81eb",
+      "version": "v1.5.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "purl": "pkg:golang/github.com/cilium/ebpf@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.9.1?package-id=5d1704ccdfbb59aa",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/cgroups/v3",
+      "purl": "pkg:golang/github.com/containerd/cgroups@v3.0.2#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/cgroups@v3.0.2?package-id=4207eaf6f39904b6#v3",
+      "version": "v3.0.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/containerd",
+      "purl": "pkg:golang/github.com/containerd/containerd@v1.7.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/containerd@v1.7.9?package-id=f8585ffcfc78ce2e",
+      "version": "v1.7.9",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:KOhK01szQbM80YfW1H6RZKh85PHGqY/9OcEZ35Je8sc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/log",
+      "purl": "pkg:golang/github.com/containerd/log@v0.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/log@v0.1.0?package-id=d50543144aae839f",
+      "version": "v0.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/stargz-snapshotter/estargz",
+      "purl": "pkg:golang/github.com/containerd/stargz-snapshotter@v0.15.1#estargz",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/stargz-snapshotter@v0.15.1?package-id=390abc45fd64da96#estargz",
+      "version": "v0.15.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/typeurl/v2",
+      "purl": "pkg:golang/github.com/containerd/typeurl@v2.1.1#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/typeurl@v2.1.1?package-id=49bb413ecf1b1c35#v2",
+      "version": "v2.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=fd98f7f80806420c",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "purl": "pkg:golang/github.com/containernetworking/cni@v1.1.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=e47a64cfd5d94175",
+      "version": "v1.1.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v0.9.1?package-id=32f511297d78f16c",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9r2Quag7HMLV8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "purl": "pkg:golang/github.com/containernetworking/plugins@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.3.0?package-id=1ec97afad4827d0b",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/buildah",
+      "purl": "pkg:golang/github.com/containers/buildah@v1.33.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/buildah@v1.33.12?package-id=c0d3b0102aaf1707",
+      "version": "v1.33.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6/X3LPnl+xXel4TNNMSjp5I5ztkpxeW3xSkLvF1IiSI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "purl": "pkg:golang/github.com/containers/common@v0.57.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.57.7?package-id=c25ac5fa7b116b52",
+      "version": "v0.57.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xA6/dXNbScnaytcFNQKTFGn6VDxwvDlCngJtfdGAf7g="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/conmon",
+      "purl": "pkg:golang/github.com/containers/conmon@v2.0.20%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/conmon@v2.0.20%2Bincompatible?package-id=7386cf9fa7f28aa8",
+      "version": "v2.0.20+incompatible",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/gvisor-tap-vsock",
+      "purl": "pkg:golang/github.com/containers/gvisor-tap-vsock@v0.7.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/gvisor-tap-vsock@v0.7.2?package-id=64013dd1a44951f6",
+      "version": "v0.7.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6CyU5D85C0/DciRRd7W0bPljK4FAS+DPrrHEQMHfZKY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/image/v5",
+      "purl": "pkg:golang/github.com/containers/image@v5.29.5#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/image@v5.29.5?package-id=b3a9f470a6979dc4#v5",
+      "version": "v5.29.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hMA9TBrk/tpXX7tYHTjbuyJ6L04Hm+m97+CZaU0VGwI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/libhvee",
+      "purl": "pkg:golang/github.com/containers/libhvee@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/libhvee@v0.5.0?package-id=c4d28ec3437ffad9",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rDhfG2NI8Q+VgeXht2dXezanxEdpj9pHqYX3vWfOGUw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/libtrust",
+      "purl": "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01?package-id=3487a0ced8b96924",
+      "version": "v0.0.0-20230121012942-c1716e8a8d01",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/luksy",
+      "purl": "pkg:golang/github.com/containers/luksy@v0.0.0-20231030195837-b5a7f79da98b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/luksy@v0.0.0-20231030195837-b5a7f79da98b?package-id=5186102f5ee8ef20",
+      "version": "v0.0.0-20231030195837-b5a7f79da98b",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8XvNAm+g7ivwPUkyiHvBs7z356JWpK9a0FDaek86+sY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/ocicrypt",
+      "purl": "pkg:golang/github.com/containers/ocicrypt@v1.1.10",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/ocicrypt@v1.1.10?package-id=83339bccba164f22",
+      "version": "v1.1.10",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r7UR6o8+lyhkEywetubUUgcKFjOWOaWz8cEBrCPX0ic="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/psgo",
+      "purl": "pkg:golang/github.com/containers/psgo@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/psgo@v1.8.0?package-id=dbb812350f8094e0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2loGekmGAxM9ir5OsXWEfGwFxorMPYnc6gEDsGFQvhY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/storage",
+      "purl": "pkg:golang/github.com/containers/storage@v1.51.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/storage@v1.51.2?package-id=c94c9f0a8fd1d8a0",
+      "version": "v1.51.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Xw8p1AG1A+Nh6dCsb1UOB3YKF5uzlCkI3uAP4fsFup4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-iptables",
+      "purl": "pkg:golang/github.com/coreos/go-iptables@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-iptables@v0.6.0?package-id=5d0cb7eaa4a0821f",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-oidc/v3",
+      "purl": "pkg:golang/github.com/coreos/go-oidc@v3.7.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-oidc@v3.7.0?package-id=74f403c5d44d527d#v3",
+      "version": "v3.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FTdj0uexT4diYIPlF4yoFVI5MRO1r5+SEcIpEw9vC0o="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v0.0.0-20190719114852-fd7a80b32e1f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v0.0.0-20190719114852-fd7a80b32e1f?package-id=768cb510c1564622",
+      "version": "v0.0.0-20190719114852-fd7a80b32e1f",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "purl": "pkg:golang/github.com/coreos/go-systemd@v22.5.1-0.20231103132048-7d375ecc2b09#v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.1-0.20231103132048-7d375ecc2b09?package-id=da2557227db91ac4#v22",
+      "version": "v22.5.1-0.20231103132048-7d375ecc2b09",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/stream-metadata-go",
+      "purl": "pkg:golang/github.com/coreos/stream-metadata-go@v0.4.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/stream-metadata-go@v0.4.4?package-id=d1972eabd953914a",
+      "version": "v0.4.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:PM/6iNhofKGydsatiY1zdnMMHBT34skb5P7nfEFR4GU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cpuguy83/go-md2man/v2",
+      "purl": "pkg:golang/github.com/cpuguy83/go-md2man@v2.0.3#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man@v2.0.3?package-id=4fc3928126aefd1a#v2",
+      "version": "v2.0.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/crc-org/vfkit",
+      "purl": "pkg:golang/github.com/crc-org/vfkit@v0.1.2-0.20231030102423-f3c783d34420",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/crc-org/vfkit@v0.1.2-0.20231030102423-f3c783d34420?package-id=9a4f86040fd4c9bf",
+      "version": "v0.1.2-0.20231030102423-f3c783d34420",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QXiiq7uk7RR4t0Urp/OtIibD+6PJHkEE2zy3QTQ42so="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyberphone/json-canonicalization",
+      "purl": "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20231011164504-785e29786b46",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20231011164504-785e29786b46?package-id=2754f6d742c1aaea",
+      "version": "v0.0.0-20231011164504-785e29786b46",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=1d9a4060dc7f58d7",
+      "version": "v0.2.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=877523c75d46a3c2",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=5bed9601b6633eee",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/digitalocean/go-libvirt",
+      "purl": "pkg:golang/github.com/digitalocean/go-libvirt@v0.0.0-20220804181439-8648fbde413e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/digitalocean/go-libvirt@v0.0.0-20220804181439-8648fbde413e?package-id=13c1189cf8b54f71",
+      "version": "v0.0.0-20220804181439-8648fbde413e",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:SCnqm8SjSa0QqRxXbo5YY//S+OryeJioe17nK+iDZpg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/digitalocean/go-qemu",
+      "purl": "pkg:golang/github.com/digitalocean/go-qemu@v0.0.0-20230711162256-2e3d0186973e",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/digitalocean/go-qemu@v0.0.0-20230711162256-2e3d0186973e?package-id=f99622502510a79a",
+      "version": "v0.0.0-20230711162256-2e3d0186973e",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:x5PInTuXLddHWHlePCNAcM8QtUfOGx44f3UmYPMtDcI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/disiqueira/gotree/v3",
+      "purl": "pkg:golang/github.com/disiqueira/gotree@v3.0.2#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/disiqueira/gotree@v3.0.2?package-id=ba601b632df342f6#v3",
+      "version": "v3.0.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ik5iuLQQoufZBNPY518dXhiO5056hyNBIK9lWhkNRq8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/distribution/reference",
+      "purl": "pkg:golang/github.com/distribution/reference@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/distribution/reference@v0.5.0?package-id=4dba30d4daf39b34",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/distribution",
+      "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible?package-id=e752a6d5b6994595",
+      "version": "v2.8.3+incompatible",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/docker",
+      "purl": "pkg:golang/github.com/docker/docker@v24.0.7%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/docker@v24.0.7%2Bincompatible?package-id=45390c3a7cd66a04",
+      "version": "v24.0.7+incompatible",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/docker-credential-helpers",
+      "purl": "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.0?package-id=9b36de361d1590fc",
+      "version": "v0.8.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-connections",
+      "purl": "pkg:golang/github.com/docker/go-connections@v0.4.1-0.20231031175723-0b8c1f4e07a0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-connections@v0.4.1-0.20231031175723-0b8c1f4e07a0?package-id=82021f28ac416c95",
+      "version": "v0.4.1-0.20231031175723-0b8c1f4e07a0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dPD5pdqsujF9jz2NQMQCDzrBSAF3M6kIxmfU98IOp9c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-plugins-helpers",
+      "purl": "pkg:golang/github.com/docker/go-plugins-helpers@v0.0.0-20211224144127-6eecb7beb651",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-plugins-helpers@v0.0.0-20211224144127-6eecb7beb651?package-id=dac3e4f2d2513c93",
+      "version": "v0.0.0-20211224144127-6eecb7beb651",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YcvzLmdrP/b8kLAGJ8GT7bdncgCAiWxJZIlt84D+RJg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-units",
+      "purl": "pkg:golang/github.com/docker/go-units@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-units@v0.5.0?package-id=3a5ed86f41f0acf4",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "purl": "pkg:golang/github.com/fatih/color@v1.15.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.15.0?package-id=f455521699a81e89",
+      "version": "v1.15.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/felixge/httpsnoop",
+      "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/felixge/httpsnoop@v1.0.3?package-id=55d70b09906d903f",
+      "version": "v1.0.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.9?package-id=43c300e9aa729c9d",
+      "version": "v1.4.9",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=c74c579f441264d1",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsouza/go-dockerclient",
+      "purl": "pkg:golang/github.com/fsouza/go-dockerclient@v1.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsouza/go-dockerclient@v1.10.0?package-id=79aedfb86dbe69e6",
+      "version": "v1.10.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ppSBsbR60I1DFbV4Ag7LlHlHakHFRNLk9XakATW1yVQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gabriel-vasile/mimetype",
+      "purl": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2?package-id=18edcc57ea86b0de",
+      "version": "v1.4.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gin-contrib/sse",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0?package-id=5b738c5758770efd",
+      "version": "v0.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gin-gonic/gin",
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1?package-id=09345e895a858a3c",
+      "version": "v1.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-jose/go-jose/v3",
+      "purl": "pkg:golang/github.com/go-jose/go-jose@v3.0.3#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-jose/go-jose@v3.0.3?package-id=4b5a858815161aed#v3",
+      "version": "v3.0.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.3.0?package-id=a7ea5bc58bf08192",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/stdr",
+      "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/stdr@v1.2.2?package-id=933384e7ba49cf7f",
+      "version": "v1.2.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-ole/go-ole",
+      "purl": "pkg:golang/github.com/go-ole/go-ole@v1.2.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-ole/go-ole@v1.2.6?package-id=70bf04f6f041e52d",
+      "version": "v1.2.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "purl": "pkg:golang/github.com/go-openapi/analysis@v0.21.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.21.4?package-id=9ea8b9ad52030bed",
+      "version": "v0.21.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ZDFLvSNxpDaomuCueM0BlSXxpANBlFYiBvr+GXrvIHc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "purl": "pkg:golang/github.com/go-openapi/errors@v0.20.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.20.4?package-id=f1e2ed6ce77fd9ee",
+      "version": "v0.20.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:unTcVm6PispJsMECE3zWgvG4xTiKda1LIR5rCRWLG6M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6?package-id=7a11fcfebcb03b98",
+      "version": "v0.19.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=fea23081cb20edbf",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "purl": "pkg:golang/github.com/go-openapi/loads@v0.21.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.21.2?package-id=4614ac5fd7096390",
+      "version": "v0.21.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r2a/xFIYeZ4Qd2TnGpWDIQNcP80dIaZgf704za8enro="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "purl": "pkg:golang/github.com/go-openapi/runtime@v0.26.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.26.0?package-id=6fe90c32a6b86cc4",
+      "version": "v0.26.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:HYOFtG00FM1UvqrcxbEJg/SwvDRvYLQKGhw2zaQjTcc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "purl": "pkg:golang/github.com/go-openapi/spec@v0.20.9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.9?package-id=928d01ff17d2a67b",
+      "version": "v0.20.9",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xnlYNQAwKd2VQRRfwTEI0DcK+2cbuvI/0c7jx3gA8/8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.21.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.21.7?package-id=a29e2d3c0ff70597",
+      "version": "v0.21.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=725453dbb9b24889",
+      "version": "v0.22.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "purl": "pkg:golang/github.com/go-openapi/validate@v0.22.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.22.1?package-id=4016181974a83f6a",
+      "version": "v0.22.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:G+c2ub6q47kfX1sOBLwIQwzBVt8qmOAARyo/9Fqs9NU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/locales",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1?package-id=5fc0f23885fecc3e",
+      "version": "v0.14.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/universal-translator",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1?package-id=44e9ee23b30396bc",
+      "version": "v0.18.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/validator/v10",
+      "purl": "pkg:golang/github.com/go-playground/validator@v10.15.5#v10",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator@v10.15.5?package-id=6f779696625a0d1c#v10",
+      "version": "v10.15.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LEBecTWb/1j5TNY1YYG2RcOUN3R7NLylN+x8TTueE24="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0?package-id=5dec6809fb961051",
+      "version": "v0.0.0-20210107165309-348f09dbbbc0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=7723f23509f6e9c9",
+      "version": "v0.0.0-20230315185526-52ccab3ef572",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "purl": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=6ed8f14e2691b0ae",
+      "version": "v0.0.0-20230315185526-52ccab3ef572",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/goccy/go-json",
+      "purl": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2?package-id=9b95f38549dbb2e7",
+      "version": "v0.10.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "purl": "pkg:golang/github.com/godbus/dbus@v5.1.1-0.20230522191255-76236955d466#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.1-0.20230522191255-76236955d466?package-id=b7c3e9fcaadfacd7#v5",
+      "version": "v5.1.1-0.20230522191255-76236955d466",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sQspH8M4niEijh3PFscJRLDnkL547IeP7kpPe3uUhEg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=3858e45e43a13e41",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=9fc12d1b7d0549a3",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2?package-id=580312068be9bbdf",
+      "version": "v1.5.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3?package-id=24106bbd02602711",
+      "version": "v1.5.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=4e7acfd6c9128ec8",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-containerregistry",
+      "purl": "pkg:golang/github.com/google/go-containerregistry@v0.16.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-containerregistry@v0.16.1?package-id=257e85f612c158db",
+      "version": "v0.16.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rUEt426sR6nyrL3gt+18ibRcvYpKYdpsa5ZW7MA08dQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-intervals",
+      "purl": "pkg:golang/github.com/google/go-intervals@v0.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-intervals@v0.0.2?package-id=8882646581544332",
+      "version": "v0.0.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FGrVEiUnTRKR8yE04qzXYaJMtnIYqobR5QbblK3ixcM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=555a0046e0839547",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38?package-id=71958bcc23037ded",
+      "version": "v0.0.0-20210407192527-94a9f03dee38",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20230323073829-e72429f035bd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20230323073829-e72429f035bd?package-id=0c815505247e335f",
+      "version": "v0.0.0-20230323073829-e72429f035bd",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r8yyd+DJDmsUhGrRBxH5Pj7KeFK5l+Y3FsgT8keqKtk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/shlex",
+      "purl": "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510?package-id=ab20454707c0ef00",
+      "version": "v0.0.0-20191202100458-e7afc7fbc510",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.4.0?package-id=fa5cb10169d3b9ca",
+      "version": "v1.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/handlers",
+      "purl": "pkg:golang/github.com/gorilla/handlers@v1.5.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/handlers@v1.5.2?package-id=7e5de02f3835a81a",
+      "version": "v1.5.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/mux",
+      "purl": "pkg:golang/github.com/gorilla/mux@v1.8.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/mux@v1.8.1?package-id=8205ef61f87399be",
+      "version": "v1.8.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/schema",
+      "purl": "pkg:golang/github.com/gorilla/schema@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/schema@v1.4.1?package-id=52af4c633255d773",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/errwrap",
+      "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0?package-id=a8a79647a7a8cf70",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-cleanhttp",
+      "purl": "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2?package-id=e1ee33c1617e1009",
+      "version": "v0.5.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-multierror",
+      "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1?package-id=5671cb08a298ac36",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-retryablehttp",
+      "purl": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.7?package-id=28dd885c1b4dbb0e",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-version",
+      "purl": "pkg:golang/github.com/hashicorp/go-version@v1.3.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-version@v1.3.0?package-id=0a0118ecc74d7c35",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hugelgupf/p9",
+      "purl": "pkg:golang/github.com/hugelgupf/p9@v0.3.1-0.20230822151754-54f5c5530921",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hugelgupf/p9@v0.3.1-0.20230822151754-54f5c5530921?package-id=2ffe99043a09760b",
+      "version": "v0.3.1-0.20230822151754-54f5c5530921",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:cfYGdNpXGZobTSSDFB+wx2FRfWptM7sCkScJgVx0Tkk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=dc1badc47df18f09",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/jinzhu/copier",
+      "purl": "pkg:golang/github.com/jinzhu/copier@v0.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jinzhu/copier@v0.4.0?package-id=a1b1e1aa033edb92",
+      "version": "v0.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=ac618cfcc28857e7",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=9a09e60e64762fb5",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/compress",
+      "purl": "pkg:golang/github.com/klauspost/compress@v1.17.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/compress@v1.17.3?package-id=1ffa33b600e6ddfd",
+      "version": "v1.17.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:qkRjuerhUU1EmXLYGkSH6EZL+vPSxIrYjLNAK4slzwA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/cpuid/v2",
+      "purl": "pkg:golang/github.com/klauspost/cpuid@v2.2.5#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid@v2.2.5?package-id=e41a09d00e6a6abe#v2",
+      "version": "v2.2.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/pgzip",
+      "purl": "pkg:golang/github.com/klauspost/pgzip@v1.2.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/pgzip@v1.2.6?package-id=07e01f5838373cd6",
+      "version": "v1.2.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/fs",
+      "purl": "pkg:golang/github.com/kr/fs@v0.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/fs@v0.1.0?package-id=398ff89cd63d2228",
+      "version": "v0.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/leodido/go-urn",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4?package-id=5281368296cb5ab9",
+      "version": "v1.2.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q="
+        }
+      ]
+    },
+    {
+      "name": "github.com/letsencrypt/boulder",
+      "purl": "pkg:golang/github.com/letsencrypt/boulder@v0.0.0-20230213213521-fdfea0d469b6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/letsencrypt/boulder@v0.0.0-20230213213521-fdfea0d469b6?package-id=258bb3371e4d4027",
+      "version": "v0.0.0-20230213213521-fdfea0d469b6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:unJdfS94Y3k85TKy+mvKzjW5R9rIC+Lv4KGbE7uNu0I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/linuxkit/virtsock",
+      "purl": "pkg:golang/github.com/linuxkit/virtsock@v0.0.0-20220523201153-1a23e78aa7a2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/linuxkit/virtsock@v0.0.0-20220523201153-1a23e78aa7a2?package-id=d3cf194c0733b47d",
+      "version": "v0.0.0-20220523201153-1a23e78aa7a2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DZMFueDbfz6PNc1GwDRA8+6lBx1TB9UnxDQliCqR73Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/lufia/plan9stats",
+      "purl": "pkg:golang/github.com/lufia/plan9stats@v0.0.0-20211012122336-39d0f177ccd0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/lufia/plan9stats@v0.0.0-20211012122336-39d0f177ccd0?package-id=8209420d49ba0096",
+      "version": "v0.0.0-20211012122336-39d0f177ccd0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/magefile/mage",
+      "purl": "pkg:golang/github.com/magefile/mage@v1.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/magefile/mage@v1.14.0?package-id=a74f649988594bbd",
+      "version": "v1.14.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=8e46bb3723393ca3",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/manifoldco/promptui",
+      "purl": "pkg:golang/github.com/manifoldco/promptui@v0.9.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/manifoldco/promptui@v0.9.0?package-id=7bac44b824f7aa5e",
+      "version": "v0.9.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13?package-id=55b67c1594f55f24",
+      "version": "v0.1.13",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.17",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17?package-id=117a3f38e559e9ed",
+      "version": "v0.0.17",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.20",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.20?package-id=b981519f33f50dbc",
+      "version": "v0.0.20",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15?package-id=0b6d7d3f1eeeeae4",
+      "version": "v0.0.15",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-shellwords",
+      "purl": "pkg:golang/github.com/mattn/go-shellwords@v1.0.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-shellwords@v1.0.12?package-id=83450e3a15e0f99d",
+      "version": "v1.0.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-sqlite3",
+      "purl": "pkg:golang/github.com/mattn/go-sqlite3@v1.14.18",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-sqlite3@v1.14.18?package-id=f5d05835504f4ffd",
+      "version": "v1.14.18",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "purl": "pkg:golang/github.com/mdlayher/socket@v0.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=f56f68404baa5b58",
+      "version": "v0.4.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "purl": "pkg:golang/github.com/mdlayher/vsock@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=2aee1d4c12209cb8",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/miekg/pkcs11",
+      "purl": "pkg:golang/github.com/miekg/pkcs11@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/miekg/pkcs11@v1.1.1?package-id=fef9e5fb9971283d",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mistifyio/go-zfs/v3",
+      "purl": "pkg:golang/github.com/mistifyio/go-zfs@v3.0.1#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mistifyio/go-zfs@v3.0.1?package-id=2216e1fe48e790da#v3",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0?package-id=7981989d0762c97e",
+      "version": "v1.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/buildkit",
+      "purl": "pkg:golang/github.com/moby/buildkit@v0.12.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/buildkit@v0.12.5?package-id=7b5f00776e604492",
+      "version": "v0.12.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:RNHH1l3HDhYyZafr5EgstEu8aGNCwyfvMtrQDtjH9T0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/patternmatcher",
+      "purl": "pkg:golang/github.com/moby/patternmatcher@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/patternmatcher@v0.6.0?package-id=64fc68737d4c9f77",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "purl": "pkg:golang/github.com/moby/sys@v0.7.1#mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.7.1?package-id=057e295fbec4aa26#mountinfo",
+      "version": "v0.7.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/sequential",
+      "purl": "pkg:golang/github.com/moby/sys@v0.5.0#sequential",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.5.0?package-id=ab4a193d344a7505#sequential",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/term",
+      "purl": "pkg:golang/github.com/moby/term@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/term@v0.5.0?package-id=249cb807e979f08f",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=909dd10ba0ae8d1c",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e5c6f4996c77bb75",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/morikuni/aec",
+      "purl": "pkg:golang/github.com/morikuni/aec@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/morikuni/aec@v1.0.0?package-id=a30048d529e8332e",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A="
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v1.4.11",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v1.4.11?package-id=e64a2938860b6dd5",
+      "version": "v1.4.11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "purl": "pkg:golang/github.com/nxadm/tail@v1.4.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v1.4.8?package-id=47dcfdbf536f7c63",
+      "version": "v1.4.8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/oklog/ulid",
+      "purl": "pkg:golang/github.com/oklog/ulid@v1.3.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/oklog/ulid@v1.3.1?package-id=14bd4a60fcd4657e",
+      "version": "v1.3.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.16.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.16.4?package-id=24c75128dfa61e89",
+      "version": "v1.16.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.16.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.16.5?package-id=ea9cf0407d9a2eca",
+      "version": "v1.16.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.13.1#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=49dac0fbe8817737#v2",
+      "version": "v2.13.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LNGfMbR2OVGBfXjvRZIZ2YCTQdGKtPLvuI1rMCCj3OU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v2.13.1#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=fc37f0a9e4bf5451#v2",
+      "version": "v2.13.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LNGfMbR2OVGBfXjvRZIZ2YCTQdGKtPLvuI1rMCCj3OU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.10.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.10.1?package-id=3b42020f9d5a81e3",
+      "version": "v1.10.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.17.0?package-id=5f42984101810003",
+      "version": "v1.17.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.30.0?package-id=41d0dd66a95fa5b6",
+      "version": "v1.30.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/go-digest",
+      "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0?package-id=5ed4b0a493e74727",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/image-spec",
+      "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0-rc5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0-rc5?package-id=de9ca21aabe7af43",
+      "version": "v1.1.0-rc5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "purl": "pkg:golang/github.com/opencontainers/runc@v1.1.10",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.10?package-id=64a86695e9014382",
+      "version": "v1.1.10",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EaL5WeO9lv9wmS6SASjszOeQdSctvpbu0DdBQBizE40="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.1.1-0.20230922153023-c0e90434df2a",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.1.1-0.20230922153023-c0e90434df2a?package-id=aa338f0fb7818fba",
+      "version": "v1.1.1-0.20230922153023-c0e90434df2a",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ekgJlqTI6efJ57J7tqvIOYtdPnJRe8MxUZHbZAC021Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-tools",
+      "purl": "pkg:golang/github.com/opencontainers/runtime-tools@v0.9.1-0.20230914150019-408c51e934dc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-tools@v0.9.1-0.20230914150019-408c51e934dc?package-id=7906f8e792e1cc23",
+      "version": "v0.9.1-0.20230914150019-408c51e934dc",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=a7a0602fcd6bf785",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "purl": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581?package-id=6996b532d4a8353f",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YWomd7tA7icznvjpDrSJ8Ksfd0xPWG4E0nEBhvABjSA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/imagebuilder",
+      "purl": "pkg:golang/github.com/openshift/imagebuilder@v1.2.6-0.20231110114814-35a50d57f722",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/imagebuilder@v1.2.6-0.20231110114814-35a50d57f722?package-id=bf8de9a16e63655a",
+      "version": "v1.2.6-0.20231110114814-35a50d57f722",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vhEmg+NeucmSYnT2j9ukkZLrR/ZOFUuUiGhxlBAlW8U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opentracing/opentracing-go",
+      "purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.2.0?package-id=efecea730dd143c9",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ostreedev/ostree-go",
+      "purl": "pkg:golang/github.com/ostreedev/ostree-go@v0.0.0-20210805093236-719684c64e4f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ostreedev/ostree-go@v0.0.0-20210805093236-719684c64e4f?package-id=1ba798c98082554e",
+      "version": "v0.0.0-20210805093236-719684c64e4f",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pelletier/go-toml/v2",
+      "purl": "pkg:golang/github.com/pelletier/go-toml@v2.1.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v2.1.0?package-id=9ff575724d7a724d#v2",
+      "version": "v2.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=0a3a6cd8ca1aca01",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=33c84874f1b5210b",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/sftp",
+      "purl": "pkg:golang/github.com/pkg/sftp@v1.13.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/sftp@v1.13.6?package-id=eabbcc7d8c6984ad",
+      "version": "v1.13.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=1fa6692567cdbf27",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/power-devops/perfstat",
+      "purl": "pkg:golang/github.com/power-devops/perfstat@v0.0.0-20210106213030-5aafc221ea8c",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/power-devops/perfstat@v0.0.0-20210106213030-5aafc221ea8c?package-id=a6395e79ef6f1b71",
+      "version": "v0.0.0-20210106213030-5aafc221ea8c",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/proglottis/gpgme",
+      "purl": "pkg:golang/github.com/proglottis/gpgme@v0.1.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/proglottis/gpgme@v0.1.3?package-id=93ae51d378faf15e",
+      "version": "v0.1.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.4?package-id=cdf6fb578549fb21",
+      "version": "v0.4.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis="
+        }
+      ]
+    },
+    {
+      "name": "github.com/rootless-containers/rootlesskit",
+      "purl": "pkg:golang/github.com/rootless-containers/rootlesskit@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rootless-containers/rootlesskit@v1.1.1?package-id=ed77de7d3dc899c3",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:F5psKWoWY9/VjZ3ifVcaosjvFZJOagX85U22M0/EQZE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/russross/blackfriday/v2",
+      "purl": "pkg:golang/github.com/russross/blackfriday@v2.1.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/russross/blackfriday@v2.1.0?package-id=a77e788e63d883b2#v2",
+      "version": "v2.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "purl": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0?package-id=aabf28e49d8c2c67",
+      "version": "v0.10.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/secure-systems-lab/go-securesystemslib",
+      "purl": "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.7.0?package-id=9282f6c607a104c5",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/segmentio/ksuid",
+      "purl": "pkg:golang/github.com/segmentio/ksuid@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/segmentio/ksuid@v1.0.4?package-id=4e38f5d4abe52fee",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/shirou/gopsutil/v3",
+      "purl": "pkg:golang/github.com/shirou/gopsutil@v3.23.10#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/shirou/gopsutil@v3.23.10?package-id=2ab56a514628a22f#v3",
+      "version": "v3.23.10",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/N42opWlYzegYaVkWejXWJpbzKv2JDy3mrgGzKsh9hM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/shoenig/go-m1cpu",
+      "purl": "pkg:golang/github.com/shoenig/go-m1cpu@v0.1.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/shoenig/go-m1cpu@v0.1.6?package-id=0f39be61a8d01bb0",
+      "version": "v0.1.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/fulcio",
+      "purl": "pkg:golang/github.com/sigstore/fulcio@v1.4.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/fulcio@v1.4.3?package-id=a86953ca7170fc4f",
+      "version": "v1.4.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9JcUCZjjVhRF9fmhVuz6i1RyhCc/EGCD7MOl+iqCJLQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/rekor",
+      "purl": "pkg:golang/github.com/sigstore/rekor@v1.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/rekor@v1.2.2?package-id=0f5a2aa6a10e7aa0",
+      "version": "v1.2.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:5JK/zKZvcQpL/jBmHvmFj3YbpDMBQnJQ6ygp8xdF3bY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/sigstore",
+      "purl": "pkg:golang/github.com/sigstore/sigstore@v1.7.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/sigstore@v1.7.5?package-id=6e3f094699d393a2",
+      "version": "v1.7.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ij55dBhLwjICmLTBJZm7SqoQLdsu/oowDanACcJNs48="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1?package-id=87cdb22161c9af0b",
+      "version": "v1.8.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.2?package-id=b270a6ffdc08cf1d",
+      "version": "v1.9.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.3?package-id=53f9cbdf66773c00",
+      "version": "v1.9.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/skratchdot/open-golang",
+      "purl": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966?package-id=381940bf58561263",
+      "version": "v0.0.0-20200116055534-eef842397966",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.0?package-id=a0860300672ecf78",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=39c06474ebd4efb7",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stefanberger/go-pkcs11uri",
+      "purl": "pkg:golang/github.com/stefanberger/go-pkcs11uri@v0.0.0-20201008174630-78d3cae3a980",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stefanberger/go-pkcs11uri@v0.0.0-20201008174630-78d3cae3a980?package-id=839631b295cbc658",
+      "version": "v0.0.0-20201008174630-78d3cae3a980",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0?package-id=af7f5942d8b925ca",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.4?package-id=0fb761477437694b",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sylabs/sif/v2",
+      "purl": "pkg:golang/github.com/sylabs/sif@v2.15.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sylabs/sif@v2.15.0?package-id=f36fac4200cf3c5b#v2",
+      "version": "v2.15.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Nv0tzksFnoQiQ2eUwpAis9nVqEu4c3RcNSxX8P3Cecw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/syndtr/gocapability",
+      "purl": "pkg:golang/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437635",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437635?package-id=66185a54383ae5aa",
+      "version": "v0.0.0-20200815063812-42c35b437635",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tchap/go-patricia/v2",
+      "purl": "pkg:golang/github.com/tchap/go-patricia@v2.3.1#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tchap/go-patricia@v2.3.1?package-id=2adf2074e170fdc9#v2",
+      "version": "v2.3.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes="
+        }
+      ]
+    },
+    {
+      "name": "github.com/titanous/rocacheck",
+      "purl": "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399?package-id=7d4bf4f63a7946a0",
+      "version": "v0.0.0-20171023193734-afe73141d399",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tklauser/go-sysconf",
+      "purl": "pkg:golang/github.com/tklauser/go-sysconf@v0.3.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tklauser/go-sysconf@v0.3.12?package-id=3c5259b6aa406e71",
+      "version": "v0.3.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tklauser/numcpus",
+      "purl": "pkg:golang/github.com/tklauser/numcpus@v0.6.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tklauser/numcpus@v0.6.1?package-id=44281e1ffe97bad8",
+      "version": "v0.6.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/twitchyliquid64/golang-asm",
+      "purl": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1?package-id=d432df03855789c3",
+      "version": "v0.15.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "purl": "pkg:golang/github.com/u-root/uio@v0.0.0-20230305220412-3e8cd9d6bf63",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230305220412-3e8cd9d6bf63?package-id=e4a19ce7d7b1e6e4",
+      "version": "v0.0.0-20230305220412-3e8cd9d6bf63",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YcojQL98T/OO+rybuzn2+5KrD5dBwXIvYBvQ2cD3Avg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ugorji/go/codec",
+      "purl": "pkg:golang/github.com/ugorji/go@v1.2.11#codec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.2.11?package-id=c9cb6dcf9c79dc0e#codec",
+      "version": "v1.2.11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ulikunitz/xz",
+      "purl": "pkg:golang/github.com/ulikunitz/xz@v0.5.11",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ulikunitz/xz@v0.5.11?package-id=b1a8ca736444c227",
+      "version": "v0.5.11",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbatts/git-validation",
+      "purl": "pkg:golang/github.com/vbatts/git-validation@v1.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbatts/git-validation@v1.2.1?package-id=440ff590c93b898e",
+      "version": "v1.2.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:O26LKWEtBOfnxKT/SAiFCAcQglKwyuZEKSq6AevpWJ4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbatts/tar-split",
+      "purl": "pkg:golang/github.com/vbatts/tar-split@v0.11.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbatts/tar-split@v0.11.5?package-id=84820f43f22105ca",
+      "version": "v0.11.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbauerster/mpb/v8",
+      "purl": "pkg:golang/github.com/vbauerster/mpb@v8.6.2#v8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbauerster/mpb@v8.6.2?package-id=bc0ebef35f07f9bf#v8",
+      "version": "v8.6.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9EhnJGQRtvgDVCychJgR96EDCOqgg2NsMuk5JUcX4DA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210916161339-2c39f3491956",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210916161339-2c39f3491956?package-id=95cb519ea26ea490",
+      "version": "v1.1.1-0.20210916161339-2c39f3491956",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2tjYQpM+MZB25iPeE20lI/PrUNrbN66Bd+P27TkVaxU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "purl": "pkg:golang/github.com/vishvananda/netlink@v1.2.1-beta.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.2.1-beta.2?package-id=b6baf9fb07b2dda4",
+      "version": "v1.2.1-beta.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20200728191858-db3c7e526aae",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20200728191858-db3c7e526aae?package-id=94b20f1eeb8f0476",
+      "version": "v0.0.0-20200728191858-db3c7e526aae",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "purl": "pkg:golang/github.com/vishvananda/netns@v0.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.4?package-id=a7a991b8910e6c4a",
+      "version": "v0.0.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/yusufpapurcu/wmi",
+      "purl": "pkg:golang/github.com/yusufpapurcu/wmi@v1.2.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yusufpapurcu/wmi@v1.2.3?package-id=b01a7ad804f424bc",
+      "version": "v1.2.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw="
+        }
+      ]
+    },
+    {
+      "name": "go.etcd.io/bbolt",
+      "purl": "pkg:golang/go.etcd.io/bbolt@v1.3.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.etcd.io/bbolt@v1.3.8?package-id=8ddfc67c925bba46",
+      "version": "v1.3.8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA="
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.11.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.11.3?package-id=45ad1a2bf64e4856",
+      "version": "v1.11.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ql6K6qYHEzB6xvu4+AU0BoRoqf9vFPcc4o7MUIdPW8Y="
+        }
+      ]
+    },
+    {
+      "name": "go.mozilla.org/pkcs7",
+      "purl": "pkg:golang/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352?package-id=926dac54f2666643",
+      "version": "v0.0.0-20210826202110-33d05740a352",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak="
+        }
+      ]
+    },
+    {
+      "name": "go.opencensus.io",
+      "purl": "pkg:golang/go.opencensus.io@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opencensus.io@v0.24.0?package-id=e52c60f016939e73",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel",
+      "purl": "pkg:golang/go.opentelemetry.io/otel@v1.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel@v1.19.0?package-id=29308692149d68c9",
+      "version": "v1.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/metric",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/metric@v1.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/metric@v1.19.0?package-id=92c323559045ab0c",
+      "version": "v1.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aTzpGtV0ar9wlV4Sna9sdJyII5jTVJEvKETPiOKwvpE="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/trace",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/trace@v1.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/trace@v1.19.0?package-id=945382bc72d2bf58",
+      "version": "v1.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/arch",
+      "purl": "pkg:golang/golang.org/x/arch@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/arch@v0.5.0?package-id=5584feb5bbed2344",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jpGode6huXQxcskEIpOCvrU+tzo81b6+oFLUYXWtH/Y="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d?package-id=7f336093b19007a3",
+      "version": "v0.0.0-20231006140011-7918f672742d",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.14.0?package-id=50f03ea7a1559dcf",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "purl": "pkg:golang/golang.org/x/mod@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0?package-id=f4e4cd3a95899b98",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781?package-id=a18b635ecdd65e7f",
+      "version": "v0.0.0-20210428140749-89ef3d95e781",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.25.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.25.0?package-id=7a095c99b61b059e",
+      "version": "v0.25.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.14.0?package-id=2340b3d14d1de776",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:P0Vrf/2538nmC0H+pEQ3MNFRRnVR7RlqyVw+bvm26z0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "purl": "pkg:golang/golang.org/x/sync@v0.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=2e6466ee8cd262bf",
+      "version": "v0.11.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20191005200804-aed5e4c7ecf9",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191005200804-aed5e4c7ecf9?package-id=d0c04f85415ed4c2",
+      "version": "v0.0.0-20191005200804-aed5e4c7ecf9",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/fsnotify/fsnotify/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200217220822-9197077df867",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200217220822-9197077df867?package-id=74753c33555d2eee",
+      "version": "v0.0.0-20200217220822-9197077df867",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netns/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1?package-id=f3b0ba69ab1b2a59",
+      "version": "v0.0.0-20200728102440-3e129f6d46b1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210112080510-489259a85091",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210112080510-489259a85091?package-id=2cf4e9a79f89427a",
+      "version": "v0.0.0-20210112080510-489259a85091",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=a389301391b9d958",
+      "version": "v0.0.0-20220715151400-c0bba94af5f8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=6bffef882ecac407",
+      "version": "v0.0.0-20220715151400-c0bba94af5f8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.14.0?package-id=f25f45b44e71443e",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.30.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=e39ce661be9bf474",
+      "version": "v0.30.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.29.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=1815e1dab70318d7",
+      "version": "v0.29.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=a51b0b1ed0058137",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20201224043029-2b0845dc783e",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20201224043029-2b0845dc783e?package-id=ce137c87f0b04b31",
+      "version": "v0.0.0-20201224043029-2b0845dc783e",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.15.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.15.0?package-id=731cdf76d49ab47e",
+      "version": "v0.15.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "purl": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d?package-id=7f5f03ba9446ff06",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=f1a37ca4d5341a88",
+      "version": "v1.6.8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230920204549-e6e6cdab5c13#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230920204549-e6e6cdab5c13?package-id=d1ff76b06e918dd5#rpc",
+      "version": "v0.0.0-20230920204549-e6e6cdab5c13",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:N3bU/SQDCDyD6R528GJ/PwW9KjYcJA3dgyH+MovAkIM="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.58.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=0536ecf5c701b428",
+      "version": "v1.58.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BjnpXut1btbtgN/6sp+brB2Kbm2LjNXnidYujAVbSoQ="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=d5cf1e90e1d3a922",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/check.v1",
+      "purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405?package-id=6ec4f733e364ddb3",
+      "version": "v0.0.0-20161208181325-20d25e280405",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/gopkg.in/yaml.v2/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/go-jose/go-jose.v2",
+      "purl": "pkg:golang/gopkg.in/go-jose/go-jose.v2@v2.6.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/go-jose/go-jose.v2@v2.6.3?package-id=3d2ed6cd7015c40e",
+      "version": "v2.6.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=e888dc297812f467",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=7de6255c8f2da4b5",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=ef4f4519d54f2d19",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=95965a2b35c782b7",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=5f213a346a9e4eab",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=bd0fda54a493606a",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA="
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubernetes",
+      "purl": "pkg:golang/k8s.io/kubernetes@v1.28.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubernetes@v1.28.4?package-id=3e5804f8cb681af1",
+      "version": "v1.28.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aRNxs5jb8FVTtlnxeA4FSDBVKuFwA8Gw40/U2zReBYA="
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=52cb6c48c30f8a48",
+      "version": "v1.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E="
+        }
+      ]
+    },
+    {
+      "name": "tags.cncf.io/container-device-interface",
+      "purl": "pkg:golang/tags.cncf.io/container-device-interface@v0.6.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/tags.cncf.io/container-device-interface@v0.6.2?package-id=05eacda07687a438",
+      "version": "v0.6.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dThE6dtp/93ZDGhqaED2Pu374SOeUkBfuvkLuiTdwzg="
+        }
+      ]
+    },
+    {
+      "name": "tags.cncf.io/container-device-interface/specs-go",
+      "purl": "pkg:golang/tags.cncf.io/container-device-interface/specs-go@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/tags.cncf.io/container-device-interface/specs-go@v0.6.0?package-id=aebbffdf383737a2",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:V+tJJN6dqu8Vym6p+Ru+K5mJ49WL6Aoc5SJFSY0RLsQ="
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "817f70cf12039bab979522451f3e3b627da81113"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8aabac01b1d704facdf674de5c5b5232791397b6a6ff14e3caba9e2c35e613a4"
+        }
+      ],
+      "bom-ref": "432c2d15dd3c142f"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/fsnotify/fsnotify/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "192cf4294f401031b7ed28d203306d9792dae038"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0dab08a9d390fa423979b281c8a30adf6368579945519dffa568ebe6f754a036"
+        }
+      ],
+      "bom-ref": "6752475cd6b8aaa0"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5bb7e05c814cd82730484497c5d1872575b4ca51"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a65f8a958855bf707d326b76b72f9c428bd226304ab8cc317a67315333b4e4c7"
+        }
+      ],
+      "bom-ref": "d62a3347df49026c"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "1b32b90219e3f35f83b1e1e003d3f556665ce584"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "25631b029f86dc1d5bc8aeae5e0450955c05e4abfaa70df298e6cb1f7ac54097"
+        }
+      ],
+      "bom-ref": "b845a6ade1fe0acd"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "157e5ea3874ec4bc3f908e5382b5f1edf9170b9c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ce583e41b985b0b33a4eefbe143df21e426790af9a236f95dcc2cef82062b526"
+        }
+      ],
+      "bom-ref": "9b6813eff6b49da6"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "732b28d0f8e9a8d8dca779a5065f4168db323409"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "01e82122d547d1228151a623fe6cacc4d7a9cb318a0f668ce08bb6b67fdb28b1"
+        }
+      ],
+      "bom-ref": "9bce1f6d3d7d8556"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "25603d41572037f657c32e040cc425e631ff26e3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "90e0814cf704a1b6c701985cffe442e44bab8f3d5fa8907f482e72ba02882b64"
+        }
+      ],
+      "bom-ref": "a6f89bb2ae66096d"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netns/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5ed6f72680912c109b38acf9081ebdb1a43d8bcc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f4789a9fcf2e402616afc906fd239a92d46e4a6e00181cd3435f1c910aafe624"
+        }
+      ],
+      "bom-ref": "5d00cdf4c5e10ed9"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/gopkg.in/yaml.v2/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5f7e941d75c7a9a445fc81663a735596ae17460e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c3b11ba9a0775ff9bc6f11dbb58a1e48cc1e68bac378a8cdc620becc661d4c33"
+        }
+      ],
+      "bom-ref": "834e53e812a67542"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "e39d9ceaf16953c05c9bbe138a7429749dedb0e6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "89ceabd0db4b208279bcf6bb088765fcbde5f94d0937c36f9d3a550af01640ee"
+        }
+      ],
+      "bom-ref": "eb7c0eac2188ec99"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/test/tools/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "c2814de81048620f8adb3421883486d7f31e2147"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e67b6d847e7d1189e85d81b1255904a3bb4e317fa64cc0821b8ca8447b4f2e6c"
+        }
+      ],
+      "bom-ref": "4c9d75aae76411dd"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/rpmbuild/BUILD/containers-podman-0e11f82/vendor/go.opentelemetry.io/otel/requirements.txt",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "6692dd8eabe01587d803a3f64ebc7c46aba9ed95"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3d81238d468b6c2ecf6d758b343d72017496bc35ab6c758c63c0b3bb1c0978f5"
+        }
+      ],
+      "bom-ref": "b8a3106977fb6164"
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "purl": "pkg:golang/github.com/containers/dnsname#plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname?package-id=345dc21937ae33cd#plugins/meta/dnsname",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.21.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9",
+      "version": "go1.21.13",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/extracted_rpms/podman-plugins-4.9.4-18.el9_4.1.aarch64/usr/libexec/cni/dnsname",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "134ba987de3c6eb02315ae1ee78870e36aa242d1"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0d159754962aec71fe9d28222978c21f24d115ae4143efe26d5ae0c8e045f3ef"
+        }
+      ],
+      "bom-ref": "e16048dc26ffff58"
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=c2d7fdcce9b70570#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=8e5a393a8d7474e8#cmd/quadlet",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=b3e2f2d0c9ee8ada#cmd/rootlessport",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.21.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8",
+      "version": "go1.21.13",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.21.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1",
+      "version": "go1.21.13",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.21.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4",
+      "version": "go1.21.13",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/extracted_rpms/podman-4.9.4-18.el9_4.1.aarch64/usr/bin/podman",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "47416a31de3487e50e0c798538d0a86e02717a2a"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "9c3e32964da68c35c75b7fac1c1590ff5628356a074e60547d402311b6ee7f4d"
+        }
+      ],
+      "bom-ref": "3e7c38694c0bef3c"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/extracted_rpms/podman-4.9.4-18.el9_4.1.aarch64/usr/libexec/podman/quadlet",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "19a4aa4468bee01acbfbf2a8b28a451b69bf1706"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c7761f348cef09ad1bbf34c3630d5147677216ce122ba714ec83adae2e9fd3a0"
+        }
+      ],
+      "bom-ref": "722eebec347dccfd"
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/extracted_rpms/podman-4.9.4-18.el9_4.1.aarch64/usr/libexec/podman/rootlessport",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "b4d4219719ae4312c477ebfc9196c757ecc95f68"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "50d9b4a1432d521dc5eff58e27492df2be676b0d1d594c009b4653c01fd1fbd6"
+        }
+      ],
+      "bom-ref": "d9b53bd6ae5a52f9"
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=e4a4aae340f8f608#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.21.13",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1",
+      "version": "go1.21.13",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-uth6dyvz/extracted_rpms/podman-remote-4.9.4-18.el9_4.1.aarch64/usr/bin/podman-remote",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "9eca6b8d243eb8aa5014a0d25111128b1ad80542"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "d0db4a85571c045f977167565f16992c0728e15e2be507cf7b42293fcf136606"
+        }
+      ],
+      "bom-ref": "621841594022a85c"
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=d4d26afe0b2e05ca#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "purl": "pkg:golang/github.com/containers/dnsname#plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname?package-id=68dd4450ddbb3655#plugins/meta/dnsname",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=a386ab4cfc920da4#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=f7f3969a537e5ad1#cmd/quadlet",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=35af3fc1e0157a15#cmd/rootlessport",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "purl": "pkg:golang/github.com/containers/dnsname#plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname?package-id=732451684778dfe1#plugins/meta/dnsname",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=4603e11095b8d608#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=16e7bab90e84a202#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=6f71862d336e3d3f#cmd/quadlet",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=d35038adf71d8c4e#cmd/rootlessport",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=f9a1e8cc6d77d049#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=cc1ec28bda975610#cmd/quadlet",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=e5cbae1234ef3897#cmd/rootlessport",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "purl": "pkg:golang/github.com/containers/podman#cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman?package-id=906efcb71fc6b771#cmd/podman",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "purl": "pkg:golang/github.com/containers/dnsname#plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname?package-id=323d3623fd7c2ddf#plugins/meta/dnsname",
+      "version": "UNKNOWN",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4.1?arch=noarch",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=aarch64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4.1?arch=s390x",
+        "pkg:pypi/codespell@2.2.5?package-id=93ce0b8f87334918",
+        "pkg:golang/dario.cat/mergo@v1.0.0?package-id=830889683f785245",
+        "pkg:golang/github.com/azure/go-ansiterm@v0.0.0-20230124172434-306776ec8161?package-id=e9e7e6d880b91c47",
+        "pkg:golang/github.com/burntsushi/toml@v1.3.2?package-id=1b8d14c0892e99f2",
+        "pkg:golang/github.com/microsoft/go-winio@v0.6.1?package-id=40cf52cbbf85a689",
+        "pkg:golang/github.com/microsoft/hcsshim@v0.12.0-rc.1?package-id=70ca0709aa342b6a",
+        "pkg:golang/github.com/vividcortex/ewma@v1.2.0?package-id=ce702c42537131b2",
+        "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d?package-id=29b6356e75990362",
+        "pkg:golang/github.com/aead/serpent@v0.0.0-20160714141033-fba169763ea6?package-id=c306d9cc564ad003",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2?package-id=6b61f83a371c983b",
+        "pkg:golang/github.com/blang/semver@v4.0.0?package-id=7ff5e24b84ae2c11#v4",
+        "pkg:golang/github.com/buger/goterm@v1.0.4?package-id=893020272c15f641",
+        "pkg:golang/github.com/bytedance/sonic@v1.10.1?package-id=691d0a16f158d1de",
+        "pkg:golang/github.com/checkpoint-restore/checkpointctl@v1.1.0?package-id=55c3fdc2e21f8fa0",
+        "pkg:golang/github.com/checkpoint-restore/go-criu@v7.0.0?package-id=23ca41634978b1d3#v7",
+        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20230717121745-296ad89f973d?package-id=37dd41ecf04410eb",
+        "pkg:golang/github.com/chenzhuoyu/iasm@v0.9.0?package-id=b1b6e5af6d27d8c2",
+        "pkg:golang/github.com/chzyer/readline@v1.5.1?package-id=6a6f66fab4da81eb",
+        "pkg:golang/github.com/cilium/ebpf@v0.9.1?package-id=5d1704ccdfbb59aa",
+        "pkg:golang/github.com/containerd/cgroups@v3.0.2?package-id=4207eaf6f39904b6#v3",
+        "pkg:golang/github.com/containerd/containerd@v1.7.9?package-id=f8585ffcfc78ce2e",
+        "pkg:golang/github.com/containerd/log@v0.1.0?package-id=d50543144aae839f",
+        "pkg:golang/github.com/containerd/stargz-snapshotter@v0.15.1?package-id=390abc45fd64da96#estargz",
+        "pkg:golang/github.com/containerd/typeurl@v2.1.1?package-id=49bb413ecf1b1c35#v2",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=fd98f7f80806420c",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=e47a64cfd5d94175",
+        "pkg:golang/github.com/containernetworking/plugins@v0.9.1?package-id=32f511297d78f16c",
+        "pkg:golang/github.com/containernetworking/plugins@v1.3.0?package-id=1ec97afad4827d0b",
+        "pkg:golang/github.com/containers/buildah@v1.33.12?package-id=c0d3b0102aaf1707",
+        "pkg:golang/github.com/containers/common@v0.57.7?package-id=c25ac5fa7b116b52",
+        "pkg:golang/github.com/containers/conmon@v2.0.20%2Bincompatible?package-id=7386cf9fa7f28aa8",
+        "pkg:golang/github.com/containers/gvisor-tap-vsock@v0.7.2?package-id=64013dd1a44951f6",
+        "pkg:golang/github.com/containers/image@v5.29.5?package-id=b3a9f470a6979dc4#v5",
+        "pkg:golang/github.com/containers/libhvee@v0.5.0?package-id=c4d28ec3437ffad9",
+        "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01?package-id=3487a0ced8b96924",
+        "pkg:golang/github.com/containers/luksy@v0.0.0-20231030195837-b5a7f79da98b?package-id=5186102f5ee8ef20",
+        "pkg:golang/github.com/containers/ocicrypt@v1.1.10?package-id=83339bccba164f22",
+        "pkg:golang/github.com/containers/psgo@v1.8.0?package-id=dbb812350f8094e0",
+        "pkg:golang/github.com/containers/storage@v1.51.2?package-id=c94c9f0a8fd1d8a0",
+        "pkg:golang/github.com/coreos/go-iptables@v0.6.0?package-id=5d0cb7eaa4a0821f",
+        "pkg:golang/github.com/coreos/go-oidc@v3.7.0?package-id=74f403c5d44d527d#v3",
+        "pkg:golang/github.com/coreos/go-systemd@v0.0.0-20190719114852-fd7a80b32e1f?package-id=768cb510c1564622",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.1-0.20231103132048-7d375ecc2b09?package-id=da2557227db91ac4#v22",
+        "pkg:golang/github.com/coreos/stream-metadata-go@v0.4.4?package-id=d1972eabd953914a",
+        "pkg:golang/github.com/cpuguy83/go-md2man@v2.0.3?package-id=4fc3928126aefd1a#v2",
+        "pkg:golang/github.com/crc-org/vfkit@v0.1.2-0.20231030102423-f3c783d34420?package-id=9a4f86040fd4c9bf",
+        "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20231011164504-785e29786b46?package-id=2754f6d742c1aaea",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=1d9a4060dc7f58d7",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=877523c75d46a3c2",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=5bed9601b6633eee",
+        "pkg:golang/github.com/digitalocean/go-libvirt@v0.0.0-20220804181439-8648fbde413e?package-id=13c1189cf8b54f71",
+        "pkg:golang/github.com/digitalocean/go-qemu@v0.0.0-20230711162256-2e3d0186973e?package-id=f99622502510a79a",
+        "pkg:golang/github.com/disiqueira/gotree@v3.0.2?package-id=ba601b632df342f6#v3",
+        "pkg:golang/github.com/distribution/reference@v0.5.0?package-id=4dba30d4daf39b34",
+        "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible?package-id=e752a6d5b6994595",
+        "pkg:golang/github.com/docker/docker@v24.0.7%2Bincompatible?package-id=45390c3a7cd66a04",
+        "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.0?package-id=9b36de361d1590fc",
+        "pkg:golang/github.com/docker/go-connections@v0.4.1-0.20231031175723-0b8c1f4e07a0?package-id=82021f28ac416c95",
+        "pkg:golang/github.com/docker/go-plugins-helpers@v0.0.0-20211224144127-6eecb7beb651?package-id=dac3e4f2d2513c93",
+        "pkg:golang/github.com/docker/go-units@v0.5.0?package-id=3a5ed86f41f0acf4",
+        "pkg:golang/github.com/fatih/color@v1.15.0?package-id=f455521699a81e89",
+        "pkg:golang/github.com/felixge/httpsnoop@v1.0.3?package-id=55d70b09906d903f",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.9?package-id=43c300e9aa729c9d",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=c74c579f441264d1",
+        "pkg:golang/github.com/fsouza/go-dockerclient@v1.10.0?package-id=79aedfb86dbe69e6",
+        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2?package-id=18edcc57ea86b0de",
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0?package-id=5b738c5758770efd",
+        "pkg:golang/github.com/gin-gonic/gin@v1.9.1?package-id=09345e895a858a3c",
+        "pkg:golang/github.com/go-jose/go-jose@v3.0.3?package-id=4b5a858815161aed#v3",
+        "pkg:golang/github.com/go-logr/logr@v1.3.0?package-id=a7ea5bc58bf08192",
+        "pkg:golang/github.com/go-logr/stdr@v1.2.2?package-id=933384e7ba49cf7f",
+        "pkg:golang/github.com/go-ole/go-ole@v1.2.6?package-id=70bf04f6f041e52d",
+        "pkg:golang/github.com/go-openapi/analysis@v0.21.4?package-id=9ea8b9ad52030bed",
+        "pkg:golang/github.com/go-openapi/errors@v0.20.4?package-id=f1e2ed6ce77fd9ee",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6?package-id=7a11fcfebcb03b98",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=fea23081cb20edbf",
+        "pkg:golang/github.com/go-openapi/loads@v0.21.2?package-id=4614ac5fd7096390",
+        "pkg:golang/github.com/go-openapi/runtime@v0.26.0?package-id=6fe90c32a6b86cc4",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.9?package-id=928d01ff17d2a67b",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.21.7?package-id=a29e2d3c0ff70597",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=725453dbb9b24889",
+        "pkg:golang/github.com/go-openapi/validate@v0.22.1?package-id=4016181974a83f6a",
+        "pkg:golang/github.com/go-playground/locales@v0.14.1?package-id=5fc0f23885fecc3e",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1?package-id=44e9ee23b30396bc",
+        "pkg:golang/github.com/go-playground/validator@v10.15.5?package-id=6f779696625a0d1c#v10",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0?package-id=5dec6809fb961051",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=7723f23509f6e9c9",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=6ed8f14e2691b0ae",
+        "pkg:golang/github.com/goccy/go-json@v0.10.2?package-id=9b95f38549dbb2e7",
+        "pkg:golang/github.com/godbus/dbus@v5.1.1-0.20230522191255-76236955d466?package-id=b7c3e9fcaadfacd7#v5",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=3858e45e43a13e41",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=9fc12d1b7d0549a3",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2?package-id=580312068be9bbdf",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3?package-id=24106bbd02602711",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=4e7acfd6c9128ec8",
+        "pkg:golang/github.com/google/go-containerregistry@v0.16.1?package-id=257e85f612c158db",
+        "pkg:golang/github.com/google/go-intervals@v0.0.2?package-id=8882646581544332",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=555a0046e0839547",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38?package-id=71958bcc23037ded",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20230323073829-e72429f035bd?package-id=0c815505247e335f",
+        "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510?package-id=ab20454707c0ef00",
+        "pkg:golang/github.com/google/uuid@v1.4.0?package-id=fa5cb10169d3b9ca",
+        "pkg:golang/github.com/gorilla/handlers@v1.5.2?package-id=7e5de02f3835a81a",
+        "pkg:golang/github.com/gorilla/mux@v1.8.1?package-id=8205ef61f87399be",
+        "pkg:golang/github.com/gorilla/schema@v1.4.1?package-id=52af4c633255d773",
+        "pkg:golang/github.com/hashicorp/errwrap@v1.1.0?package-id=a8a79647a7a8cf70",
+        "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2?package-id=e1ee33c1617e1009",
+        "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1?package-id=5671cb08a298ac36",
+        "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.7?package-id=28dd885c1b4dbb0e",
+        "pkg:golang/github.com/hashicorp/go-version@v1.3.0?package-id=0a0118ecc74d7c35",
+        "pkg:golang/github.com/hugelgupf/p9@v0.3.1-0.20230822151754-54f5c5530921?package-id=2ffe99043a09760b",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=dc1badc47df18f09",
+        "pkg:golang/github.com/jinzhu/copier@v0.4.0?package-id=a1b1e1aa033edb92",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=ac618cfcc28857e7",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=9a09e60e64762fb5",
+        "pkg:golang/github.com/klauspost/compress@v1.17.3?package-id=1ffa33b600e6ddfd",
+        "pkg:golang/github.com/klauspost/cpuid@v2.2.5?package-id=e41a09d00e6a6abe#v2",
+        "pkg:golang/github.com/klauspost/pgzip@v1.2.6?package-id=07e01f5838373cd6",
+        "pkg:golang/github.com/kr/fs@v0.1.0?package-id=398ff89cd63d2228",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.4?package-id=5281368296cb5ab9",
+        "pkg:golang/github.com/letsencrypt/boulder@v0.0.0-20230213213521-fdfea0d469b6?package-id=258bb3371e4d4027",
+        "pkg:golang/github.com/linuxkit/virtsock@v0.0.0-20220523201153-1a23e78aa7a2?package-id=d3cf194c0733b47d",
+        "pkg:golang/github.com/lufia/plan9stats@v0.0.0-20211012122336-39d0f177ccd0?package-id=8209420d49ba0096",
+        "pkg:golang/github.com/magefile/mage@v1.14.0?package-id=a74f649988594bbd",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=8e46bb3723393ca3",
+        "pkg:golang/github.com/manifoldco/promptui@v0.9.0?package-id=7bac44b824f7aa5e",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13?package-id=55b67c1594f55f24",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17?package-id=117a3f38e559e9ed",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.20?package-id=b981519f33f50dbc",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.15?package-id=0b6d7d3f1eeeeae4",
+        "pkg:golang/github.com/mattn/go-shellwords@v1.0.12?package-id=83450e3a15e0f99d",
+        "pkg:golang/github.com/mattn/go-sqlite3@v1.14.18?package-id=f5d05835504f4ffd",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=f56f68404baa5b58",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=2aee1d4c12209cb8",
+        "pkg:golang/github.com/miekg/pkcs11@v1.1.1?package-id=fef9e5fb9971283d",
+        "pkg:golang/github.com/mistifyio/go-zfs@v3.0.1?package-id=2216e1fe48e790da#v3",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0?package-id=7981989d0762c97e",
+        "pkg:golang/github.com/moby/buildkit@v0.12.5?package-id=7b5f00776e604492",
+        "pkg:golang/github.com/moby/patternmatcher@v0.6.0?package-id=64fc68737d4c9f77",
+        "pkg:golang/github.com/moby/sys@v0.7.1?package-id=057e295fbec4aa26#mountinfo",
+        "pkg:golang/github.com/moby/sys@v0.5.0?package-id=ab4a193d344a7505#sequential",
+        "pkg:golang/github.com/moby/term@v0.5.0?package-id=249cb807e979f08f",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=909dd10ba0ae8d1c",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e5c6f4996c77bb75",
+        "pkg:golang/github.com/morikuni/aec@v1.0.0?package-id=a30048d529e8332e",
+        "pkg:golang/github.com/nxadm/tail@v1.4.11?package-id=e64a2938860b6dd5",
+        "pkg:golang/github.com/nxadm/tail@v1.4.8?package-id=47dcfdbf536f7c63",
+        "pkg:golang/github.com/oklog/ulid@v1.3.1?package-id=14bd4a60fcd4657e",
+        "pkg:golang/github.com/onsi/ginkgo@v1.16.4?package-id=24c75128dfa61e89",
+        "pkg:golang/github.com/onsi/ginkgo@v1.16.5?package-id=ea9cf0407d9a2eca",
+        "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=49dac0fbe8817737#v2",
+        "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=fc37f0a9e4bf5451#v2",
+        "pkg:golang/github.com/onsi/gomega@v1.10.1?package-id=3b42020f9d5a81e3",
+        "pkg:golang/github.com/onsi/gomega@v1.17.0?package-id=5f42984101810003",
+        "pkg:golang/github.com/onsi/gomega@v1.30.0?package-id=41d0dd66a95fa5b6",
+        "pkg:golang/github.com/opencontainers/go-digest@v1.0.0?package-id=5ed4b0a493e74727",
+        "pkg:golang/github.com/opencontainers/image-spec@v1.1.0-rc5?package-id=de9ca21aabe7af43",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.10?package-id=64a86695e9014382",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.1.1-0.20230922153023-c0e90434df2a?package-id=aa338f0fb7818fba",
+        "pkg:golang/github.com/opencontainers/runtime-tools@v0.9.1-0.20230914150019-408c51e934dc?package-id=7906f8e792e1cc23",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=a7a0602fcd6bf785",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581?package-id=6996b532d4a8353f",
+        "pkg:golang/github.com/openshift/imagebuilder@v1.2.6-0.20231110114814-35a50d57f722?package-id=bf8de9a16e63655a",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.2.0?package-id=efecea730dd143c9",
+        "pkg:golang/github.com/ostreedev/ostree-go@v0.0.0-20210805093236-719684c64e4f?package-id=1ba798c98082554e",
+        "pkg:golang/github.com/pelletier/go-toml@v2.1.0?package-id=9ff575724d7a724d#v2",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=0a3a6cd8ca1aca01",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=33c84874f1b5210b",
+        "pkg:golang/github.com/pkg/sftp@v1.13.6?package-id=eabbcc7d8c6984ad",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=1fa6692567cdbf27",
+        "pkg:golang/github.com/power-devops/perfstat@v0.0.0-20210106213030-5aafc221ea8c?package-id=a6395e79ef6f1b71",
+        "pkg:golang/github.com/proglottis/gpgme@v0.1.3?package-id=93ae51d378faf15e",
+        "pkg:golang/github.com/rivo/uniseg@v0.4.4?package-id=cdf6fb578549fb21",
+        "pkg:golang/github.com/rootless-containers/rootlesskit@v1.1.1?package-id=ed77de7d3dc899c3",
+        "pkg:golang/github.com/russross/blackfriday@v2.1.0?package-id=a77e788e63d883b2#v2",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0?package-id=aabf28e49d8c2c67",
+        "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.7.0?package-id=9282f6c607a104c5",
+        "pkg:golang/github.com/segmentio/ksuid@v1.0.4?package-id=4e38f5d4abe52fee",
+        "pkg:golang/github.com/shirou/gopsutil@v3.23.10?package-id=2ab56a514628a22f#v3",
+        "pkg:golang/github.com/shoenig/go-m1cpu@v0.1.6?package-id=0f39be61a8d01bb0",
+        "pkg:golang/github.com/sigstore/fulcio@v1.4.3?package-id=a86953ca7170fc4f",
+        "pkg:golang/github.com/sigstore/rekor@v1.2.2?package-id=0f5a2aa6a10e7aa0",
+        "pkg:golang/github.com/sigstore/sigstore@v1.7.5?package-id=6e3f094699d393a2",
+        "pkg:golang/github.com/sirupsen/logrus@v1.8.1?package-id=87cdb22161c9af0b",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.2?package-id=b270a6ffdc08cf1d",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.3?package-id=53f9cbdf66773c00",
+        "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966?package-id=381940bf58561263",
+        "pkg:golang/github.com/spf13/cobra@v1.8.0?package-id=a0860300672ecf78",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=39c06474ebd4efb7",
+        "pkg:golang/github.com/stefanberger/go-pkcs11uri@v0.0.0-20201008174630-78d3cae3a980?package-id=839631b295cbc658",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0?package-id=af7f5942d8b925ca",
+        "pkg:golang/github.com/stretchr/testify@v1.8.4?package-id=0fb761477437694b",
+        "pkg:golang/github.com/sylabs/sif@v2.15.0?package-id=f36fac4200cf3c5b#v2",
+        "pkg:golang/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437635?package-id=66185a54383ae5aa",
+        "pkg:golang/github.com/tchap/go-patricia@v2.3.1?package-id=2adf2074e170fdc9#v2",
+        "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399?package-id=7d4bf4f63a7946a0",
+        "pkg:golang/github.com/tklauser/go-sysconf@v0.3.12?package-id=3c5259b6aa406e71",
+        "pkg:golang/github.com/tklauser/numcpus@v0.6.1?package-id=44281e1ffe97bad8",
+        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1?package-id=d432df03855789c3",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230305220412-3e8cd9d6bf63?package-id=e4a19ce7d7b1e6e4",
+        "pkg:golang/github.com/ugorji/go@v1.2.11?package-id=c9cb6dcf9c79dc0e#codec",
+        "pkg:golang/github.com/ulikunitz/xz@v0.5.11?package-id=b1a8ca736444c227",
+        "pkg:golang/github.com/vbatts/git-validation@v1.2.1?package-id=440ff590c93b898e",
+        "pkg:golang/github.com/vbatts/tar-split@v0.11.5?package-id=84820f43f22105ca",
+        "pkg:golang/github.com/vbauerster/mpb@v8.6.2?package-id=bc0ebef35f07f9bf#v8",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210916161339-2c39f3491956?package-id=95cb519ea26ea490",
+        "pkg:golang/github.com/vishvananda/netlink@v1.2.1-beta.2?package-id=b6baf9fb07b2dda4",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20200728191858-db3c7e526aae?package-id=94b20f1eeb8f0476",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.4?package-id=a7a991b8910e6c4a",
+        "pkg:golang/github.com/yusufpapurcu/wmi@v1.2.3?package-id=b01a7ad804f424bc",
+        "pkg:golang/go.etcd.io/bbolt@v1.3.8?package-id=8ddfc67c925bba46",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.11.3?package-id=45ad1a2bf64e4856",
+        "pkg:golang/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352?package-id=926dac54f2666643",
+        "pkg:golang/go.opencensus.io@v0.24.0?package-id=e52c60f016939e73",
+        "pkg:golang/go.opentelemetry.io/otel@v1.19.0?package-id=29308692149d68c9",
+        "pkg:golang/go.opentelemetry.io/otel/metric@v1.19.0?package-id=92c323559045ab0c",
+        "pkg:golang/go.opentelemetry.io/otel/trace@v1.19.0?package-id=945382bc72d2bf58",
+        "pkg:golang/golang.org/x/arch@v0.5.0?package-id=5584feb5bbed2344",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d?package-id=7f336093b19007a3",
+        "pkg:golang/golang.org/x/mod@v0.14.0?package-id=50f03ea7a1559dcf",
+        "pkg:golang/golang.org/x/mod@v0.17.0?package-id=f4e4cd3a95899b98",
+        "pkg:golang/golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781?package-id=a18b635ecdd65e7f",
+        "pkg:golang/golang.org/x/net@v0.25.0?package-id=7a095c99b61b059e",
+        "pkg:golang/golang.org/x/oauth2@v0.14.0?package-id=2340b3d14d1de776",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=2e6466ee8cd262bf",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20191005200804-aed5e4c7ecf9?package-id=d0c04f85415ed4c2",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200217220822-9197077df867?package-id=74753c33555d2eee",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1?package-id=f3b0ba69ab1b2a59",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210112080510-489259a85091?package-id=2cf4e9a79f89427a",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=a389301391b9d958",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=6bffef882ecac407",
+        "pkg:golang/golang.org/x/sys@v0.14.0?package-id=f25f45b44e71443e",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=e39ce661be9bf474",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=1815e1dab70318d7",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=a51b0b1ed0058137",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20201224043029-2b0845dc783e?package-id=ce137c87f0b04b31",
+        "pkg:golang/golang.org/x/tools@v0.15.0?package-id=731cdf76d49ab47e",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d?package-id=7f5f03ba9446ff06",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=f1a37ca4d5341a88",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230920204549-e6e6cdab5c13?package-id=d1ff76b06e918dd5#rpc",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=0536ecf5c701b428",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=d5cf1e90e1d3a922",
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405?package-id=6ec4f733e364ddb3",
+        "pkg:golang/gopkg.in/go-jose/go-jose.v2@v2.6.3?package-id=3d2ed6cd7015c40e",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=e888dc297812f467",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=7de6255c8f2da4b5",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=ef4f4519d54f2d19",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=95965a2b35c782b7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=5f213a346a9e4eab",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=bd0fda54a493606a",
+        "pkg:golang/k8s.io/kubernetes@v1.28.4?package-id=3e5804f8cb681af1",
+        "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=52cb6c48c30f8a48",
+        "pkg:golang/tags.cncf.io/container-device-interface@v0.6.2?package-id=05eacda07687a438",
+        "pkg:golang/tags.cncf.io/container-device-interface/specs-go@v0.6.0?package-id=aebbffdf383737a2",
+        "432c2d15dd3c142f",
+        "6752475cd6b8aaa0",
+        "d62a3347df49026c",
+        "b845a6ade1fe0acd",
+        "9b6813eff6b49da6",
+        "9bce1f6d3d7d8556",
+        "a6f89bb2ae66096d",
+        "5d00cdf4c5e10ed9",
+        "834e53e812a67542",
+        "eb7c0eac2188ec99",
+        "4c9d75aae76411dd",
+        "b8a3106977fb6164"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=aarch64",
+      "provides": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9",
+        "e16048dc26ffff58",
+        "pkg:golang/github.com/containers/dnsname?package-id=345dc21937ae33cd#plugins/meta/dnsname"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname?package-id=345dc21937ae33cd#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=aarch64",
+      "provides": [
+        "d9b53bd6ae5a52f9",
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8",
+        "pkg:golang/github.com/containers/podman?package-id=c2d7fdcce9b70570#cmd/podman",
+        "pkg:golang/github.com/containers/podman?package-id=8e5a393a8d7474e8#cmd/quadlet",
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1",
+        "pkg:golang/github.com/containers/podman?package-id=b3e2f2d0c9ee8ada#cmd/rootlessport",
+        "722eebec347dccfd",
+        "3e7c38694c0bef3c",
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=8e5a393a8d7474e8#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=b3e2f2d0c9ee8ada#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=c2d7fdcce9b70570#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=aarch64",
+      "provides": [
+        "621841594022a85c",
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1",
+        "pkg:golang/github.com/containers/podman?package-id=e4a4aae340f8f608#cmd/podman"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=e4a4aae340f8f608#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=ppc64le",
+      "provides": [
+        "pkg:golang/github.com/containers/podman?package-id=d4d26afe0b2e05ca#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=d4d26afe0b2e05ca#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=ppc64le",
+      "provides": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9",
+        "pkg:golang/github.com/containers/dnsname?package-id=68dd4450ddbb3655#plugins/meta/dnsname",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname?package-id=68dd4450ddbb3655#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=ppc64le",
+      "provides": [
+        "d9b53bd6ae5a52f9",
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8",
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1",
+        "pkg:golang/github.com/containers/podman?package-id=f7f3969a537e5ad1#cmd/quadlet",
+        "pkg:golang/github.com/containers/podman?package-id=a386ab4cfc920da4#cmd/podman",
+        "pkg:golang/github.com/containers/podman?package-id=35af3fc1e0157a15#cmd/rootlessport",
+        "722eebec347dccfd",
+        "3e7c38694c0bef3c",
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=35af3fc1e0157a15#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=a386ab4cfc920da4#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=f7f3969a537e5ad1#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=x86_64",
+      "provides": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9",
+        "pkg:golang/github.com/containers/dnsname?package-id=732451684778dfe1#plugins/meta/dnsname",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname?package-id=732451684778dfe1#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=x86_64",
+      "provides": [
+        "pkg:golang/github.com/containers/podman?package-id=4603e11095b8d608#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=4603e11095b8d608#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=x86_64",
+      "provides": [
+        "d9b53bd6ae5a52f9",
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8",
+        "pkg:golang/github.com/containers/podman?package-id=16e7bab90e84a202#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1",
+        "3e7c38694c0bef3c",
+        "pkg:golang/github.com/containers/podman?package-id=d35038adf71d8c4e#cmd/rootlessport",
+        "722eebec347dccfd",
+        "pkg:golang/github.com/containers/podman?package-id=6f71862d336e3d3f#cmd/quadlet",
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=16e7bab90e84a202#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=6f71862d336e3d3f#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=d35038adf71d8c4e#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=s390x",
+      "provides": [
+        "d9b53bd6ae5a52f9",
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8",
+        "pkg:golang/github.com/containers/podman?package-id=f9a1e8cc6d77d049#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1",
+        "pkg:golang/github.com/containers/podman?package-id=e5cbae1234ef3897#cmd/rootlessport",
+        "pkg:golang/github.com/containers/podman?package-id=cc1ec28bda975610#cmd/quadlet",
+        "722eebec347dccfd",
+        "3e7c38694c0bef3c",
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=cc1ec28bda975610#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=070c3cb3bf1a35d1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=e5cbae1234ef3897#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=daa097ef83970ec4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=f9a1e8cc6d77d049#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=37f52e8498364ab8"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4.1?arch=s390x",
+      "provides": [
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1",
+        "pkg:golang/github.com/containers/podman?package-id=906efcb71fc6b771#cmd/podman",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman?package-id=906efcb71fc6b771#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=e1d16bc9da9e49d1"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4.1?arch=s390x",
+      "provides": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9",
+        "pkg:golang/github.com/containers/dnsname?package-id=323d3623fd7c2ddf#plugins/meta/dnsname",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname?package-id=323d3623fd7c2ddf#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=f3a44b75403239b9"
+      ]
+    }
+  ],
+  "serialNumber": "urn:uuid:bc963eda-3384-4bfe-9763-3a85452ea41e"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/CE8E7B92C4BD452.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2606/CE8E7B92C4BD452.json
@@ -1,0 +1,8727 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "rpm-manifest-generator",
+          "type": "application",
+          "version": "0.0.1",
+          "manufacturer": {
+            "url": [
+              "https://www.redhat.com"
+            ],
+            "name": "Red Hat"
+          }
+        }
+      ]
+    },
+    "licenses": [
+      {
+        "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+      }
+    ],
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f9a22f77a60d00d59df5749420b5631788e0916b02abb9207d9764aed3ea51e"
+        }
+      ],
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9598e379d67c69be6d1f6a9c62c41ed2"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8e8d60d2fd5baffb06a5a236c554eab7f27aea2d788aa7f8feb1664321fbf25f"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    "timestamp": "2025-03-25T13:36:37Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "147407"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3f9a22f77a60d00d59df5749420b5631788e0916b02abb9207d9764aed3ea51e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "name": "dnsname",
+            "purl": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef",
+            "type": "library",
+            "hashes": [
+              {
+                "alg": "SHA-512",
+                "content": "2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef"
+              }
+            ],
+            "bom-ref": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef",
+            "version": "bdc4ab8",
+            "evidence": {
+              "identity": [
+                {
+                  "field": "purl",
+                  "concludedValue": "pkg:generic/dnsname@bdc4ab8?download_url=https://pkgs.devel.redhat.com/repo/podman/dnsname-bdc4ab8.tar.gz/sha512/2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef/dnsname-bdc4ab8.tar.gz&checksum=SHA-512:2c7f4463b439d143c1cc1194b45bbd18e220bd03aa2c466cd81a14d043b753d69d84d331518cca3fab9b75ad5467b73f640f7d8ddce3eee05a5f5507d6f20cef"
+                }
+              ]
+            },
+            "pedigree": {
+              "ancestors": [
+                {
+                  "name": "dnsname",
+                  "purl": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c",
+                  "type": "library",
+                  "hashes": [
+                    {
+                      "alg": "SHA-256",
+                      "content": "7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c"
+                    }
+                  ],
+                  "bom-ref": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c",
+                  "version": "bdc4ab8",
+                  "evidence": {
+                    "identity": [
+                      {
+                        "field": "purl",
+                        "concludedValue": "pkg:generic/dnsname@bdc4ab8?download_url=https://github.com/containers/dnsname/archive/bdc4ab85266ade865a7c398336e98721e62ef6b2/dnsname-bdc4ab8.tar.gz&checksum=SHA-256:7d7f4580e53101860636842f9e1804ff846fe00f391063ff81546e76e93fc58c"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9598e379d67c69be6d1f6a9c62c41ed2"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8e8d60d2fd5baffb06a5a236c554eab7f27aea2d788aa7f8feb1664321fbf25f"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images",
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3567926",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        }
+      ]
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2c5f40631da93aa8287ec93dab9ad77fe3d26e1a40bc782dd934729f64ae5c51"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "6011e0c2d0aff4416b8da37bf077594f"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ff64f448fb0a9a9b264ab7bd6d4f43465ce5977c3788ad43b4c68c423ef69385"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4a3debaedfefc8c0b29ee9ed6c73d91983ab965dca2aaf1197c5ad99de7ce410"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "531424e1fa792b706b5d6d28611d41db"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "0e196daa4ede5c18535e2fe59705deb0894eb827f8fb8c10efc2fdb1ac0ec3b6"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "734b5576349dc5bdf722b7d7088833718bdc69c27ad20f1d9f09acff5e28030e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "efe61d480295ee0680e8a39908a745f5"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2b1ea2e43518ee9f03624323e8e70b0dba051f6967a23e7b1b17ed8231271fe4"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "487abd32ae3e056783d22b7f8e6341a24d64420ca2095b935060ba91697132ba"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b64c6bb084c31d479b8f64dbdba77faf"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "73182eff54cb2950a8e9823fcc93cd8fdb307f54dc0ca0d85b611e28a0f4f7f6"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f5be9d0bacca14cb75a2f6ead70c82c9748e0bfb8df0c829af60bd30e9d012ef"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "c836a417bea4c1915ce6427ecc0359fa"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "033f285e011ef5bb279b962c97ca9246c25aa57ca9543eb36cf0e892b59bfc42"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c386acbe51e3431837f4503510c066e47edd05305f67c1739ed3e833b90ca3ff"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "93896b7557a18e0f09bd17b2cf457947"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "e496efb9714ff32b8979a288b712adacfe7a06eed1abbc5b5c10e2961cac1b45"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-docker",
+      "purl": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a2e18c978e47eeb1c78e0d53292034c419c51c1fe3fe0b44943a7c01a46c2afe"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "036f9d28add89d917c486c7c084bb639"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "dcc3190facee895f5f2976885df7fceee6a5e4840bff6c3477086cc2b2391e0f"
+        }
+      ],
+      "description": "This package installs a script named docker that emulates the Docker CLI by executes podman commands, it also creates links between all Docker CLI man pages and podman."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "98bf8b18bc8573fe2337b6d68611ce0619d497778bc46779cf1683e427c7147e"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b6a2a41bd4c1b3eaf93d959a0bb5e222"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "92fd41786eba6823a1c2d38adcd9840dcbdc10562b2e76d0ceddd9d9d454f4ca"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e37ff779c1c5bbab86b5108679e8c25baa0b6898bfdc0b7f2c139848665ac053"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=aarch64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=aarch64&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "db2520b7bcbe443015d0e43c6fadc390"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1e969f991f267f869da6792195b5944d5182629cb281ab792cb05a72ae6c7462"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7da6caa95ae5ed0aab0e72c6e1ac1a5c983e7baed7fde95607195b35503a0db7"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "fe1ff4cadb65d17914290abf42738849"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2b4c88316d88f8a5a6f9bc515a17af2a8759b31934d28016288591f9b5a29441"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b7edd6f7cfc299505812d46cc5693702c0639e2402ea52c303bb70d3d6199d5"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "7296c0be57b7eeae9c57b6c8c592d743"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "d9ebf5f998772d17f2f92228fae170fabc8134f769527d8e3ab4c59144d0e2c2"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9e337cf752d61e0ee62724ec9c47b1acae3a9e4432cd5cfd553f92c81680d0b0"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "f6d1d73121a3ac9043d73ffad03f8ff6"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "9661d00dee825ada58a454efda68e6220ca66b231d34cea5d7348aef1483204e"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "edbf8e370fcecbf895341a1465a1bef356e792369d427c83beebcc9b78d1abc1"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e1e70c6b11bace0e8fdea678701379d3"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8c88aa28fc26f446071e9faef44e8c82608b1ca41a46fe976e09cdaadbbc3db8"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7618261801add9c4ee8a4db0f669fc3a2f7574adf63d04c83fc40b896e15eb12"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ed9b4591c6fc0866c180591a84b4d24c"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "70f3e9d4f9813654ee76ac62503160651666b05fdb1852ec2719d80e9aae8b48"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b988a91116df5599d87c7279872932dc9a4af9960ba11dad96cb99bb0d9be039"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "ffb52fc28ad92192b6caeb3033218421"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "5f7e661ec524a0c3867fce0e486630bc37c316ae96a492fc1a9398787c8cebd6"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c5f053162693085ce7ac1040d21019ec8e5174d366704107ba844b9fc9d50c42"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "62e40c4775d957faee6d71c9c3979f09"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6ec05e80477a0f5600ecf26d8cfe33039d60083ef99a661f38578550b56f6aa6"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d128861f241a6b7b83d85a455c8c5b298b90951646cab742485afadb1504eb66"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le&repository_id=rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "3fb7e7af4fa67e5d11496ac7856c36c7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "dc4f94705f5bf0785c93e1d0cee0d3a607a08b4cf4039584a45aa53ba2a0a23d"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d0a45f410bcb8779373c4a9f8a79ec109050e0cf9c8e23cff47c45d54ed18dbe"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e3afa87e6c2478be9c88ff0eb74b7258"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "f86a050e6fefd130456e6ecb0900da7a9058dcdea38dd4a607f5b35193ce9b01"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "63a0053b49c8e5a08acbadc3c411d1dc70d632d2239f0f84b1a1c5335ed32763"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "5edeb0178e3198d7f2559015a09db92a"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ad278a4289a8a0cd011293147e7607ea4c43a083de6fd5a19b7bab4bfd0406df"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "095a0826e646b539b09495f68351d5fb605fcddf195ec28e1dc3146fb8c9bd50"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8a85d422d04e8231dcf053fd7ff7c4e4"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8e316f3f121a19038969d90933962e1c9effa1ca44506bbcc1ca278352b24c10"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1b4f2372c72139d4b9e6e3b169bce7890831cf3aba17d736058598ba89d94fd9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "bed2db7ddbba6da8d80e70255ea2de4d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "ff98ea84c573982f58cde2c7222fcfb31b079ddf63a22c037d60d1f1fbfe4f61"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "46a8ad2b2f83fc5556e95fe44ff579c7d700f2933270f2dd681ac26b7ad5922d"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b568c279ec1e9ceb4caec887e6145e5d"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "43222345593d6ec76b47fd8bbf0d5542425ef0e68bf2081ef471cafb52e92c2c"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "48b02fa2175f187bbb9f196106cf91b6db9ea65ef813693bfda30db4c7b4eeb6"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "e704543c2bbd7d62f8b971339e6ea915"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "c5e15e64ce3364690077832aeb4c9df2a122c23688208917ac112351260a3f75"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "896b90207de778d78c1b71eb4a368395aea86de779339b2a26e836e891a1a8fb"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0791ad9208d49f8c038dd6842016b267"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8d112aaa8164153c270038e9703d052c8d8e2749a34d6c0ab22210b5195d6927"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "47e3908a0e3373c46a972b234fdc1785d3adc05f257e47675061d8ad875b78ea"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "0aebf3aadb3ab90d53897451a91c7fb7"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "fc293a466d2bee5fefc7760c49b5bf9a62f1e27d43c03fff8fa136771ba9dd00"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "81bc6c2bd563f6c44397b25ccd828e07279ddb5c774f395b1736300b396a1e89"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "13cc1c164e22a8d25f31b675327f74a0"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "1d1c61d8a660b8009c3a65ba4893c81f70e7d4950bb340fd46cf034be70c2a53"
+        }
+      ],
+      "description": "This package provides debug information for package podman. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman",
+      "purl": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6865c16d194be5b65d5f5bf93a1cc120a08d0a7608fd1c6e81ef73c62001170a"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "b263ae955820a4ff608da292f017db40"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6f83865f8a398e0d342f066c2b601e1bceb26e9af046f15e03b79cdb21f998a4"
+        }
+      ],
+      "description": "podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool. podman provides a Docker-CLI comparable command line that eases the transition from other container engines and allows the management of pods, containers and images. Simply put: alias docker=podman. Most podman commands can be run as a regular user, without requiring additional privileges. podman uses Buildah(1) internally to create container images. Both tools share image (not container) storage, hence each can use or manipulate images (but not containers) created by the other. Manage Pods, Containers and Container Images podman Simple management tool for pods, containers and images"
+    },
+    {
+      "name": "podman-debugsource",
+      "purl": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "64d9d6e154a8623e85b6034d31af248c67ee30b8545b58f2de10925245e06e06"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8886efb025c0d495a51b86575f8b5211"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "8e8b51a111ae94b28b734524fbc47aa9b3c955482ce90a2bc66794da2cfad756"
+        }
+      ],
+      "description": "This package provides debug sources for package podman. Debug sources are useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b2d197348ef481e339a207715a9ea65d7ebd6d8a5b0ddd2772176defab07f173"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "9e01d52421a5120ae700b492c1fd5391"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "606713f376e8035380cb34f45058b7fb120de3df50f711de9f22f94c1fc6fff2"
+        }
+      ],
+      "description": "This package provides debug information for package podman-remote. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-remote",
+      "purl": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "243efc8e54815a94356d968c6c5198ea41cb6379eb66958f7863acae8183d68a"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "8352b08639e2fb686d71b8d1623893bd"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "6b3857eb5096a3f7ff27da1693799610e6e76d346f413ae6cfe3d67afe30be81"
+        }
+      ],
+      "description": "podman-remote provides a local client interacting with a Podman backend node through a RESTful API tunneled through a ssh connection. In this context, a podman node is a Linux system with Podman installed on it and the API service activated. Credentials for this session can be passed in using flags, environment variables, or in containers.conf."
+    },
+    {
+      "name": "podman-plugins-debuginfo",
+      "purl": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "93515071362459b794cfb1346d63e0eca7178c91d3b1b71519727a56e8db2974"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-debug-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-debug-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "a9a314d3028d6350562b558148a81a01"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "48b33e4b4b57f7109178e357925f628423e36a3a0660754726a82a839a70a089"
+        }
+      ],
+      "description": "This package provides debug information for package podman-plugins. Debug information is useful when developing applications that use this package or when debugging this package."
+    },
+    {
+      "name": "podman-plugins",
+      "purl": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "82f92e6f0ca5fa9f7bd89b7fd37ed9ac3a43690be6d395e3c05cad81c7cc4d38"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "d8521163b71db8f32699f3d38327ec01"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "77ab42cdc8ca0d793d12f59bcf385fa7e0b54036c13b4f4b803e8306807e044e"
+        }
+      ],
+      "description": "This plugin sets up the use of dnsmasq on a given CNI network so that Pods can resolve each other by name. When configured, the pod and its IP address are added to a network specific hosts file that dnsmasq will read in. Similarly, when a pod is removed from the network, it will remove the entry from the hosts file. Each CNI network will have its own dnsmasq instance."
+    },
+    {
+      "name": "podman-tests",
+      "purl": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4",
+      "type": "library",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "de9b5b8eee5c135ab60c82df703b4000a36cbce59c39d747fad085406afeefe9"
+        }
+      ],
+      "bom-ref": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=s390x",
+      "version": "4.9.4-18.el9_4",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-eus-rpms__9_DOT_4"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=s390x&repository_id=rhel-9-for-s390x-appstream-e4s-rpms__9_DOT_4"
+          }
+        ]
+      },
+      "licenses": [
+        {
+          "expression": "Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0"
+        }
+      ],
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "properties": [
+        {
+          "name": "package:rpm:sigmd5",
+          "value": "6a3426317af40d21b0df429104d3b47b"
+        },
+        {
+          "name": "package:rpm:sha256header",
+          "value": "2bbeafa9ce146116c6562bf36aa56eb35f94f899e4b27ee6fb36d40689802c62"
+        }
+      ],
+      "description": "Tests for podman This package contains system tests for podman"
+    },
+    {
+      "name": "codespell",
+      "type": "library",
+      "bom-ref": "pkg:pypi/codespell@2.2.5?package-id=93ce0b8f87334918",
+      "version": "2.2.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "python-package-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/vendor/go.opentelemetry.io/otel/requirements.txt"
+        }
+      ]
+    },
+    {
+      "name": "dario.cat/mergo",
+      "type": "library",
+      "bom-ref": "pkg:golang/dario.cat/mergo@v1.0.0?package-id=830889683f785245",
+      "version": "v1.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Azure/go-ansiterm",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/azure/go-ansiterm@v0.0.0-20230124172434-306776ec8161?package-id=e9e7e6d880b91c47",
+      "version": "v0.0.0-20230124172434-306776ec8161",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/BurntSushi/toml",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v1.3.2?package-id=1b8d14c0892e99f2",
+      "version": "v1.3.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Microsoft/go-winio",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/microsoft/go-winio@v0.6.1?package-id=40cf52cbbf85a689",
+      "version": "v0.6.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow="
+        }
+      ]
+    },
+    {
+      "name": "github.com/Microsoft/hcsshim",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/microsoft/hcsshim@v0.12.0-rc.1?package-id=70ca0709aa342b6a",
+      "version": "v0.12.0-rc.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Hy+xzYujv7urO5wrgcG58SPMOXNLrj4WCJbySs2XX/A="
+        }
+      ]
+    },
+    {
+      "name": "github.com/VividCortex/ewma",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vividcortex/ewma@v1.2.0?package-id=ce702c42537131b2",
+      "version": "v1.2.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow="
+        }
+      ]
+    },
+    {
+      "name": "github.com/acarl005/stripansi",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d?package-id=29b6356e75990362",
+      "version": "v0.0.0-20180116102854-5a71ef0e047d",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/aead/serpent",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/aead/serpent@v0.0.0-20160714141033-fba169763ea6?package-id=c306d9cc564ad003",
+      "version": "v0.0.0-20160714141033-fba169763ea6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:5L8Mj9Co9sJVgW3TpYk2gxGJnDjsYuboNTcRmbtGKGs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/asaskevich/govalidator",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2?package-id=6b61f83a371c983b",
+      "version": "v0.0.0-20230301143203-a9d515a09cc2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so="
+        }
+      ]
+    },
+    {
+      "name": "github.com/blang/semver/v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/blang/semver@v4.0.0?package-id=7ff5e24b84ae2c11#v4",
+      "version": "v4.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/buger/goterm",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/buger/goterm@v1.0.4?package-id=893020272c15f641",
+      "version": "v1.0.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/bytedance/sonic",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.10.1?package-id=691d0a16f158d1de",
+      "version": "v1.10.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:7a1wuFXL1cMy7a3f7/VFcEtriuXQnUBhtoVfOZiaysc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/checkpoint-restore/checkpointctl",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/checkpoint-restore/checkpointctl@v1.1.0?package-id=55c3fdc2e21f8fa0",
+      "version": "v1.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:plS/2zBzbAXO6DH/H+TqD7ZGhz8iQVb+NLgsOJSTWaw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/checkpoint-restore/go-criu/v7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/checkpoint-restore/go-criu@v7.0.0?package-id=23ca41634978b1d3#v7",
+      "version": "v7.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:R4UF/njKOuq8ooG7naFGsCeKsjv5j+rIhgFgSSeC2KY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chenzhuoyu/base64x",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20230717121745-296ad89f973d?package-id=37dd41ecf04410eb",
+      "version": "v0.0.0-20230717121745-296ad89f973d",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:77cEq6EriyTZ0g/qfRdp61a3Uu/AWrgIq2s0ClJV1g0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chenzhuoyu/iasm",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/iasm@v0.9.0?package-id=b1b6e5af6d27d8c2",
+      "version": "v0.9.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/chzyer/readline",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/readline@v1.5.1?package-id=6a6f66fab4da81eb",
+      "version": "v1.5.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cilium/ebpf",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cilium/ebpf@v0.9.1?package-id=5d1704ccdfbb59aa",
+      "version": "v0.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/cgroups/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/cgroups@v3.0.2?package-id=4207eaf6f39904b6#v3",
+      "version": "v3.0.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/containerd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/containerd@v1.7.9?package-id=f8585ffcfc78ce2e",
+      "version": "v1.7.9",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:KOhK01szQbM80YfW1H6RZKh85PHGqY/9OcEZ35Je8sc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/log",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/log@v0.1.0?package-id=d50543144aae839f",
+      "version": "v0.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/stargz-snapshotter/estargz",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/stargz-snapshotter@v0.15.1?package-id=390abc45fd64da96#estargz",
+      "version": "v0.15.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containerd/typeurl/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containerd/typeurl@v2.1.1?package-id=49bb413ecf1b1c35#v2",
+      "version": "v2.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=fd98f7f80806420c",
+      "version": "v1.1.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/cni",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=e47a64cfd5d94175",
+      "version": "v1.1.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v0.9.1?package-id=32f511297d78f16c",
+      "version": "v0.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9r2Quag7HMLV8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containernetworking/plugins",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containernetworking/plugins@v1.3.0?package-id=1ec97afad4827d0b",
+      "version": "v1.3.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/buildah",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/buildah@v1.33.12?package-id=c0d3b0102aaf1707",
+      "version": "v1.33.12",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6/X3LPnl+xXel4TNNMSjp5I5ztkpxeW3xSkLvF1IiSI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/common",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/common@v0.57.7?package-id=c25ac5fa7b116b52",
+      "version": "v0.57.7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xA6/dXNbScnaytcFNQKTFGn6VDxwvDlCngJtfdGAf7g="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/conmon",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/conmon@v2.0.20%2Bincompatible?package-id=7386cf9fa7f28aa8",
+      "version": "v2.0.20+incompatible",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/gvisor-tap-vsock",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/gvisor-tap-vsock@v0.7.2?package-id=64013dd1a44951f6",
+      "version": "v0.7.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6CyU5D85C0/DciRRd7W0bPljK4FAS+DPrrHEQMHfZKY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/image/v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/image@v5.29.5?package-id=b3a9f470a6979dc4#v5",
+      "version": "v5.29.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hMA9TBrk/tpXX7tYHTjbuyJ6L04Hm+m97+CZaU0VGwI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/libhvee",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/libhvee@v0.5.0?package-id=c4d28ec3437ffad9",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rDhfG2NI8Q+VgeXht2dXezanxEdpj9pHqYX3vWfOGUw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/libtrust",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01?package-id=3487a0ced8b96924",
+      "version": "v0.0.0-20230121012942-c1716e8a8d01",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/luksy",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/luksy@v0.0.0-20231030195837-b5a7f79da98b?package-id=5186102f5ee8ef20",
+      "version": "v0.0.0-20231030195837-b5a7f79da98b",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8XvNAm+g7ivwPUkyiHvBs7z356JWpK9a0FDaek86+sY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/ocicrypt",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/ocicrypt@v1.1.10?package-id=83339bccba164f22",
+      "version": "v1.1.10",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r7UR6o8+lyhkEywetubUUgcKFjOWOaWz8cEBrCPX0ic="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/psgo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/psgo@v1.8.0?package-id=dbb812350f8094e0",
+      "version": "v1.8.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2loGekmGAxM9ir5OsXWEfGwFxorMPYnc6gEDsGFQvhY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/storage",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/storage@v1.51.2?package-id=c94c9f0a8fd1d8a0",
+      "version": "v1.51.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Xw8p1AG1A+Nh6dCsb1UOB3YKF5uzlCkI3uAP4fsFup4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-iptables",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-iptables@v0.6.0?package-id=5d0cb7eaa4a0821f",
+      "version": "v0.6.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-oidc/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-oidc@v3.7.0?package-id=74f403c5d44d527d#v3",
+      "version": "v3.7.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FTdj0uexT4diYIPlF4yoFVI5MRO1r5+SEcIpEw9vC0o="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v0.0.0-20190719114852-fd7a80b32e1f?package-id=768cb510c1564622",
+      "version": "v0.0.0-20190719114852-fd7a80b32e1f",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-systemd/v22",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-systemd@v22.5.1-0.20231103132048-7d375ecc2b09?package-id=da2557227db91ac4#v22",
+      "version": "v22.5.1-0.20231103132048-7d375ecc2b09",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/stream-metadata-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/stream-metadata-go@v0.4.4?package-id=d1972eabd953914a",
+      "version": "v0.4.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:PM/6iNhofKGydsatiY1zdnMMHBT34skb5P7nfEFR4GU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cpuguy83/go-md2man/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man@v2.0.3?package-id=4fc3928126aefd1a#v2",
+      "version": "v2.0.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/crc-org/vfkit",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/crc-org/vfkit@v0.1.2-0.20231030102423-f3c783d34420?package-id=9a4f86040fd4c9bf",
+      "version": "v0.1.2-0.20231030102423-f3c783d34420",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QXiiq7uk7RR4t0Urp/OtIibD+6PJHkEE2zy3QTQ42so="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyberphone/json-canonicalization",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20231011164504-785e29786b46?package-id=2754f6d742c1aaea",
+      "version": "v0.0.0-20231011164504-785e29786b46",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2Dx4IHfC1yHWI12AxQDJM1QbRCDfk6M+blLzlZCXdrc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/cyphar/filepath-securejoin",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=1d9a4060dc7f58d7",
+      "version": "v0.2.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=877523c75d46a3c2",
+      "version": "v1.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=5bed9601b6633eee",
+      "version": "v1.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/digitalocean/go-libvirt",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/digitalocean/go-libvirt@v0.0.0-20220804181439-8648fbde413e?package-id=13c1189cf8b54f71",
+      "version": "v0.0.0-20220804181439-8648fbde413e",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:SCnqm8SjSa0QqRxXbo5YY//S+OryeJioe17nK+iDZpg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/digitalocean/go-qemu",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/digitalocean/go-qemu@v0.0.0-20230711162256-2e3d0186973e?package-id=f99622502510a79a",
+      "version": "v0.0.0-20230711162256-2e3d0186973e",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:x5PInTuXLddHWHlePCNAcM8QtUfOGx44f3UmYPMtDcI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/disiqueira/gotree/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/disiqueira/gotree@v3.0.2?package-id=ba601b632df342f6#v3",
+      "version": "v3.0.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ik5iuLQQoufZBNPY518dXhiO5056hyNBIK9lWhkNRq8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/distribution/reference",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/distribution/reference@v0.5.0?package-id=4dba30d4daf39b34",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/distribution",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible?package-id=e752a6d5b6994595",
+      "version": "v2.8.3+incompatible",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/docker",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/docker@v24.0.7%2Bincompatible?package-id=45390c3a7cd66a04",
+      "version": "v24.0.7+incompatible",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/docker-credential-helpers",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.0?package-id=9b36de361d1590fc",
+      "version": "v0.8.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-connections",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-connections@v0.4.1-0.20231031175723-0b8c1f4e07a0?package-id=82021f28ac416c95",
+      "version": "v0.4.1-0.20231031175723-0b8c1f4e07a0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dPD5pdqsujF9jz2NQMQCDzrBSAF3M6kIxmfU98IOp9c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-plugins-helpers",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-plugins-helpers@v0.0.0-20211224144127-6eecb7beb651?package-id=dac3e4f2d2513c93",
+      "version": "v0.0.0-20211224144127-6eecb7beb651",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YcvzLmdrP/b8kLAGJ8GT7bdncgCAiWxJZIlt84D+RJg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/docker/go-units",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docker/go-units@v0.5.0?package-id=3a5ed86f41f0acf4",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fatih/color@v1.15.0?package-id=f455521699a81e89",
+      "version": "v1.15.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/felixge/httpsnoop",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/felixge/httpsnoop@v1.0.3?package-id=55d70b09906d903f",
+      "version": "v1.0.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.9?package-id=43c300e9aa729c9d",
+      "version": "v1.4.9",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=c74c579f441264d1",
+      "version": "v1.7.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsouza/go-dockerclient",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsouza/go-dockerclient@v1.10.0?package-id=79aedfb86dbe69e6",
+      "version": "v1.10.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ppSBsbR60I1DFbV4Ag7LlHlHakHFRNLk9XakATW1yVQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gabriel-vasile/mimetype",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2?package-id=18edcc57ea86b0de",
+      "version": "v1.4.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gin-contrib/sse",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0?package-id=5b738c5758770efd",
+      "version": "v0.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gin-gonic/gin",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1?package-id=09345e895a858a3c",
+      "version": "v1.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-jose/go-jose/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-jose/go-jose@v3.0.3?package-id=4b5a858815161aed#v3",
+      "version": "v3.0.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.3.0?package-id=a7ea5bc58bf08192",
+      "version": "v1.3.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/stdr",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/stdr@v1.2.2?package-id=933384e7ba49cf7f",
+      "version": "v1.2.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-ole/go-ole",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-ole/go-ole@v1.2.6?package-id=70bf04f6f041e52d",
+      "version": "v1.2.6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/analysis",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/analysis@v0.21.4?package-id=9ea8b9ad52030bed",
+      "version": "v0.21.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ZDFLvSNxpDaomuCueM0BlSXxpANBlFYiBvr+GXrvIHc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/errors",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/errors@v0.20.4?package-id=f1e2ed6ce77fd9ee",
+      "version": "v0.20.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:unTcVm6PispJsMECE3zWgvG4xTiKda1LIR5rCRWLG6M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6?package-id=7a11fcfebcb03b98",
+      "version": "v0.19.6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=fea23081cb20edbf",
+      "version": "v0.20.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/loads",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/loads@v0.21.2?package-id=4614ac5fd7096390",
+      "version": "v0.21.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r2a/xFIYeZ4Qd2TnGpWDIQNcP80dIaZgf704za8enro="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/runtime",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/runtime@v0.26.0?package-id=6fe90c32a6b86cc4",
+      "version": "v0.26.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:HYOFtG00FM1UvqrcxbEJg/SwvDRvYLQKGhw2zaQjTcc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/spec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/spec@v0.20.9?package-id=928d01ff17d2a67b",
+      "version": "v0.20.9",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xnlYNQAwKd2VQRRfwTEI0DcK+2cbuvI/0c7jx3gA8/8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/strfmt",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/strfmt@v0.21.7?package-id=a29e2d3c0ff70597",
+      "version": "v0.21.7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=725453dbb9b24889",
+      "version": "v0.22.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/validate",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/validate@v0.22.1?package-id=4016181974a83f6a",
+      "version": "v0.22.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:G+c2ub6q47kfX1sOBLwIQwzBVt8qmOAARyo/9Fqs9NU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/locales",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1?package-id=5fc0f23885fecc3e",
+      "version": "v0.14.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/universal-translator",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1?package-id=44e9ee23b30396bc",
+      "version": "v0.18.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-playground/validator/v10",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator@v10.15.5?package-id=6f779696625a0d1c#v10",
+      "version": "v10.15.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LEBecTWb/1j5TNY1YYG2RcOUN3R7NLylN+x8TTueE24="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0?package-id=5dec6809fb961051",
+      "version": "v0.0.0-20210107165309-348f09dbbbc0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=7723f23509f6e9c9",
+      "version": "v0.0.0-20230315185526-52ccab3ef572",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-task/slim-sprig",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=6ed8f14e2691b0ae",
+      "version": "v0.0.0-20230315185526-52ccab3ef572",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/goccy/go-json",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2?package-id=9b95f38549dbb2e7",
+      "version": "v0.10.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/godbus/dbus/v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/godbus/dbus@v5.1.1-0.20230522191255-76236955d466?package-id=b7c3e9fcaadfacd7#v5",
+      "version": "v5.1.1-0.20230522191255-76236955d466",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sQspH8M4niEijh3PFscJRLDnkL547IeP7kpPe3uUhEg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=3858e45e43a13e41",
+      "version": "v1.3.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=9fc12d1b7d0549a3",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2?package-id=580312068be9bbdf",
+      "version": "v1.5.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.3?package-id=24106bbd02602711",
+      "version": "v1.5.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=4e7acfd6c9128ec8",
+      "version": "v0.6.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-containerregistry",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-containerregistry@v0.16.1?package-id=257e85f612c158db",
+      "version": "v0.16.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rUEt426sR6nyrL3gt+18ibRcvYpKYdpsa5ZW7MA08dQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-intervals",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-intervals@v0.0.2?package-id=8882646581544332",
+      "version": "v0.0.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FGrVEiUnTRKR8yE04qzXYaJMtnIYqobR5QbblK3ixcM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=555a0046e0839547",
+      "version": "v1.2.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38?package-id=71958bcc23037ded",
+      "version": "v0.0.0-20210407192527-94a9f03dee38",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/pprof",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20230323073829-e72429f035bd?package-id=0c815505247e335f",
+      "version": "v0.0.0-20230323073829-e72429f035bd",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:r8yyd+DJDmsUhGrRBxH5Pj7KeFK5l+Y3FsgT8keqKtk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/shlex",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510?package-id=ab20454707c0ef00",
+      "version": "v0.0.0-20191202100458-e7afc7fbc510",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.4.0?package-id=fa5cb10169d3b9ca",
+      "version": "v1.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/handlers",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/handlers@v1.5.2?package-id=7e5de02f3835a81a",
+      "version": "v1.5.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/mux",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/mux@v1.8.1?package-id=8205ef61f87399be",
+      "version": "v1.8.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/schema",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/schema@v1.4.1?package-id=52af4c633255d773",
+      "version": "v1.4.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/errwrap",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0?package-id=a8a79647a7a8cf70",
+      "version": "v1.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-cleanhttp",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2?package-id=e1ee33c1617e1009",
+      "version": "v0.5.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-multierror",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1?package-id=5671cb08a298ac36",
+      "version": "v1.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-retryablehttp",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.7?package-id=28dd885c1b4dbb0e",
+      "version": "v0.7.7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-version",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-version@v1.3.0?package-id=0a0118ecc74d7c35",
+      "version": "v1.3.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/hugelgupf/p9",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hugelgupf/p9@v0.3.1-0.20230822151754-54f5c5530921?package-id=2ffe99043a09760b",
+      "version": "v0.3.1-0.20230822151754-54f5c5530921",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:cfYGdNpXGZobTSSDFB+wx2FRfWptM7sCkScJgVx0Tkk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=dc1badc47df18f09",
+      "version": "v1.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/jinzhu/copier",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jinzhu/copier@v0.4.0?package-id=a1b1e1aa033edb92",
+      "version": "v0.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=ac618cfcc28857e7",
+      "version": "v1.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=9a09e60e64762fb5",
+      "version": "v1.1.12",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/compress",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/compress@v1.17.3?package-id=1ffa33b600e6ddfd",
+      "version": "v1.17.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:qkRjuerhUU1EmXLYGkSH6EZL+vPSxIrYjLNAK4slzwA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/cpuid/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid@v2.2.5?package-id=e41a09d00e6a6abe#v2",
+      "version": "v2.2.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/klauspost/pgzip",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/pgzip@v1.2.6?package-id=07e01f5838373cd6",
+      "version": "v1.2.6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/kr/fs",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/fs@v0.1.0?package-id=398ff89cd63d2228",
+      "version": "v0.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/leodido/go-urn",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4?package-id=5281368296cb5ab9",
+      "version": "v1.2.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q="
+        }
+      ]
+    },
+    {
+      "name": "github.com/letsencrypt/boulder",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/letsencrypt/boulder@v0.0.0-20230213213521-fdfea0d469b6?package-id=258bb3371e4d4027",
+      "version": "v0.0.0-20230213213521-fdfea0d469b6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:unJdfS94Y3k85TKy+mvKzjW5R9rIC+Lv4KGbE7uNu0I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/linuxkit/virtsock",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/linuxkit/virtsock@v0.0.0-20220523201153-1a23e78aa7a2?package-id=d3cf194c0733b47d",
+      "version": "v0.0.0-20220523201153-1a23e78aa7a2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DZMFueDbfz6PNc1GwDRA8+6lBx1TB9UnxDQliCqR73Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/lufia/plan9stats",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/lufia/plan9stats@v0.0.0-20211012122336-39d0f177ccd0?package-id=8209420d49ba0096",
+      "version": "v0.0.0-20211012122336-39d0f177ccd0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/magefile/mage",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/magefile/mage@v1.14.0?package-id=a74f649988594bbd",
+      "version": "v1.14.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=8e46bb3723393ca3",
+      "version": "v0.7.7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/manifoldco/promptui",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/manifoldco/promptui@v0.9.0?package-id=7bac44b824f7aa5e",
+      "version": "v0.9.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.13?package-id=55b67c1594f55f24",
+      "version": "v0.1.13",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.17?package-id=117a3f38e559e9ed",
+      "version": "v0.0.17",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.20?package-id=b981519f33f50dbc",
+      "version": "v0.0.20",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15?package-id=0b6d7d3f1eeeeae4",
+      "version": "v0.0.15",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-shellwords",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-shellwords@v1.0.12?package-id=83450e3a15e0f99d",
+      "version": "v1.0.12",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-sqlite3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-sqlite3@v1.14.18?package-id=f5d05835504f4ffd",
+      "version": "v1.14.18",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/socket",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=f56f68404baa5b58",
+      "version": "v0.4.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mdlayher/vsock",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=2aee1d4c12209cb8",
+      "version": "v1.2.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/miekg/pkcs11",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/miekg/pkcs11@v1.1.1?package-id=fef9e5fb9971283d",
+      "version": "v1.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mistifyio/go-zfs/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mistifyio/go-zfs@v3.0.1?package-id=2216e1fe48e790da#v3",
+      "version": "v3.0.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/mitchellh/mapstructure",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0?package-id=7981989d0762c97e",
+      "version": "v1.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/buildkit",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/buildkit@v0.12.5?package-id=7b5f00776e604492",
+      "version": "v0.12.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:RNHH1l3HDhYyZafr5EgstEu8aGNCwyfvMtrQDtjH9T0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/patternmatcher",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/patternmatcher@v0.6.0?package-id=64fc68737d4c9f77",
+      "version": "v0.6.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/mountinfo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.7.1?package-id=057e295fbec4aa26#mountinfo",
+      "version": "v0.7.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/sys/sequential",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/sys@v0.5.0?package-id=ab4a193d344a7505#sequential",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/moby/term",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/term@v0.5.0?package-id=249cb807e979f08f",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=909dd10ba0ae8d1c",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e5c6f4996c77bb75",
+      "version": "v1.0.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/morikuni/aec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/morikuni/aec@v1.0.0?package-id=a30048d529e8332e",
+      "version": "v1.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A="
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v1.4.11?package-id=e64a2938860b6dd5",
+      "version": "v1.4.11",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/nxadm/tail",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nxadm/tail@v1.4.8?package-id=47dcfdbf536f7c63",
+      "version": "v1.4.8",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/oklog/ulid",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/oklog/ulid@v1.3.1?package-id=14bd4a60fcd4657e",
+      "version": "v1.3.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.16.4?package-id=24c75128dfa61e89",
+      "version": "v1.16.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.16.5?package-id=ea9cf0407d9a2eca",
+      "version": "v1.16.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=49dac0fbe8817737#v2",
+      "version": "v2.13.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LNGfMbR2OVGBfXjvRZIZ2YCTQdGKtPLvuI1rMCCj3OU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/ginkgo/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=fc37f0a9e4bf5451#v2",
+      "version": "v2.13.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:LNGfMbR2OVGBfXjvRZIZ2YCTQdGKtPLvuI1rMCCj3OU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.10.1?package-id=3b42020f9d5a81e3",
+      "version": "v1.10.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.17.0?package-id=5f42984101810003",
+      "version": "v1.17.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/onsi/gomega",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.30.0?package-id=41d0dd66a95fa5b6",
+      "version": "v1.30.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/go-digest",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0?package-id=5ed4b0a493e74727",
+      "version": "v1.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/image-spec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0-rc5?package-id=de9ca21aabe7af43",
+      "version": "v1.1.0-rc5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runc@v1.1.10?package-id=64a86695e9014382",
+      "version": "v1.1.10",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EaL5WeO9lv9wmS6SASjszOeQdSctvpbu0DdBQBizE40="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-spec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-spec@v1.1.1-0.20230922153023-c0e90434df2a?package-id=aa338f0fb7818fba",
+      "version": "v1.1.1-0.20230922153023-c0e90434df2a",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ekgJlqTI6efJ57J7tqvIOYtdPnJRe8MxUZHbZAC021Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/runtime-tools",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/runtime-tools@v0.9.1-0.20230914150019-408c51e934dc?package-id=7906f8e792e1cc23",
+      "version": "v0.9.1-0.20230914150019-408c51e934dc",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opencontainers/selinux",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=a7a0602fcd6bf785",
+      "version": "v1.11.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/golang-crypto",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581?package-id=6996b532d4a8353f",
+      "version": "v0.33.1-0.20250310193910-9003f682e581",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YWomd7tA7icznvjpDrSJ8Ksfd0xPWG4E0nEBhvABjSA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/openshift/imagebuilder",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/openshift/imagebuilder@v1.2.6-0.20231110114814-35a50d57f722?package-id=bf8de9a16e63655a",
+      "version": "v1.2.6-0.20231110114814-35a50d57f722",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vhEmg+NeucmSYnT2j9ukkZLrR/ZOFUuUiGhxlBAlW8U="
+        }
+      ]
+    },
+    {
+      "name": "github.com/opentracing/opentracing-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.2.0?package-id=efecea730dd143c9",
+      "version": "v1.2.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ostreedev/ostree-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ostreedev/ostree-go@v0.0.0-20210805093236-719684c64e4f?package-id=1ba798c98082554e",
+      "version": "v0.0.0-20210805093236-719684c64e4f",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pelletier/go-toml/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v2.1.0?package-id=9ff575724d7a724d#v2",
+      "version": "v2.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=0a3a6cd8ca1aca01",
+      "version": "v0.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=33c84874f1b5210b",
+      "version": "v0.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/sftp",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/sftp@v1.13.6?package-id=eabbcc7d8c6984ad",
+      "version": "v1.13.6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo="
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=1fa6692567cdbf27",
+      "version": "v1.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/power-devops/perfstat",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/power-devops/perfstat@v0.0.0-20210106213030-5aafc221ea8c?package-id=a6395e79ef6f1b71",
+      "version": "v0.0.0-20210106213030-5aafc221ea8c",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/proglottis/gpgme",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/proglottis/gpgme@v0.1.3?package-id=93ae51d378faf15e",
+      "version": "v0.1.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.4?package-id=cdf6fb578549fb21",
+      "version": "v0.4.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis="
+        }
+      ]
+    },
+    {
+      "name": "github.com/rootless-containers/rootlesskit",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rootless-containers/rootlesskit@v1.1.1?package-id=ed77de7d3dc899c3",
+      "version": "v1.1.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:F5psKWoWY9/VjZ3ifVcaosjvFZJOagX85U22M0/EQZE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/russross/blackfriday/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/russross/blackfriday@v2.1.0?package-id=a77e788e63d883b2#v2",
+      "version": "v2.1.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/seccomp/libseccomp-golang",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0?package-id=aabf28e49d8c2c67",
+      "version": "v0.10.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/secure-systems-lab/go-securesystemslib",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.7.0?package-id=9282f6c607a104c5",
+      "version": "v0.7.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/segmentio/ksuid",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/segmentio/ksuid@v1.0.4?package-id=4e38f5d4abe52fee",
+      "version": "v1.0.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c="
+        }
+      ]
+    },
+    {
+      "name": "github.com/shirou/gopsutil/v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/shirou/gopsutil@v3.23.10?package-id=2ab56a514628a22f#v3",
+      "version": "v3.23.10",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:/N42opWlYzegYaVkWejXWJpbzKv2JDy3mrgGzKsh9hM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/shoenig/go-m1cpu",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/shoenig/go-m1cpu@v0.1.6?package-id=0f39be61a8d01bb0",
+      "version": "v0.1.6",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/fulcio",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/fulcio@v1.4.3?package-id=a86953ca7170fc4f",
+      "version": "v1.4.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9JcUCZjjVhRF9fmhVuz6i1RyhCc/EGCD7MOl+iqCJLQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/rekor",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/rekor@v1.2.2?package-id=0f5a2aa6a10e7aa0",
+      "version": "v1.2.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:5JK/zKZvcQpL/jBmHvmFj3YbpDMBQnJQ6ygp8xdF3bY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sigstore/sigstore",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sigstore/sigstore@v1.7.5?package-id=6e3f094699d393a2",
+      "version": "v1.7.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ij55dBhLwjICmLTBJZm7SqoQLdsu/oowDanACcJNs48="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1?package-id=87cdb22161c9af0b",
+      "version": "v1.8.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.2?package-id=b270a6ffdc08cf1d",
+      "version": "v1.9.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.3?package-id=53f9cbdf66773c00",
+      "version": "v1.9.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ="
+        }
+      ]
+    },
+    {
+      "name": "github.com/skratchdot/open-golang",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966?package-id=381940bf58561263",
+      "version": "v0.0.0-20200116055534-eef842397966",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.0?package-id=a0860300672ecf78",
+      "version": "v1.8.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=39c06474ebd4efb7",
+      "version": "v1.0.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stefanberger/go-pkcs11uri",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stefanberger/go-pkcs11uri@v0.0.0-20201008174630-78d3cae3a980?package-id=839631b295cbc658",
+      "version": "v0.0.0-20201008174630-78d3cae3a980",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0?package-id=af7f5942d8b925ca",
+      "version": "v1.7.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY="
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.4?package-id=0fb761477437694b",
+      "version": "v1.8.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/sylabs/sif/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sylabs/sif@v2.15.0?package-id=f36fac4200cf3c5b#v2",
+      "version": "v2.15.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Nv0tzksFnoQiQ2eUwpAis9nVqEu4c3RcNSxX8P3Cecw="
+        }
+      ]
+    },
+    {
+      "name": "github.com/syndtr/gocapability",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437635?package-id=66185a54383ae5aa",
+      "version": "v0.0.0-20200815063812-42c35b437635",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tchap/go-patricia/v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tchap/go-patricia@v2.3.1?package-id=2adf2074e170fdc9#v2",
+      "version": "v2.3.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes="
+        }
+      ]
+    },
+    {
+      "name": "github.com/titanous/rocacheck",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399?package-id=7d4bf4f63a7946a0",
+      "version": "v0.0.0-20171023193734-afe73141d399",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tklauser/go-sysconf",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tklauser/go-sysconf@v0.3.12?package-id=3c5259b6aa406e71",
+      "version": "v0.3.12",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/tklauser/numcpus",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tklauser/numcpus@v0.6.1?package-id=44281e1ffe97bad8",
+      "version": "v0.6.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk="
+        }
+      ]
+    },
+    {
+      "name": "github.com/twitchyliquid64/golang-asm",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1?package-id=d432df03855789c3",
+      "version": "v0.15.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI="
+        }
+      ]
+    },
+    {
+      "name": "github.com/u-root/uio",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/u-root/uio@v0.0.0-20230305220412-3e8cd9d6bf63?package-id=e4a19ce7d7b1e6e4",
+      "version": "v0.0.0-20230305220412-3e8cd9d6bf63",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YcojQL98T/OO+rybuzn2+5KrD5dBwXIvYBvQ2cD3Avg="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ugorji/go/codec",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.2.11?package-id=c9cb6dcf9c79dc0e#codec",
+      "version": "v1.2.11",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/ulikunitz/xz",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ulikunitz/xz@v0.5.11?package-id=b1a8ca736444c227",
+      "version": "v0.5.11",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbatts/git-validation",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbatts/git-validation@v1.2.1?package-id=440ff590c93b898e",
+      "version": "v1.2.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:O26LKWEtBOfnxKT/SAiFCAcQglKwyuZEKSq6AevpWJ4="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbatts/tar-split",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbatts/tar-split@v0.11.5?package-id=84820f43f22105ca",
+      "version": "v0.11.5",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vbauerster/mpb/v8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vbauerster/mpb@v8.6.2?package-id=bc0ebef35f07f9bf#v8",
+      "version": "v8.6.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9EhnJGQRtvgDVCychJgR96EDCOqgg2NsMuk5JUcX4DA="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210916161339-2c39f3491956?package-id=95cb519ea26ea490",
+      "version": "v1.1.1-0.20210916161339-2c39f3491956",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2tjYQpM+MZB25iPeE20lI/PrUNrbN66Bd+P27TkVaxU="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netlink",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netlink@v1.2.1-beta.2?package-id=b6baf9fb07b2dda4",
+      "version": "v1.2.1-beta.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.0-20200728191858-db3c7e526aae?package-id=94b20f1eeb8f0476",
+      "version": "v0.0.0-20200728191858-db3c7e526aae",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns="
+        }
+      ]
+    },
+    {
+      "name": "github.com/vishvananda/netns",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/vishvananda/netns@v0.0.4?package-id=a7a991b8910e6c4a",
+      "version": "v0.0.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8="
+        }
+      ]
+    },
+    {
+      "name": "github.com/yusufpapurcu/wmi",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yusufpapurcu/wmi@v1.2.3?package-id=b01a7ad804f424bc",
+      "version": "v1.2.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw="
+        }
+      ]
+    },
+    {
+      "name": "go.etcd.io/bbolt",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.etcd.io/bbolt@v1.3.8?package-id=8ddfc67c925bba46",
+      "version": "v1.3.8",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA="
+        }
+      ]
+    },
+    {
+      "name": "go.mongodb.org/mongo-driver",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mongodb.org/mongo-driver@v1.11.3?package-id=45ad1a2bf64e4856",
+      "version": "v1.11.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ql6K6qYHEzB6xvu4+AU0BoRoqf9vFPcc4o7MUIdPW8Y="
+        }
+      ]
+    },
+    {
+      "name": "go.mozilla.org/pkcs7",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352?package-id=926dac54f2666643",
+      "version": "v0.0.0-20210826202110-33d05740a352",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak="
+        }
+      ]
+    },
+    {
+      "name": "go.opencensus.io",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opencensus.io@v0.24.0?package-id=e52c60f016939e73",
+      "version": "v0.24.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel@v1.19.0?package-id=29308692149d68c9",
+      "version": "v1.19.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/metric",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/metric@v1.19.0?package-id=92c323559045ab0c",
+      "version": "v1.19.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aTzpGtV0ar9wlV4Sna9sdJyII5jTVJEvKETPiOKwvpE="
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/trace",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/trace@v1.19.0?package-id=945382bc72d2bf58",
+      "version": "v1.19.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/arch",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/arch@v0.5.0?package-id=5584feb5bbed2344",
+      "version": "v0.5.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jpGode6huXQxcskEIpOCvrU+tzo81b6+oFLUYXWtH/Y="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d?package-id=7f336093b19007a3",
+      "version": "v0.0.0-20231006140011-7918f672742d",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.14.0?package-id=50f03ea7a1559dcf",
+      "version": "v0.14.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.17.0?package-id=f4e4cd3a95899b98",
+      "version": "v0.17.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781?package-id=a18b635ecdd65e7f",
+      "version": "v0.0.0-20210428140749-89ef3d95e781",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.25.0?package-id=7a095c99b61b059e",
+      "version": "v0.25.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.14.0?package-id=2340b3d14d1de776",
+      "version": "v0.14.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:P0Vrf/2538nmC0H+pEQ3MNFRRnVR7RlqyVw+bvm26z0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sync",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.11.0?package-id=2e6466ee8cd262bf",
+      "version": "v0.11.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191005200804-aed5e4c7ecf9?package-id=d0c04f85415ed4c2",
+      "version": "v0.0.0-20191005200804-aed5e4c7ecf9",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/fsnotify/fsnotify/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200217220822-9197077df867?package-id=74753c33555d2eee",
+      "version": "v0.0.0-20200217220822-9197077df867",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netns/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1?package-id=f3b0ba69ab1b2a59",
+      "version": "v0.0.0-20200728102440-3e129f6d46b1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210112080510-489259a85091?package-id=2cf4e9a79f89427a",
+      "version": "v0.0.0-20210112080510-489259a85091",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=a389301391b9d958",
+      "version": "v0.0.0-20220715151400-c0bba94af5f8",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=6bffef882ecac407",
+      "version": "v0.0.0-20220715151400-c0bba94af5f8",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.14.0?package-id=f25f45b44e71443e",
+      "version": "v0.14.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.30.0?package-id=e39ce661be9bf474",
+      "version": "v0.30.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.29.0?package-id=1815e1dab70318d7",
+      "version": "v0.29.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.22.0?package-id=a51b0b1ed0058137",
+      "version": "v0.22.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20201224043029-2b0845dc783e?package-id=ce137c87f0b04b31",
+      "version": "v0.0.0-20201224043029-2b0845dc783e",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.15.0?package-id=731cdf76d49ab47e",
+      "version": "v0.15.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/test/tools/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8="
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d?package-id=7f5f03ba9446ff06",
+      "version": "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/appengine",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=f1a37ca4d5341a88",
+      "version": "v1.6.8",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230920204549-e6e6cdab5c13?package-id=d1ff76b06e918dd5#rpc",
+      "version": "v0.0.0-20230920204549-e6e6cdab5c13",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:N3bU/SQDCDyD6R528GJ/PwW9KjYcJA3dgyH+MovAkIM="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=0536ecf5c701b428",
+      "version": "v1.58.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BjnpXut1btbtgN/6sp+brB2Kbm2LjNXnidYujAVbSoQ="
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=d5cf1e90e1d3a922",
+      "version": "v1.33.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/check.v1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405?package-id=6ec4f733e364ddb3",
+      "version": "v0.0.0-20161208181325-20d25e280405",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/gopkg.in/yaml.v2/go.mod"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/go-jose/go-jose.v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/go-jose/go-jose.v2@v2.6.3?package-id=3d2ed6cd7015c40e",
+      "version": "v2.6.3",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=e888dc297812f467",
+      "version": "v0.9.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=7de6255c8f2da4b5",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=ef4f4519d54f2d19",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=95965a2b35c782b7",
+      "version": "v2.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=5f213a346a9e4eab",
+      "version": "v2.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY="
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=bd0fda54a493606a",
+      "version": "v3.0.1",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA="
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kubernetes",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kubernetes@v1.28.4?package-id=3e5804f8cb681af1",
+      "version": "v1.28.4",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aRNxs5jb8FVTtlnxeA4FSDBVKuFwA8Gw40/U2zReBYA="
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=52cb6c48c30f8a48",
+      "version": "v1.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E="
+        }
+      ]
+    },
+    {
+      "name": "tags.cncf.io/container-device-interface",
+      "type": "library",
+      "bom-ref": "pkg:golang/tags.cncf.io/container-device-interface@v0.6.2?package-id=05eacda07687a438",
+      "version": "v0.6.2",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:dThE6dtp/93ZDGhqaED2Pu374SOeUkBfuvkLuiTdwzg="
+        }
+      ]
+    },
+    {
+      "name": "tags.cncf.io/container-device-interface/specs-go",
+      "type": "library",
+      "bom-ref": "pkg:golang/tags.cncf.io/container-device-interface/specs-go@v0.6.0?package-id=aebbffdf383737a2",
+      "version": "v0.6.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-file-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/containers-podman-0e11f82/go.mod"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:V+tJJN6dqu8Vym6p+Ru+K5mJ49WL6Aoc5SJFSY0RLsQ="
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "817f70cf12039bab979522451f3e3b627da81113"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "8aabac01b1d704facdf674de5c5b5232791397b6a6ff14e3caba9e2c35e613a4"
+        }
+      ],
+      "bom-ref": "432c2d15dd3c142f",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/fsnotify/fsnotify/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "192cf4294f401031b7ed28d203306d9792dae038"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "0dab08a9d390fa423979b281c8a30adf6368579945519dffa568ebe6f754a036"
+        }
+      ],
+      "bom-ref": "6752475cd6b8aaa0",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/nxadm/tail/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5bb7e05c814cd82730484497c5d1872575b4ca51"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "a65f8a958855bf707d326b76b72f9c428bd226304ab8cc317a67315333b4e4c7"
+        }
+      ],
+      "bom-ref": "d62a3347df49026c",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/ginkgo/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "1b32b90219e3f35f83b1e1e003d3f556665ce584"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "25631b029f86dc1d5bc8aeae5e0450955c05e4abfaa70df298e6cb1f7ac54097"
+        }
+      ],
+      "bom-ref": "b845a6ade1fe0acd",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/onsi/gomega/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "157e5ea3874ec4bc3f908e5382b5f1edf9170b9c"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "ce583e41b985b0b33a4eefbe143df21e426790af9a236f95dcc2cef82062b526"
+        }
+      ],
+      "bom-ref": "9b6813eff6b49da6",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/sirupsen/logrus/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "732b28d0f8e9a8d8dca779a5065f4168db323409"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "01e82122d547d1228151a623fe6cacc4d7a9cb318a0f668ce08bb6b67fdb28b1"
+        }
+      ],
+      "bom-ref": "9bce1f6d3d7d8556",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netlink/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "25603d41572037f657c32e040cc425e631ff26e3"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "90e0814cf704a1b6c701985cffe442e44bab8f3d5fa8907f482e72ba02882b64"
+        }
+      ],
+      "bom-ref": "a6f89bb2ae66096d",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/github.com/vishvananda/netns/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5ed6f72680912c109b38acf9081ebdb1a43d8bcc"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "f4789a9fcf2e402616afc906fd239a92d46e4a6e00181cd3435f1c910aafe624"
+        }
+      ],
+      "bom-ref": "5d00cdf4c5e10ed9",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/dnsname-bdc4ab85266ade865a7c398336e98721e62ef6b2/vendor/gopkg.in/yaml.v2/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "5f7e941d75c7a9a445fc81663a735596ae17460e"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "c3b11ba9a0775ff9bc6f11dbb58a1e48cc1e68bac378a8cdc620becc661d4c33"
+        }
+      ],
+      "bom-ref": "834e53e812a67542",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "e39d9ceaf16953c05c9bbe138a7429749dedb0e6"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "89ceabd0db4b208279bcf6bb088765fcbde5f94d0937c36f9d3a550af01640ee"
+        }
+      ],
+      "bom-ref": "eb7c0eac2188ec99",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/test/tools/go.mod",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "c2814de81048620f8adb3421883486d7f31e2147"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e67b6d847e7d1189e85d81b1255904a3bb4e317fa64cc0821b8ca8447b4f2e6c"
+        }
+      ],
+      "bom-ref": "4c9d75aae76411dd",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/rpmbuild/BUILD/containers-podman-0e11f82/vendor/go.opentelemetry.io/otel/requirements.txt",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "6692dd8eabe01587d803a3f64ebc7c46aba9ed95"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "3d81238d468b6c2ecf6d758b343d72017496bc35ab6c758c63c0b3bb1c0978f5"
+        }
+      ],
+      "bom-ref": "b8a3106977fb6164",
+      "evidence": {}
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=c56c3dedd9c2e801#cmd/podman",
+      "version": "v3.44.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e",
+      "version": "go1.21.13",
+      "evidence": {},
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/extracted_rpms/podman-remote-4.9.4-18.el9_4.aarch64/usr/bin/podman-remote",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "56846e6ab0fb5ee46a498b4b6f3be5580c3f5c21"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "7d2f6fcfef073a1f17b22e73741b867b3cdba9a58ca13f371ee5b7e0de7820a7"
+        }
+      ],
+      "bom-ref": "621841594022a85c",
+      "evidence": {}
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=72333f468fbbd985#plugins/meta/dnsname",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85",
+      "version": "go1.21.13",
+      "evidence": {},
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/extracted_rpms/podman-plugins-4.9.4-18.el9_4.aarch64/usr/libexec/cni/dnsname",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "e322f1085cebb2256488c0a57a16c42723ff2f25"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "369cf0c1852a4b4021dbd99761817dea4dc8286a8f9191275d15c8ef72ae5226"
+        }
+      ],
+      "bom-ref": "e16048dc26ffff58",
+      "evidence": {}
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=20594327197779e5#cmd/podman",
+      "version": "v3.44.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=db5b4781160ac247#cmd/quadlet",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f66d3ff41d77cc3e#cmd/rootlessport",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "arm64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2",
+      "version": "go1.21.13",
+      "evidence": {},
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31",
+      "version": "go1.21.13",
+      "evidence": {},
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34",
+      "version": "go1.21.13",
+      "evidence": {},
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        }
+      ]
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/extracted_rpms/podman-4.9.4-18.el9_4.aarch64/usr/bin/podman",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "c1b1d118f975d7aef7c50911a3eec556c22937b4"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "2f8c2f74695912ab189364a5537f9a77506e4f689a056688e067f9c96f4b5914"
+        }
+      ],
+      "bom-ref": "3e7c38694c0bef3c",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/extracted_rpms/podman-4.9.4-18.el9_4.aarch64/usr/libexec/podman/quadlet",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "090fed16c0e799070a6ee2018c4fca8bb3f52a05"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "e2081e94c4b1e483834e2307e48c6061b66e4f1fc226818d42df2a9a0d1e39c4"
+        }
+      ],
+      "bom-ref": "722eebec347dccfd",
+      "evidence": {}
+    },
+    {
+      "name": "/tmp/koji-rpm-manifest-generator-u3mnwoox/extracted_rpms/podman-4.9.4-18.el9_4.aarch64/usr/libexec/podman/rootlessport",
+      "type": "file",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "70320a6f31442d6c8146ce5109f4bdd90f5d14ab"
+        },
+        {
+          "alg": "SHA-256",
+          "content": "87503809e3ed1d0ba2fb63c47d3c040d524868e3e22a54fe158709057f9c7aaa"
+        }
+      ],
+      "bom-ref": "d9b53bd6ae5a52f9",
+      "evidence": {}
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=596bc2986195ad9a#plugins/meta/dnsname",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=a0ecf4e4efa372b6#cmd/podman",
+      "version": "v3.44.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=5b6d17b611edf5a7#cmd/quadlet",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=e74f595be6c58439#cmd/rootlessport",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=77931425bae542d7#cmd/podman",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "ppc64le"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=b448c44daea5402c#cmd/podman",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=074bb61871d3bb41#plugins/meta/dnsname",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=0b7acbecbb7f4425#cmd/podman",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c7debbb08312f127#cmd/quadlet",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c0b2a359da0f262f#cmd/rootlessport",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@v4.0.0?package-id=7d23ac3003235523#cmd/podman",
+      "version": "v4.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/quadlet",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f2376156f28cba3a#cmd/quadlet",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/quadlet"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/quadlet"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/rootlessport",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=8be2b0da4a991d7d#cmd/rootlessport",
+      "version": "(devel)",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/podman/rootlessport"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/rootlessport"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/podman/cmd/podman",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/podman@v4.0.0?package-id=a941c94077d4e3c3#cmd/podman",
+      "version": "v4.0.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/bin/podman-remote"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/podman/cmd/podman"
+        }
+      ]
+    },
+    {
+      "name": "github.com/containers/dnsname/plugins/meta/dnsname",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/containers/dnsname@v0.4.0?package-id=329281ef4c76fc90#plugins/meta/dnsname",
+      "version": "v0.4.0",
+      "evidence": {},
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/usr/libexec/cni/dnsname"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "s390x"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.21.13"
+        },
+        {
+          "name": "syft:metadata:mainModule",
+          "value": "github.com/containers/dnsname/plugins/meta/dnsname"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=src",
+      "provides": [
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-docker@4.9.4-18.el9_4?arch=noarch",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=aarch64",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/podman-debuginfo@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-debugsource@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-remote-debuginfo@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-plugins-debuginfo@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x",
+        "pkg:rpm/redhat/podman-tests@4.9.4-18.el9_4?arch=s390x",
+        "pkg:pypi/codespell@2.2.5?package-id=93ce0b8f87334918",
+        "pkg:golang/dario.cat/mergo@v1.0.0?package-id=830889683f785245",
+        "pkg:golang/github.com/azure/go-ansiterm@v0.0.0-20230124172434-306776ec8161?package-id=e9e7e6d880b91c47",
+        "pkg:golang/github.com/burntsushi/toml@v1.3.2?package-id=1b8d14c0892e99f2",
+        "pkg:golang/github.com/microsoft/go-winio@v0.6.1?package-id=40cf52cbbf85a689",
+        "pkg:golang/github.com/microsoft/hcsshim@v0.12.0-rc.1?package-id=70ca0709aa342b6a",
+        "pkg:golang/github.com/vividcortex/ewma@v1.2.0?package-id=ce702c42537131b2",
+        "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d?package-id=29b6356e75990362",
+        "pkg:golang/github.com/aead/serpent@v0.0.0-20160714141033-fba169763ea6?package-id=c306d9cc564ad003",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2?package-id=6b61f83a371c983b",
+        "pkg:golang/github.com/blang/semver@v4.0.0?package-id=7ff5e24b84ae2c11#v4",
+        "pkg:golang/github.com/buger/goterm@v1.0.4?package-id=893020272c15f641",
+        "pkg:golang/github.com/bytedance/sonic@v1.10.1?package-id=691d0a16f158d1de",
+        "pkg:golang/github.com/checkpoint-restore/checkpointctl@v1.1.0?package-id=55c3fdc2e21f8fa0",
+        "pkg:golang/github.com/checkpoint-restore/go-criu@v7.0.0?package-id=23ca41634978b1d3#v7",
+        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20230717121745-296ad89f973d?package-id=37dd41ecf04410eb",
+        "pkg:golang/github.com/chenzhuoyu/iasm@v0.9.0?package-id=b1b6e5af6d27d8c2",
+        "pkg:golang/github.com/chzyer/readline@v1.5.1?package-id=6a6f66fab4da81eb",
+        "pkg:golang/github.com/cilium/ebpf@v0.9.1?package-id=5d1704ccdfbb59aa",
+        "pkg:golang/github.com/containerd/cgroups@v3.0.2?package-id=4207eaf6f39904b6#v3",
+        "pkg:golang/github.com/containerd/containerd@v1.7.9?package-id=f8585ffcfc78ce2e",
+        "pkg:golang/github.com/containerd/log@v0.1.0?package-id=d50543144aae839f",
+        "pkg:golang/github.com/containerd/stargz-snapshotter@v0.15.1?package-id=390abc45fd64da96#estargz",
+        "pkg:golang/github.com/containerd/typeurl@v2.1.1?package-id=49bb413ecf1b1c35#v2",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=fd98f7f80806420c",
+        "pkg:golang/github.com/containernetworking/cni@v1.1.2?package-id=e47a64cfd5d94175",
+        "pkg:golang/github.com/containernetworking/plugins@v0.9.1?package-id=32f511297d78f16c",
+        "pkg:golang/github.com/containernetworking/plugins@v1.3.0?package-id=1ec97afad4827d0b",
+        "pkg:golang/github.com/containers/buildah@v1.33.12?package-id=c0d3b0102aaf1707",
+        "pkg:golang/github.com/containers/common@v0.57.7?package-id=c25ac5fa7b116b52",
+        "pkg:golang/github.com/containers/conmon@v2.0.20%2Bincompatible?package-id=7386cf9fa7f28aa8",
+        "pkg:golang/github.com/containers/gvisor-tap-vsock@v0.7.2?package-id=64013dd1a44951f6",
+        "pkg:golang/github.com/containers/image@v5.29.5?package-id=b3a9f470a6979dc4#v5",
+        "pkg:golang/github.com/containers/libhvee@v0.5.0?package-id=c4d28ec3437ffad9",
+        "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01?package-id=3487a0ced8b96924",
+        "pkg:golang/github.com/containers/luksy@v0.0.0-20231030195837-b5a7f79da98b?package-id=5186102f5ee8ef20",
+        "pkg:golang/github.com/containers/ocicrypt@v1.1.10?package-id=83339bccba164f22",
+        "pkg:golang/github.com/containers/psgo@v1.8.0?package-id=dbb812350f8094e0",
+        "pkg:golang/github.com/containers/storage@v1.51.2?package-id=c94c9f0a8fd1d8a0",
+        "pkg:golang/github.com/coreos/go-iptables@v0.6.0?package-id=5d0cb7eaa4a0821f",
+        "pkg:golang/github.com/coreos/go-oidc@v3.7.0?package-id=74f403c5d44d527d#v3",
+        "pkg:golang/github.com/coreos/go-systemd@v0.0.0-20190719114852-fd7a80b32e1f?package-id=768cb510c1564622",
+        "pkg:golang/github.com/coreos/go-systemd@v22.5.1-0.20231103132048-7d375ecc2b09?package-id=da2557227db91ac4#v22",
+        "pkg:golang/github.com/coreos/stream-metadata-go@v0.4.4?package-id=d1972eabd953914a",
+        "pkg:golang/github.com/cpuguy83/go-md2man@v2.0.3?package-id=4fc3928126aefd1a#v2",
+        "pkg:golang/github.com/crc-org/vfkit@v0.1.2-0.20231030102423-f3c783d34420?package-id=9a4f86040fd4c9bf",
+        "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20231011164504-785e29786b46?package-id=2754f6d742c1aaea",
+        "pkg:golang/github.com/cyphar/filepath-securejoin@v0.2.4?package-id=1d9a4060dc7f58d7",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=877523c75d46a3c2",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=5bed9601b6633eee",
+        "pkg:golang/github.com/digitalocean/go-libvirt@v0.0.0-20220804181439-8648fbde413e?package-id=13c1189cf8b54f71",
+        "pkg:golang/github.com/digitalocean/go-qemu@v0.0.0-20230711162256-2e3d0186973e?package-id=f99622502510a79a",
+        "pkg:golang/github.com/disiqueira/gotree@v3.0.2?package-id=ba601b632df342f6#v3",
+        "pkg:golang/github.com/distribution/reference@v0.5.0?package-id=4dba30d4daf39b34",
+        "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible?package-id=e752a6d5b6994595",
+        "pkg:golang/github.com/docker/docker@v24.0.7%2Bincompatible?package-id=45390c3a7cd66a04",
+        "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.0?package-id=9b36de361d1590fc",
+        "pkg:golang/github.com/docker/go-connections@v0.4.1-0.20231031175723-0b8c1f4e07a0?package-id=82021f28ac416c95",
+        "pkg:golang/github.com/docker/go-plugins-helpers@v0.0.0-20211224144127-6eecb7beb651?package-id=dac3e4f2d2513c93",
+        "pkg:golang/github.com/docker/go-units@v0.5.0?package-id=3a5ed86f41f0acf4",
+        "pkg:golang/github.com/fatih/color@v1.15.0?package-id=f455521699a81e89",
+        "pkg:golang/github.com/felixge/httpsnoop@v1.0.3?package-id=55d70b09906d903f",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.9?package-id=43c300e9aa729c9d",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0?package-id=c74c579f441264d1",
+        "pkg:golang/github.com/fsouza/go-dockerclient@v1.10.0?package-id=79aedfb86dbe69e6",
+        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2?package-id=18edcc57ea86b0de",
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0?package-id=5b738c5758770efd",
+        "pkg:golang/github.com/gin-gonic/gin@v1.9.1?package-id=09345e895a858a3c",
+        "pkg:golang/github.com/go-jose/go-jose@v3.0.3?package-id=4b5a858815161aed#v3",
+        "pkg:golang/github.com/go-logr/logr@v1.3.0?package-id=a7ea5bc58bf08192",
+        "pkg:golang/github.com/go-logr/stdr@v1.2.2?package-id=933384e7ba49cf7f",
+        "pkg:golang/github.com/go-ole/go-ole@v1.2.6?package-id=70bf04f6f041e52d",
+        "pkg:golang/github.com/go-openapi/analysis@v0.21.4?package-id=9ea8b9ad52030bed",
+        "pkg:golang/github.com/go-openapi/errors@v0.20.4?package-id=f1e2ed6ce77fd9ee",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6?package-id=7a11fcfebcb03b98",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2?package-id=fea23081cb20edbf",
+        "pkg:golang/github.com/go-openapi/loads@v0.21.2?package-id=4614ac5fd7096390",
+        "pkg:golang/github.com/go-openapi/runtime@v0.26.0?package-id=6fe90c32a6b86cc4",
+        "pkg:golang/github.com/go-openapi/spec@v0.20.9?package-id=928d01ff17d2a67b",
+        "pkg:golang/github.com/go-openapi/strfmt@v0.21.7?package-id=a29e2d3c0ff70597",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.4?package-id=725453dbb9b24889",
+        "pkg:golang/github.com/go-openapi/validate@v0.22.1?package-id=4016181974a83f6a",
+        "pkg:golang/github.com/go-playground/locales@v0.14.1?package-id=5fc0f23885fecc3e",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1?package-id=44e9ee23b30396bc",
+        "pkg:golang/github.com/go-playground/validator@v10.15.5?package-id=6f779696625a0d1c#v10",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0?package-id=5dec6809fb961051",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=7723f23509f6e9c9",
+        "pkg:golang/github.com/go-task/slim-sprig@v0.0.0-20230315185526-52ccab3ef572?package-id=6ed8f14e2691b0ae",
+        "pkg:golang/github.com/goccy/go-json@v0.10.2?package-id=9b95f38549dbb2e7",
+        "pkg:golang/github.com/godbus/dbus@v5.1.1-0.20230522191255-76236955d466?package-id=b7c3e9fcaadfacd7#v5",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2?package-id=3858e45e43a13e41",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da?package-id=9fc12d1b7d0549a3",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2?package-id=580312068be9bbdf",
+        "pkg:golang/github.com/golang/protobuf@v1.5.3?package-id=24106bbd02602711",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=4e7acfd6c9128ec8",
+        "pkg:golang/github.com/google/go-containerregistry@v0.16.1?package-id=257e85f612c158db",
+        "pkg:golang/github.com/google/go-intervals@v0.0.2?package-id=8882646581544332",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0?package-id=555a0046e0839547",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38?package-id=71958bcc23037ded",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20230323073829-e72429f035bd?package-id=0c815505247e335f",
+        "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510?package-id=ab20454707c0ef00",
+        "pkg:golang/github.com/google/uuid@v1.4.0?package-id=fa5cb10169d3b9ca",
+        "pkg:golang/github.com/gorilla/handlers@v1.5.2?package-id=7e5de02f3835a81a",
+        "pkg:golang/github.com/gorilla/mux@v1.8.1?package-id=8205ef61f87399be",
+        "pkg:golang/github.com/gorilla/schema@v1.4.1?package-id=52af4c633255d773",
+        "pkg:golang/github.com/hashicorp/errwrap@v1.1.0?package-id=a8a79647a7a8cf70",
+        "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2?package-id=e1ee33c1617e1009",
+        "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1?package-id=5671cb08a298ac36",
+        "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.7?package-id=28dd885c1b4dbb0e",
+        "pkg:golang/github.com/hashicorp/go-version@v1.3.0?package-id=0a0118ecc74d7c35",
+        "pkg:golang/github.com/hugelgupf/p9@v0.3.1-0.20230822151754-54f5c5530921?package-id=2ffe99043a09760b",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=dc1badc47df18f09",
+        "pkg:golang/github.com/jinzhu/copier@v0.4.0?package-id=a1b1e1aa033edb92",
+        "pkg:golang/github.com/josharian/intern@v1.0.0?package-id=ac618cfcc28857e7",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12?package-id=9a09e60e64762fb5",
+        "pkg:golang/github.com/klauspost/compress@v1.17.3?package-id=1ffa33b600e6ddfd",
+        "pkg:golang/github.com/klauspost/cpuid@v2.2.5?package-id=e41a09d00e6a6abe#v2",
+        "pkg:golang/github.com/klauspost/pgzip@v1.2.6?package-id=07e01f5838373cd6",
+        "pkg:golang/github.com/kr/fs@v0.1.0?package-id=398ff89cd63d2228",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.4?package-id=5281368296cb5ab9",
+        "pkg:golang/github.com/letsencrypt/boulder@v0.0.0-20230213213521-fdfea0d469b6?package-id=258bb3371e4d4027",
+        "pkg:golang/github.com/linuxkit/virtsock@v0.0.0-20220523201153-1a23e78aa7a2?package-id=d3cf194c0733b47d",
+        "pkg:golang/github.com/lufia/plan9stats@v0.0.0-20211012122336-39d0f177ccd0?package-id=8209420d49ba0096",
+        "pkg:golang/github.com/magefile/mage@v1.14.0?package-id=a74f649988594bbd",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7?package-id=8e46bb3723393ca3",
+        "pkg:golang/github.com/manifoldco/promptui@v0.9.0?package-id=7bac44b824f7aa5e",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.13?package-id=55b67c1594f55f24",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.17?package-id=117a3f38e559e9ed",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.20?package-id=b981519f33f50dbc",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.15?package-id=0b6d7d3f1eeeeae4",
+        "pkg:golang/github.com/mattn/go-shellwords@v1.0.12?package-id=83450e3a15e0f99d",
+        "pkg:golang/github.com/mattn/go-sqlite3@v1.14.18?package-id=f5d05835504f4ffd",
+        "pkg:golang/github.com/mdlayher/socket@v0.4.1?package-id=f56f68404baa5b58",
+        "pkg:golang/github.com/mdlayher/vsock@v1.2.1?package-id=2aee1d4c12209cb8",
+        "pkg:golang/github.com/miekg/pkcs11@v1.1.1?package-id=fef9e5fb9971283d",
+        "pkg:golang/github.com/mistifyio/go-zfs@v3.0.1?package-id=2216e1fe48e790da#v3",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.5.0?package-id=7981989d0762c97e",
+        "pkg:golang/github.com/moby/buildkit@v0.12.5?package-id=7b5f00776e604492",
+        "pkg:golang/github.com/moby/patternmatcher@v0.6.0?package-id=64fc68737d4c9f77",
+        "pkg:golang/github.com/moby/sys@v0.7.1?package-id=057e295fbec4aa26#mountinfo",
+        "pkg:golang/github.com/moby/sys@v0.5.0?package-id=ab4a193d344a7505#sequential",
+        "pkg:golang/github.com/moby/term@v0.5.0?package-id=249cb807e979f08f",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd?package-id=909dd10ba0ae8d1c",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2?package-id=e5c6f4996c77bb75",
+        "pkg:golang/github.com/morikuni/aec@v1.0.0?package-id=a30048d529e8332e",
+        "pkg:golang/github.com/nxadm/tail@v1.4.11?package-id=e64a2938860b6dd5",
+        "pkg:golang/github.com/nxadm/tail@v1.4.8?package-id=47dcfdbf536f7c63",
+        "pkg:golang/github.com/oklog/ulid@v1.3.1?package-id=14bd4a60fcd4657e",
+        "pkg:golang/github.com/onsi/ginkgo@v1.16.4?package-id=24c75128dfa61e89",
+        "pkg:golang/github.com/onsi/ginkgo@v1.16.5?package-id=ea9cf0407d9a2eca",
+        "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=49dac0fbe8817737#v2",
+        "pkg:golang/github.com/onsi/ginkgo@v2.13.1?package-id=fc37f0a9e4bf5451#v2",
+        "pkg:golang/github.com/onsi/gomega@v1.10.1?package-id=3b42020f9d5a81e3",
+        "pkg:golang/github.com/onsi/gomega@v1.17.0?package-id=5f42984101810003",
+        "pkg:golang/github.com/onsi/gomega@v1.30.0?package-id=41d0dd66a95fa5b6",
+        "pkg:golang/github.com/opencontainers/go-digest@v1.0.0?package-id=5ed4b0a493e74727",
+        "pkg:golang/github.com/opencontainers/image-spec@v1.1.0-rc5?package-id=de9ca21aabe7af43",
+        "pkg:golang/github.com/opencontainers/runc@v1.1.10?package-id=64a86695e9014382",
+        "pkg:golang/github.com/opencontainers/runtime-spec@v1.1.1-0.20230922153023-c0e90434df2a?package-id=aa338f0fb7818fba",
+        "pkg:golang/github.com/opencontainers/runtime-tools@v0.9.1-0.20230914150019-408c51e934dc?package-id=7906f8e792e1cc23",
+        "pkg:golang/github.com/opencontainers/selinux@v1.11.0?package-id=a7a0602fcd6bf785",
+        "pkg:golang/github.com/openshift/golang-crypto@v0.33.1-0.20250310193910-9003f682e581?package-id=6996b532d4a8353f",
+        "pkg:golang/github.com/openshift/imagebuilder@v1.2.6-0.20231110114814-35a50d57f722?package-id=bf8de9a16e63655a",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.2.0?package-id=efecea730dd143c9",
+        "pkg:golang/github.com/ostreedev/ostree-go@v0.0.0-20210805093236-719684c64e4f?package-id=1ba798c98082554e",
+        "pkg:golang/github.com/pelletier/go-toml@v2.1.0?package-id=9ff575724d7a724d#v2",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=0a3a6cd8ca1aca01",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=33c84874f1b5210b",
+        "pkg:golang/github.com/pkg/sftp@v1.13.6?package-id=eabbcc7d8c6984ad",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=1fa6692567cdbf27",
+        "pkg:golang/github.com/power-devops/perfstat@v0.0.0-20210106213030-5aafc221ea8c?package-id=a6395e79ef6f1b71",
+        "pkg:golang/github.com/proglottis/gpgme@v0.1.3?package-id=93ae51d378faf15e",
+        "pkg:golang/github.com/rivo/uniseg@v0.4.4?package-id=cdf6fb578549fb21",
+        "pkg:golang/github.com/rootless-containers/rootlesskit@v1.1.1?package-id=ed77de7d3dc899c3",
+        "pkg:golang/github.com/russross/blackfriday@v2.1.0?package-id=a77e788e63d883b2#v2",
+        "pkg:golang/github.com/seccomp/libseccomp-golang@v0.10.0?package-id=aabf28e49d8c2c67",
+        "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.7.0?package-id=9282f6c607a104c5",
+        "pkg:golang/github.com/segmentio/ksuid@v1.0.4?package-id=4e38f5d4abe52fee",
+        "pkg:golang/github.com/shirou/gopsutil@v3.23.10?package-id=2ab56a514628a22f#v3",
+        "pkg:golang/github.com/shoenig/go-m1cpu@v0.1.6?package-id=0f39be61a8d01bb0",
+        "pkg:golang/github.com/sigstore/fulcio@v1.4.3?package-id=a86953ca7170fc4f",
+        "pkg:golang/github.com/sigstore/rekor@v1.2.2?package-id=0f5a2aa6a10e7aa0",
+        "pkg:golang/github.com/sigstore/sigstore@v1.7.5?package-id=6e3f094699d393a2",
+        "pkg:golang/github.com/sirupsen/logrus@v1.8.1?package-id=87cdb22161c9af0b",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.2?package-id=b270a6ffdc08cf1d",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.3?package-id=53f9cbdf66773c00",
+        "pkg:golang/github.com/skratchdot/open-golang@v0.0.0-20200116055534-eef842397966?package-id=381940bf58561263",
+        "pkg:golang/github.com/spf13/cobra@v1.8.0?package-id=a0860300672ecf78",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=39c06474ebd4efb7",
+        "pkg:golang/github.com/stefanberger/go-pkcs11uri@v0.0.0-20201008174630-78d3cae3a980?package-id=839631b295cbc658",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0?package-id=af7f5942d8b925ca",
+        "pkg:golang/github.com/stretchr/testify@v1.8.4?package-id=0fb761477437694b",
+        "pkg:golang/github.com/sylabs/sif@v2.15.0?package-id=f36fac4200cf3c5b#v2",
+        "pkg:golang/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437635?package-id=66185a54383ae5aa",
+        "pkg:golang/github.com/tchap/go-patricia@v2.3.1?package-id=2adf2074e170fdc9#v2",
+        "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399?package-id=7d4bf4f63a7946a0",
+        "pkg:golang/github.com/tklauser/go-sysconf@v0.3.12?package-id=3c5259b6aa406e71",
+        "pkg:golang/github.com/tklauser/numcpus@v0.6.1?package-id=44281e1ffe97bad8",
+        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1?package-id=d432df03855789c3",
+        "pkg:golang/github.com/u-root/uio@v0.0.0-20230305220412-3e8cd9d6bf63?package-id=e4a19ce7d7b1e6e4",
+        "pkg:golang/github.com/ugorji/go@v1.2.11?package-id=c9cb6dcf9c79dc0e#codec",
+        "pkg:golang/github.com/ulikunitz/xz@v0.5.11?package-id=b1a8ca736444c227",
+        "pkg:golang/github.com/vbatts/git-validation@v1.2.1?package-id=440ff590c93b898e",
+        "pkg:golang/github.com/vbatts/tar-split@v0.11.5?package-id=84820f43f22105ca",
+        "pkg:golang/github.com/vbauerster/mpb@v8.6.2?package-id=bc0ebef35f07f9bf#v8",
+        "pkg:golang/github.com/vishvananda/netlink@v1.1.1-0.20210916161339-2c39f3491956?package-id=95cb519ea26ea490",
+        "pkg:golang/github.com/vishvananda/netlink@v1.2.1-beta.2?package-id=b6baf9fb07b2dda4",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.0-20200728191858-db3c7e526aae?package-id=94b20f1eeb8f0476",
+        "pkg:golang/github.com/vishvananda/netns@v0.0.4?package-id=a7a991b8910e6c4a",
+        "pkg:golang/github.com/yusufpapurcu/wmi@v1.2.3?package-id=b01a7ad804f424bc",
+        "pkg:golang/go.etcd.io/bbolt@v1.3.8?package-id=8ddfc67c925bba46",
+        "pkg:golang/go.mongodb.org/mongo-driver@v1.11.3?package-id=45ad1a2bf64e4856",
+        "pkg:golang/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352?package-id=926dac54f2666643",
+        "pkg:golang/go.opencensus.io@v0.24.0?package-id=e52c60f016939e73",
+        "pkg:golang/go.opentelemetry.io/otel@v1.19.0?package-id=29308692149d68c9",
+        "pkg:golang/go.opentelemetry.io/otel/metric@v1.19.0?package-id=92c323559045ab0c",
+        "pkg:golang/go.opentelemetry.io/otel/trace@v1.19.0?package-id=945382bc72d2bf58",
+        "pkg:golang/golang.org/x/arch@v0.5.0?package-id=5584feb5bbed2344",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d?package-id=7f336093b19007a3",
+        "pkg:golang/golang.org/x/mod@v0.14.0?package-id=50f03ea7a1559dcf",
+        "pkg:golang/golang.org/x/mod@v0.17.0?package-id=f4e4cd3a95899b98",
+        "pkg:golang/golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781?package-id=a18b635ecdd65e7f",
+        "pkg:golang/golang.org/x/net@v0.25.0?package-id=7a095c99b61b059e",
+        "pkg:golang/golang.org/x/oauth2@v0.14.0?package-id=2340b3d14d1de776",
+        "pkg:golang/golang.org/x/sync@v0.11.0?package-id=2e6466ee8cd262bf",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20191005200804-aed5e4c7ecf9?package-id=d0c04f85415ed4c2",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200217220822-9197077df867?package-id=74753c33555d2eee",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1?package-id=f3b0ba69ab1b2a59",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210112080510-489259a85091?package-id=2cf4e9a79f89427a",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=a389301391b9d958",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8?package-id=6bffef882ecac407",
+        "pkg:golang/golang.org/x/sys@v0.14.0?package-id=f25f45b44e71443e",
+        "pkg:golang/golang.org/x/sys@v0.30.0?package-id=e39ce661be9bf474",
+        "pkg:golang/golang.org/x/term@v0.29.0?package-id=1815e1dab70318d7",
+        "pkg:golang/golang.org/x/text@v0.22.0?package-id=a51b0b1ed0058137",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20201224043029-2b0845dc783e?package-id=ce137c87f0b04b31",
+        "pkg:golang/golang.org/x/tools@v0.15.0?package-id=731cdf76d49ab47e",
+        "pkg:golang/golang.org/x/tools@v0.21.1-0.20240508182429-e35e4ccd0d2d?package-id=7f5f03ba9446ff06",
+        "pkg:golang/google.golang.org/appengine@v1.6.8?package-id=f1a37ca4d5341a88",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20230920204549-e6e6cdab5c13?package-id=d1ff76b06e918dd5#rpc",
+        "pkg:golang/google.golang.org/grpc@v1.58.3?package-id=0536ecf5c701b428",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0?package-id=d5cf1e90e1d3a922",
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405?package-id=6ec4f733e364ddb3",
+        "pkg:golang/gopkg.in/go-jose/go-jose.v2@v2.6.3?package-id=3d2ed6cd7015c40e",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1?package-id=e888dc297812f467",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=7de6255c8f2da4b5",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7?package-id=ef4f4519d54f2d19",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=95965a2b35c782b7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=5f213a346a9e4eab",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=bd0fda54a493606a",
+        "pkg:golang/k8s.io/kubernetes@v1.28.4?package-id=3e5804f8cb681af1",
+        "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=52cb6c48c30f8a48",
+        "pkg:golang/tags.cncf.io/container-device-interface@v0.6.2?package-id=05eacda07687a438",
+        "pkg:golang/tags.cncf.io/container-device-interface/specs-go@v0.6.0?package-id=aebbffdf383737a2",
+        "432c2d15dd3c142f",
+        "6752475cd6b8aaa0",
+        "d62a3347df49026c",
+        "b845a6ade1fe0acd",
+        "9b6813eff6b49da6",
+        "9bce1f6d3d7d8556",
+        "a6f89bb2ae66096d",
+        "5d00cdf4c5e10ed9",
+        "834e53e812a67542",
+        "eb7c0eac2188ec99",
+        "4c9d75aae76411dd",
+        "b8a3106977fb6164"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=aarch64",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@v3.44.0?package-id=c56c3dedd9c2e801#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=c56c3dedd9c2e801#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=aarch64",
+      "provides": [
+        "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=72333f468fbbd985#plugins/meta/dnsname",
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=72333f468fbbd985#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=aarch64",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@v3.44.0?package-id=20594327197779e5#cmd/podman",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=db5b4781160ac247#cmd/quadlet",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f66d3ff41d77cc3e#cmd/rootlessport",
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2",
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31",
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34",
+        "3e7c38694c0bef3c",
+        "722eebec347dccfd",
+        "d9b53bd6ae5a52f9"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=db5b4781160ac247#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f66d3ff41d77cc3e#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=20594327197779e5#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=ppc64le",
+      "provides": [
+        "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=596bc2986195ad9a#plugins/meta/dnsname",
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=596bc2986195ad9a#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=ppc64le",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@v3.44.0?package-id=a0ecf4e4efa372b6#cmd/podman",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=5b6d17b611edf5a7#cmd/quadlet",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=e74f595be6c58439#cmd/rootlessport",
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2",
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31",
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34",
+        "3e7c38694c0bef3c",
+        "722eebec347dccfd",
+        "d9b53bd6ae5a52f9"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=5b6d17b611edf5a7#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=e74f595be6c58439#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@v3.44.0?package-id=a0ecf4e4efa372b6#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=ppc64le",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=77931425bae542d7#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=77931425bae542d7#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=x86_64",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=b448c44daea5402c#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=b448c44daea5402c#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=x86_64",
+      "provides": [
+        "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=074bb61871d3bb41#plugins/meta/dnsname",
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname@%28devel%29?package-id=074bb61871d3bb41#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=x86_64",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=0b7acbecbb7f4425#cmd/podman",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c7debbb08312f127#cmd/quadlet",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c0b2a359da0f262f#cmd/rootlessport",
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2",
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31",
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34",
+        "3e7c38694c0bef3c",
+        "722eebec347dccfd",
+        "d9b53bd6ae5a52f9"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=0b7acbecbb7f4425#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c0b2a359da0f262f#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=c7debbb08312f127#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman@4.9.4-18.el9_4?arch=s390x",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@v4.0.0?package-id=7d23ac3003235523#cmd/podman",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f2376156f28cba3a#cmd/quadlet",
+        "pkg:golang/github.com/containers/podman@%28devel%29?package-id=8be2b0da4a991d7d#cmd/rootlessport",
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2",
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31",
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34",
+        "3e7c38694c0bef3c",
+        "722eebec347dccfd",
+        "d9b53bd6ae5a52f9"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=8be2b0da4a991d7d#cmd/rootlessport",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fbabf79881324a34"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@%28devel%29?package-id=f2376156f28cba3a#cmd/quadlet",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=b04b8f8affba8b31"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@v4.0.0?package-id=7d23ac3003235523#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=88a5a801ad8362d2"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-remote@4.9.4-18.el9_4?arch=s390x",
+      "provides": [
+        "pkg:golang/github.com/containers/podman@v4.0.0?package-id=a941c94077d4e3c3#cmd/podman",
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e",
+        "621841594022a85c"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/podman@v4.0.0?package-id=a941c94077d4e3c3#cmd/podman",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=179eb130386a396e"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/podman-plugins@4.9.4-18.el9_4?arch=s390x",
+      "provides": [
+        "pkg:golang/github.com/containers/dnsname@v0.4.0?package-id=329281ef4c76fc90#plugins/meta/dnsname",
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85",
+        "e16048dc26ffff58"
+      ],
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/containers/dnsname@v0.4.0?package-id=329281ef4c76fc90#plugins/meta/dnsname",
+      "dependsOn": [
+        "pkg:golang/stdlib@1.21.13?package-id=fecc49d2f9e4ee85"
+      ]
+    }
+  ],
+  "serialNumber": "urn:uuid:351729d4-9ada-4e40-aa29-a6f82ef8d41c"
+}

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -69,7 +69,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":4
+      "total":6
     })));
 
     // purl partial search latest
@@ -81,7 +81,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":8
+      "total":5
     })));
     Ok(())
 }

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -58,7 +58,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(64, response["total"]);
+    assert_eq!(8, response["total"]);
 
     // purl partial search latest
     let uri: String = format!(
@@ -69,7 +69,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":16
+      "total":4
     })));
 
     // purl partial search latest
@@ -81,7 +81,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":19
+      "total":8
     })));
     Ok(())
 }
@@ -210,7 +210,7 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(response["total"], 30);
+    assert_eq!(response["total"], 22);
 
     // purl partial latest search
     let uri: String = format!(
@@ -219,7 +219,7 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(response["total"], 8);
+    assert_eq!(response["total"], 6);
 
     // name exact search
     let uri: String = format!(
@@ -228,7 +228,7 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(response["total"], 30);
+    assert_eq!(response["total"], 22);
 
     // latest name exact search
     let uri: String = format!(
@@ -237,7 +237,7 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(response["total"], 8);
+    assert_eq!(response["total"], 6);
 
     Ok(())
 }

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -1,4 +1,5 @@
 use crate::test::caller;
+
 use actix_http::Request;
 use actix_web::test::TestRequest;
 use serde_json::{Value, json};
@@ -238,5 +239,102 @@ async fn resolve_rh_variant_latest_filter_middleware_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     assert_eq!(response["total"], 8);
 
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn test_tc2606(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    ctx.ingest_documents([
+        "cyclonedx/rh/latest_filters/TC-2606/1F5B983228BA420.json",
+        "cyclonedx/rh/latest_filters/TC-2606/401A4500E49D44D.json",
+        "cyclonedx/rh/latest_filters/TC-2606/74092FCBFD294FC.json",
+        "cyclonedx/rh/latest_filters/TC-2606/80138DC9368C4D3.json",
+        "cyclonedx/rh/latest_filters/TC-2606/B67E38F00200413.json",
+        "cyclonedx/rh/latest_filters/TC-2606/CE8E7B92C4BD452.json",
+    ])
+    .await?;
+
+    let uri: String = "/api/v2/analysis/component".to_string();
+    let request: Request = TestRequest::get().uri(&uri).to_request();
+    let response = app.call_service(request).await;
+    assert_eq!(200, response.response().status());
+
+    // latest cpe search
+    let uri: String = format!(
+        "/api/v2/analysis/latest/component/{}?descendants=1",
+        urlencoding::encode("cpe:/a:redhat:rhel_eus:9.4::appstream")
+    );
+    let request: Request = TestRequest::get().uri(&uri).to_request();
+    let response: Value = app.call_and_read_body_json(request).await;
+    log::info!("{:#?}", response);
+    assert_eq!(response["total"], 2);
+
+    assert!(response.contains_subset(json!(
+            {
+      "items": [
+        {
+          "node_id": "RHEL-9.4.0.Z.EUS",
+          "name": "Red Hat Enterprise Linux 9.4 Extended Update Support",
+          "version": "RHEL-9.4.0.Z.EUS",
+          "published": "2025-06-09 10:18:20+00",
+          "document_id": "urn:uuid:501c2eae-1514-3252-a7ce-b6beed26fe62/1",
+          "descendants": [
+            {
+              "node_id": "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src",
+              "purl": [
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/grafana@9.2.10-23.el9_4?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4"
+              ],
+              "name": "grafana",
+              "version": "9.2.10-23.el9_4",
+              "published": "2025-06-09 10:18:20+00",
+              "document_id": "urn:uuid:501c2eae-1514-3252-a7ce-b6beed26fe62/1",
+              "relationship": "generates"
+            }
+          ],
+        },
+        {
+          "node_id": "RHEL-9.4.0.Z.EUS",
+          "name": "Red Hat Enterprise Linux 9.4 Extended Update Support",
+          "version": "RHEL-9.4.0.Z.EUS",
+          "published": "2025-06-09 03:29:53+00",
+          "document_id": "urn:uuid:b84b0b69-6d39-3b23-86c6-5c258fc730b7/1",
+          "descendants": [
+            {
+              "node_id": "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+              "purl": [
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-s390x-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-ppc64le-appstream-e4s-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-aus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-x86_64-appstream-eus-source-rpms__9_DOT_4",
+                "pkg:rpm/redhat/podman@4.9.4-18.el9_4.1?arch=src&repository_id=rhel-9-for-aarch64-appstream-eus-source-rpms__9_DOT_4"
+              ],
+              "name": "podman",
+              "version": "4.9.4-18.el9_4.1",
+              "published": "2025-06-09 03:29:53+00",
+              "document_id": "urn:uuid:b84b0b69-6d39-3b23-86c6-5c258fc730b7/1",
+              "relationship": "generates"
+            }
+          ],
+        }
+      ],
+      "total": 2
+    })));
     Ok(())
 }

--- a/modules/analysis/src/endpoints/tests/rh_variant.rs
+++ b/modules/analysis/src/endpoints/tests/rh_variant.rs
@@ -675,7 +675,7 @@ async fn resolve_rh_variant_image_variant_cdx_external_reference_ancestors(
             "document_id": "urn:uuid:aa6b5176-94f2-4c73-90bd-613fb1e560e8/1",
             "ancestors":[
             {
-                "node_id": "2b8dc6da540ea58f",
+                "node_id": "ose-openstack-cinder-csi-driver-operator-container_s390x",
                 "purl": [
                 "pkg:oci/ose-openstack-cinder-csi-driver-operator@sha256:d3d96f71664efb8c2bd9290b8e1ca9c9b93a54cecb266078c4d954a2e9c05d4d?arch=s390x&os=linux&tag=v4.15.0-202501280037.p0.gd0c2407.assembly.stream.el8"
                 ],

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -395,7 +395,10 @@ impl InnerService {
         let latest_sbom_ids: Vec<_> = match query {
             GraphQuery::Component(ComponentReference::Id(node_id)) => {
                 let subquery = find::<sbom_node::Entity>()
-                    .left_join(sbom_package::Entity)
+                    .join(
+                        JoinType::LeftJoin,
+                        sbom_node::Relation::PackageBySbomId.def(),
+                    )
                     .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
                     .join(
                         JoinType::LeftJoin,
@@ -407,7 +410,10 @@ impl InnerService {
             }
             GraphQuery::Component(ComponentReference::Name(name)) => {
                 let subquery = find::<sbom_node::Entity>()
-                    .left_join(sbom_package::Entity)
+                    .join(
+                        JoinType::LeftJoin,
+                        sbom_node::Relation::PackageBySbomId.def(),
+                    )
                     .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
                     .join(
                         JoinType::LeftJoin,
@@ -419,7 +425,10 @@ impl InnerService {
             }
             GraphQuery::Component(ComponentReference::Purl(purl)) => {
                 let subquery = find::<sbom_package_purl_ref::Entity>()
-                    .left_join(sbom_package::Entity)
+                    .join(
+                        JoinType::LeftJoin,
+                        sbom_node::Relation::PackageBySbomId.def(),
+                    )
                     .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
                     .join(
                         JoinType::LeftJoin,
@@ -449,7 +458,10 @@ impl InnerService {
             }
             GraphQuery::Query(query) => {
                 let subquery = find::<sbom_node::Entity>()
-                    .join(JoinType::Join, sbom_node::Relation::Package.def())
+                    .join(
+                        JoinType::LeftJoin,
+                        sbom_node::Relation::PackageBySbomId.def(),
+                    )
                     .join(JoinType::LeftJoin, sbom_package::Relation::Purl.def())
                     .join(JoinType::LeftJoin, sbom_package::Relation::Cpe.def())
                     .join(

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -196,21 +196,42 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
     {
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
-            match sbom_node_checksum::Entity::find()
-                .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-                .all(connection)
-                .await
-            {
-                Ok(matches) => matches
-                    .into_iter()
-                    .next() // just return the first
-                    .map(|matched_model| ResolvedSbom {
-                        sbom_id: matched_model.sbom_id,
-                        node_id: matched_model.node_id,
-                    }),
-                _ => None,
+
+            // TODO: we need to have slightly different behaviour - depending on if encoded from rh cdx or rh spdx.
+            //       no doubt there are probably better ways to achieve this then what we have here.
+            if sbom_external_node_ref.starts_with("SPDXRef") {
+                match sbom_node_checksum::Entity::find()
+                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                    .all(connection)
+                    .await
+                {
+                    Ok(matches) => matches
+                        .into_iter()
+                        .next() // just return the first
+                        .map(|matched_model| ResolvedSbom {
+                            sbom_id: matched_model.sbom_id,
+                            node_id: matched_model.node_id,
+                        }),
+                    _ => None,
+                }
+            } else {
+                match sbom_node_checksum::Entity::find()
+                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                    .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
+                    .all(connection)
+                    .await
+                {
+                    Ok(matches) => matches
+                        .into_iter()
+                        .next() // just return the first
+                        .map(|matched_model| ResolvedSbom {
+                            sbom_id: matched_model.sbom_id,
+                            node_id: matched_model.node_id,
+                        }),
+                    _ => None,
+                }
             }
         }
         _ => None,
@@ -232,22 +253,44 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
     {
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
-            match sbom_node_checksum::Entity::find()
-                .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-                .all(connection)
-                .await
-            {
-                Ok(matches) => matches
-                    .into_iter()
-                    .map(|matched| ResolvedSbom {
-                        sbom_id: matched.sbom_id,
-                        node_id: matched.node_id,
-                    })
-                    .collect(),
 
-                _ => vec![],
+            // TODO: we need to have slightly different behaviour - depending on if encoded from rh cdx or rh spdx.
+            //       no doubt there are probably better ways to achieve this then what we have here.
+            if sbom_external_node_ref.starts_with("SPDXRef") {
+                match sbom_node_checksum::Entity::find()
+                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                    .all(connection)
+                    .await
+                {
+                    Ok(matches) => matches
+                        .into_iter()
+                        .map(|matched| ResolvedSbom {
+                            sbom_id: matched.sbom_id,
+                            node_id: matched.node_id,
+                        })
+                        .collect(),
+
+                    _ => vec![],
+                }
+            } else {
+                match sbom_node_checksum::Entity::find()
+                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                    .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
+                    .all(connection)
+                    .await
+                {
+                    Ok(matches) => matches
+                        .into_iter()
+                        .map(|matched| ResolvedSbom {
+                            sbom_id: matched.sbom_id,
+                            node_id: matched.node_id,
+                        })
+                        .collect(),
+
+                    _ => vec![],
+                }
             }
         }
         _ => {

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -197,7 +197,8 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
 
-            // TODO: we need to have slightly different behaviour - depending on if encoded from rh cdx or rh spdx.
+            // TODO: Resolution of external sbom is different between spdx/cdx so we need to have
+            //       slightly different heuristics - depending on if encoded from rh cdx or rh spdx.
             //       no doubt there are probably better ways to achieve this then what we have here.
             if sbom_external_node_ref.starts_with("SPDXRef") {
                 match sbom_node_checksum::Entity::find()
@@ -254,7 +255,8 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
 
-            // TODO: we need to have slightly different behaviour - depending on if encoded from rh cdx or rh spdx.
+            // TODO: Resolution of external sbom is different between spdx/cdx so we need to have
+            //       slightly different heuristics - depending on if encoded from rh cdx or rh spdx.
             //       no doubt there are probably better ways to achieve this then what we have here.
             if sbom_external_node_ref.starts_with("SPDXRef") {
                 match sbom_node_checksum::Entity::find()

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -701,7 +701,7 @@ fn acyclic(id: &str, graph: &Arc<PackageGraph>) -> bool {
         // FIXME: we need a better strategy handling such errors
         let start = graph.node_weight(start);
         let end = graph.node_weight(end);
-        log::debug!(
+        log::warn!(
             "analysis graph of sbom {id} has circular references (detected: {start:?} -> {end:?})!",
         );
     }


### PR DESCRIPTION
There were a few issues here to fix:

- [x]  loosen the requirement to have duplicate bom-refs in cdx (which is invalid cdx!), specifically on the metadata.component
- [x]  ensure cpe queries actually returned all top level roots
- [x]  added test for TC-2606
- [x] review/fix existing cdx tests
- [x] review/fix existing spdx tests

(fixes TC-2606)