### PR TITLE
ci: Add a filter for docs avoiding unnecessary run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,12 @@ jobs:
 
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+      - uses: dorny/paths-filter@v3
+        id: doc_filter
+        with:
+          filters: |
+            docs:
+              - 'docs/book/**'
 
       - name: Cache Theseus Postgresql Installation
         uses: actions/cache@v4
@@ -88,6 +94,7 @@ jobs:
               exit 1
           fi
       - name: Check the docs
+        if: steps.doc_filter.outputs.docs == 'true'
         run: |
           cd docs/book
           npm ci


### PR DESCRIPTION
Run `npm ci` and `make all` only if `docs/book` was changed