### PR TITLE
fix: add support for golang versions with 'v' prefix

### DIFF
--- a/etc/test-data/osv/GHSA-69ch-w2m2-3vjp.json
+++ b/etc/test-data/osv/GHSA-69ch-w2m2-3vjp.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-69ch-w2m2-3vjp",
+  "modified": "2025-05-16T02:08:37Z",
+  "published": "2022-10-14T19:00:40Z",
+  "aliases": [
+    "CVE-2022-32149"
+  ],
+  "summary": "golang.org/x/text/language Denial of service via crafted Accept-Language header",
+  "details": "The BCP 47 tag parser has quadratic time complexity due to inherent aspects of its design. Since the parser is, by design, exposed to untrusted user input, this can be leveraged to force a program to consume significant time parsing Accept-Language headers. The parser cannot be easily rewritten to fix this behavior for various reasons. Instead the solution implemented in this CL is to limit the total complexity of tags passed into ParseAcceptLanguage by limiting the number of dashes in the string to 1000. This should be more than enough for the majority of real world use cases, where the number of tags being sent is likely to be in the single digits.\n\n### Specific Go Packages Affected\ngolang.org/x/text/language",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "golang.org/x/text"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.3.8"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32149"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang/go/issues/56152"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/golang/text/commit/434eadcdbc3b0256971992e8c70027278364c72c"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/golang/text"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/cl/442235"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/issue/56152"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/g/golang-announce/c/-hjNw559_tE/m/KlGTfid5CAAJ"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pkg.go.dev/vuln/GO-2022-1059"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.netapp.com/advisory/ntap-20230203-0006"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-772"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2022-10-28T20:11:26Z",
+    "nvd_published_at": "2022-10-14T15:15:00Z"
+  }
+}

--- a/etc/test-data/osv/GHSA-ppp9-7jff-5vj2.json
+++ b/etc/test-data/osv/GHSA-ppp9-7jff-5vj2.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-ppp9-7jff-5vj2",
+  "modified": "2025-04-14T22:09:42Z",
+  "published": "2022-12-26T06:30:22Z",
+  "aliases": [
+    "CVE-2021-38561"
+  ],
+  "summary": "golang.org/x/text/language Out-of-bounds Read vulnerability",
+  "details": "golang.org/x/text/language in golang.org/x/text before 0.3.7 can panic with an out-of-bounds read during BCP 47 language tag parsing. Index calculation is mishandled. If parsing untrusted user input, this can be used as a vector for a denial-of-service attack.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "golang.org/x/text"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0.3.7"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-38561"
+    },
+    {
+      "type": "WEB",
+      "url": "https://deps.dev/advisory/OSV/GO-2021-0113"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.dev/cl/340830"
+    },
+    {
+      "type": "WEB",
+      "url": "https://go.googlesource.com/text/+/383b2e75a7a4198c42f8f87833eefb772868a56f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://groups.google.com/g/golang-announce"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pkg.go.dev/golang.org/x/text/language"
+    },
+    {
+      "type": "WEB",
+      "url": "https://pkg.go.dev/vuln/GO-2021-0113"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-125"
+    ],
+    "severity": "HIGH",
+    "github_reviewed": true,
+    "github_reviewed_at": "2023-01-09T20:02:12Z",
+    "nvd_published_at": "2022-12-26T06:15:00Z"
+  }
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -28,6 +28,7 @@ mod m0001070_vulnerability_scores;
 mod m0001100_remove_get_purl;
 mod m0001110_sbom_node_checksum_indexes;
 mod m0001120_sbom_external_node_indexes;
+mod m0001130_gover_cmp;
 
 pub struct Migrator;
 
@@ -59,6 +60,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001100_remove_get_purl::Migration),
             Box::new(m0001110_sbom_node_checksum_indexes::Migration),
             Box::new(m0001120_sbom_external_node_indexes::Migration),
+            Box::new(m0001130_gover_cmp::Migration),
         ]
     }
 }

