### PR TITLE
fix: remove 'runs-on' from 'backport' CI job

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -12,8 +12,6 @@ on:
 
 jobs:
   cherry_pick_job:
-    runs-on: ubuntu-24.04
-
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
Reusable workflow call is done by using `uses` and `runs-on` isn't allowed so I'm removing it (ref. https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow)