### PR TITLE
fix(storage): clean up the returned content encoding

### DIFF
--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -171,8 +171,13 @@ impl StorageBackend for S3Backend {
 
         match req.send().await {
             Ok(resp) => {
-                let compression = match resp.content_encoding() {
-                    Some(encoding) => Compression::from_str(encoding)?,
+                let content_encoding = resp.content_encoding();
+                log::debug!("Content encoding: {content_encoding:?}");
+
+                let compression = match content_encoding {
+                    Some(encoding) => Compression::from_str(encoding).inspect_err(|_| {
+                        log::warn!("Content encoding: '{encoding}' not supported")
+                    })?,
                     None => Compression::None,
                 };
 


### PR DESCRIPTION
ODF seems to return `aws-chunked` as encoding type, which should not
be stored or returned. We filter this out, not failing in the next
step, where we decode this encoding into the compression enum variant.

Closes: #1850

## Summary by Sourcery

Sanitize and filter S3 response content encodings by removing the `aws-chunked` token, add logging for cleaned encodings, and handle unsupported encodings gracefully.

Bug Fixes:
- Filter out the unwanted `aws-chunked` encoding from S3 object metadata to prevent invalid compression parsing

Enhancements:
- Introduce a `cleanup` utility to sanitize the `content-encoding` header and log its value
- Log a warning for unsupported encodings instead of failing outright

Tests:
- Add unit tests for the `cleanup` function covering various encoding combinations