--- a/migration/src/m0001130_gover_cmp.rs
+++ b/migration/src/m0001130_gover_cmp.rs
@@ -1,0 +1,27 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0001130_gover_cmp_fns/gover_cmp_up.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(include_str!("m0001130_gover_cmp_fns/gover_cmp_down.sql"))
+            .await
+            .map(|_| ())?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m0001130_gover_cmp_fns/gover_cmp_down.sql
+++ b/migration/src/m0001130_gover_cmp_fns/gover_cmp_down.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+begin
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            -- Git is git, and hard.
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            -- Semver is semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            -- RubyGems claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            -- NPM claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            -- Golang claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            -- NuGet claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            -- Just check if it is equal
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            -- Look at me! I'm an RPM! I'm special!
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            -- Look at me! I'm a Maven! I'm kinda special!
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            -- Python versioning
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            -- Packagist PHP strongly encourages semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            -- Erlang Hex claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            -- Swift Package Manager claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            -- Pub Dart Flutter claims to be semver
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;
+
+DROP FUNCTION IF EXISTS public.golang_version_matches(text, public.version_range);

--- a/migration/src/m0001130_gover_cmp_fns/gover_cmp_up.sql
+++ b/migration/src/m0001130_gover_cmp_fns/gover_cmp_up.sql
@@ -1,0 +1,80 @@
+--
+-- Name: golang_version_matches(text, public.version_range); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.golang_version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+DECLARE
+    norm_version text := version_p;
+BEGIN
+    -- Strip leading 'v' from version_p if present
+    IF version_p LIKE 'v%' THEN
+        norm_version := substring(version_p FROM 2);
+    END IF;
+
+    RETURN semver_version_matches(norm_version, range_p);
+END
+$$;
+
+
+
+--
+-- Name: version_matches(text, public.version_range); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION public.version_matches(version_p text, range_p public.version_range) RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+declare
+begin
+    -- for an authoritative list of support schemes, see the enum
+    -- `trustify_entity::version_scheme::VersionScheme`
+    return case
+        when range_p.version_scheme_id = 'git'
+            -- Git is git, and hard.
+            then gitver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'semver'
+            -- Semver is semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'gem'
+            -- RubyGems claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'npm'
+            -- NPM claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'golang'
+            -- Golang claims to be semver
+            then golang_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'nuget'
+            -- NuGet claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'generic'
+            -- Just check if it is equal
+            then generic_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'rpm'
+            -- Look at me! I'm an RPM! I'm special!
+            then rpmver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'maven'
+            -- Look at me! I'm a Maven! I'm kinda special!
+            then maven_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'python'
+            -- Python versioning
+            then python_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'packagist'
+            -- Packagist PHP strongly encourages semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'hex'
+            -- Erlang Hex claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'swift'
+            -- Swift Package Manager claims to be semver
+            then semver_version_matches(version_p, range_p)
+        when range_p.version_scheme_id = 'pub'
+            -- Pub Dart Flutter claims to be semver
+            then semver_version_matches(version_p, range_p)
+        else
+            false
+    end;
+end
+$$;

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -463,8 +463,13 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
-    ctx.ingest_documents(["osv/RUSTSEC-2021-0079.json", "osv/GHSA-2ccf-ffrj-m4qw.json"])
-        .await?;
+    ctx.ingest_documents([
+        "osv/RUSTSEC-2021-0079.json",
+        "osv/GHSA-2ccf-ffrj-m4qw.json",
+        "osv/GHSA-69ch-w2m2-3vjp.json",
+        "osv/GHSA-ppp9-7jff-5vj2.json",
+    ])
+    .await?;
 
     let result = service.analyze_purls(Vec::<&str>::new(), &ctx.db).await?;
 
@@ -476,8 +481,10 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     }
 
     let expected = [
-        "pkg:npm/%40fastify/passport@1.0.0", // ECOSYSTEM:affected
-        "pkg:cargo/hyper@0.14.9",            // SEMVER:affected - no namespace
+        "pkg:npm/%40fastify/passport@1.0.0",   // ECOSYSTEM:affected
+        "pkg:cargo/hyper@0.14.9",              // SEMVER:affected - no namespace
+        "pkg:golang/golang.org/x/text@v0.3.6", // GOLANG:affected
+        "pkg:golang/golang.org/x/text@0.3.6",  // SEMVER:affected
     ];
 
     let not_found = [


### PR DESCRIPTION
Go ecosystem often uses 'v' prefix before semver formatted versions

https://go.dev/ref/mod#versions

On the other hand, OSV and other adivsories are reporting pure semver versions. Newly introduced golang_version_matches pgsql function, strips the prefix if it is present and then continues with semver match.