### PR TITLE
fix(fundamental): change response of analyse purl endpoint

### DIFF
--- a/modules/fundamental/src/ai/service/tools/cve_info.rs
+++ b/modules/fundamental/src/ai/service/tools/cve_info.rs
@@ -59,6 +59,7 @@ The input should be the partial or full name of the Vulnerability to search for.
         )
     }
 
+    #[allow(deprecated)]
     async fn run(&self, input: Value) -> Result<String, Box<dyn Error>> {
         let service = &self.service;
 

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -1,0 +1,35 @@
+use crate::{advisory::model::AdvisoryHead, vulnerability::model::VulnerabilityHead};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, ops::Deref};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisRequest {
+    pub purls: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisDetails {
+    #[serde(flatten)]
+    pub head: VulnerabilityHead,
+
+    /// Map of status to advisories
+    ///
+    /// Allowed status values:
+    /// - `affected`: Advisories that affect the package
+    /// - `under_investigation`: Advisories that might affect the package, but the investigation is still ongoing
+    ///
+    /// Additional status values may be added in the future; see API documentation for details.
+    pub status: BTreeMap<String, Vec<AdvisoryHead>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisResponse(pub BTreeMap<String, Vec<AnalysisDetails>>);
+
+impl Deref for AnalysisResponse {
+    type Target = BTreeMap<String, Vec<AnalysisDetails>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/modules/fundamental/src/vulnerability/model/details/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/details/mod.rs
@@ -20,10 +20,12 @@ pub struct VulnerabilityDetails {
 
     /// Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.
     #[schema(required)]
+    #[deprecated(note = "This is no longer supported")]
     pub average_severity: Option<Severity>,
 
     /// Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
     #[schema(required)]
+    #[deprecated(note = "This is no longer supported")]
     pub average_score: Option<f64>,
 
     /// Advisories addressing this vulnerability, if any.

--- a/modules/fundamental/src/vulnerability/model/mod.rs
+++ b/modules/fundamental/src/vulnerability/model/mod.rs
@@ -1,13 +1,14 @@
+mod analyze;
 mod details;
 mod summary;
 
+pub use analyze::*;
 pub use details::*;
 pub use summary::*;
 
 use crate::Error;
 use sea_orm::{ColumnTrait, ConnectionTrait, ModelTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, ops::Deref};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::memo::Memo;
@@ -133,21 +134,5 @@ impl VulnerabilityHead {
             released: advisory_vulnerability.release_date,
             cwes: advisory_vulnerability.cwes.clone().unwrap_or_default(),
         }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisRequest {
-    pub purls: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
-pub struct AnalysisResponse(HashMap<String, Vec<VulnerabilityDetails>>);
-
-impl Deref for AnalysisResponse {
-    type Target = HashMap<String, Vec<VulnerabilityDetails>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,21 +1,30 @@
-use std::{collections::HashMap, str::FromStr};
-
 use crate::{
     Error,
-    vulnerability::model::{VulnerabilityDetails, VulnerabilitySummary},
+    advisory::model::AdvisoryHead,
+    vulnerability::model::{
+        AnalysisDetails, AnalysisResponse, VulnerabilityDetails, VulnerabilityHead,
+        VulnerabilitySummary,
+    },
 };
 use futures_util::{TryFutureExt, TryStreamExt};
-use sea_orm::{EntityTrait, Statement, StreamTrait, prelude::*};
+use sea_orm::{
+    EntityTrait, FromQueryResult, Statement, StreamTrait, TryGetableFromJson, prelude::*,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
 use tracing::instrument;
 use trustify_common::{
     db::{
         limiter::LimiterTrait,
         query::{Columns, Filtering, Query},
     },
+    memo::Memo,
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
 };
-use trustify_entity::vulnerability;
+use trustify_entity::{advisory, vulnerability};
 use trustify_module_ingestor::common::Deprecation;
 
 #[derive(Default)]
@@ -89,10 +98,35 @@ impl VulnerabilityService {
         &self,
         purls: impl IntoIterator<Item = impl AsRef<str>>,
         connection: &C,
-    ) -> Result<HashMap<String, Vec<VulnerabilityDetails>>, Error>
+    ) -> Result<AnalysisResponse, Error>
     where
         C: ConnectionTrait + StreamTrait,
     {
+        let query = Self::build_query(purls, connection)?;
+
+        let stmt = Statement::from_string(connection.get_database_backend(), query);
+        log::debug!("Analyzing using: {stmt}");
+        let result = connection.stream(stmt).map_err(Error::from).await?;
+        let result = result
+            .map_err(Error::from)
+            .and_then(|row| Self::row_to_vuln(row, connection))
+            .try_fold(
+                BTreeMap::new(),
+                |mut acc: BTreeMap<String, Vec<AnalysisDetails>>, (requested_purl, head)| async {
+                    acc.entry(requested_purl).or_default().push(head);
+                    Ok(acc)
+                },
+            )
+            .await?;
+
+        Ok(AnalysisResponse(result))
+    }
+
+    /// Build the query for finding matching vulnerabilities
+    fn build_query(
+        purls: impl IntoIterator<Item = impl AsRef<str>>,
+        connection: &impl ConnectionTrait,
+    ) -> Result<String, Error> {
         let query = purls
             .into_iter()
             .map(|p| {
@@ -107,96 +141,154 @@ impl VulnerabilityService {
                             sql,
                             [namespace.into()],
                         )
+                        .to_string()
                     }
-                    None => Statement::from_string(
-                        connection.get_database_backend(),
-                        "base_purl.namespace IS NULL",
-                    ),
+                    None => "base_purl.namespace IS NULL".to_string(),
                 };
 
-                let values = [
-                    p.into(),
-                    purl.name.into(),
-                    purl.ty.into(),
-                    purl.version.ok_or_else(|| PurlErr::MissingVersion(p.to_owned()))?.into(),
-                ];
-                let sql = format!(r#"
-                  SELECT $1 as requested_purl,
-                    vulnerability.id, vulnerability.title, vulnerability.reserved,
-                    vulnerability.published, vulnerability.modified, vulnerability.withdrawn, vulnerability.cwes
-                  FROM base_purl
-                    LEFT JOIN purl_status ON base_purl.id = purl_status.base_purl_id
-                    INNER JOIN version_range ON purl_status.version_range_id = version_range.id
-                    LEFT JOIN vulnerability ON purl_status.vulnerability_id = vulnerability.id
-                    INNER JOIN status ON purl_status.status_id = status.id
-                  WHERE {ns_condition}
-                    AND base_purl.name = $2
-                    AND base_purl.type = $3
-                    AND version_matches($4, version_range.*) = TRUE
-                    AND status.slug != 'fixed'"#);
-                let query =
-                    Statement::from_sql_and_values(connection.get_database_backend(), &sql, values);
+                let sql = format!(
+                    r#"
+SELECT
+  $1 as requested_purl,
+  vulnerability.id,
+  vulnerability.title,
+  vulnerability.reserved,
+  vulnerability.published,
+  vulnerability.modified,
+  vulnerability.withdrawn,
+  vulnerability.cwes,
+  jsonb_agg(
+    jsonb_build_object(
+      'status', status.slug,
+      'id', purl_status.advisory_id
+    )
+  ) AS advisories
+FROM base_purl
+  LEFT JOIN purl_status ON base_purl.id = purl_status.base_purl_id
+  INNER JOIN version_range ON purl_status.version_range_id = version_range.id
+  LEFT JOIN vulnerability ON purl_status.vulnerability_id = vulnerability.id
+  INNER JOIN status ON purl_status.status_id = status.id
+WHERE {ns_condition}
+  AND base_purl.name = $2
+  AND base_purl.type = $3
+  AND version_matches($4, version_range.*) = TRUE
+  AND status.slug NOT IN (
+    'fixed',
+    'not_affected',
+    'recommended'
+  )
+GROUP BY
+  vulnerability.id,
+  vulnerability.title,
+  vulnerability.reserved,
+  vulnerability.published,
+  vulnerability.modified,
+  vulnerability.withdrawn,
+  vulnerability.cwes,
+  requested_purl
+"#
+                );
+                let query = Statement::from_sql_and_values(
+                    connection.get_database_backend(),
+                    &sql,
+                    [
+                        p.into(),
+                        purl.name.into(),
+                        purl.ty.into(),
+                        purl.version
+                            .ok_or_else(|| PurlErr::MissingVersion(p.to_owned()))?
+                            .into(),
+                    ],
+                );
                 Ok(query.to_string())
             })
             .collect::<Result<Vec<String>, Error>>()?
             .join(" UNION ALL ");
 
-        let stmt = Statement::from_string(connection.get_database_backend(), query);
-        log::debug!("Analyzing using: {stmt}");
-        let result = connection.stream(stmt).map_err(Error::from).await?;
-        let result = result
-            .map_err(Error::from)
-            .and_then(|row| self.to_vuln(row, connection))
-            .try_fold(
-                HashMap::new(),
-                |mut acc: HashMap<String, Vec<VulnerabilityDetails>>,
-                 (requested_purl, vuln_details)| async {
-                    acc.entry(requested_purl).or_default().push(vuln_details);
-                    Ok(acc)
-                },
-            )
-            .await?;
-
-        Ok(result)
+        Ok(query)
     }
 
+    /// Take a row from [`Self::build_query`] and turn it into a result entry
+    ///
+    /// This will return a tuple of the original PURL and then the result
     #[instrument(
         skip_all,
         fields(purl, id),
         err(level=tracing::Level::INFO),
     )]
-    async fn to_vuln<C: ConnectionTrait>(
-        &self,
+    async fn row_to_vuln<C>(
         row: QueryResult,
         connection: &C,
-    ) -> Result<(String, VulnerabilityDetails), Error> {
+    ) -> Result<(String, AnalysisDetails), Error>
+    where
+        C: ConnectionTrait + StreamTrait,
+    {
+        let requested_purl: String = row.try_get_by("requested_purl")?;
+
+        let vulnerability = vulnerability::Model::from_query_result(&row, "")?;
+
         let span = tracing::Span::current();
-
-        let requested_purl: String = row.try_get("", "requested_purl")?;
-        let id = row.try_get("", "id")?;
-
         span.record("purl", &requested_purl);
-        span.record("id", &id);
+        span.record("id", &vulnerability.id);
 
-        let vulnerability = vulnerability::Model {
-            id,
-            title: row.try_get("", "title")?,
-            reserved: row.try_get("", "reserved")?,
-            published: row.try_get("", "published")?,
-            modified: row.try_get("", "modified")?,
-            withdrawn: row.try_get("", "withdrawn")?,
-            cwes: row.try_get("", "cwes")?,
-            base_score: row.try_get("", "base_score")?,
-            base_severity: row.try_get("", "base_severity")?,
-        };
+        let head = VulnerabilityHead::from_vulnerability_entity(
+            &vulnerability,
+            Memo::NotProvided,
+            connection,
+        )
+        .await?;
 
-        let vuln_details =
-            VulnerabilityDetails::from_entity(&vulnerability, Deprecation::Ignore, connection)
-                .await;
-        match vuln_details {
-            Ok(details) => Ok((requested_purl, details)),
-            Err(e) => Err(e),
+        /// result struct for getting the array of status/advisory entries
+        #[derive(serde::Deserialize)]
+        struct Entry {
+            status: String,
+            id: Uuid,
         }
+
+        impl TryGetableFromJson for Entry {}
+
+        // deserialize from JSONB
+
+        let advisories: Option<Vec<Entry>> = row.try_get_by("advisories")?;
+        let ids = advisories
+            .iter()
+            .flatten()
+            .map(|e| e.id)
+            .collect::<Vec<_>>();
+
+        // create a map for looking up the status once we resolved the ID to a struct
+        let statuses = advisories
+            .into_iter()
+            .flatten()
+            .map(|e| (e.id, e.status))
+            .collect::<HashMap<_, _>>();
+
+        // query for all advisories and translate into map
+
+        let status = advisory::Entity::find()
+            .filter(advisory::Column::Id.is_in(ids))
+            .stream(connection)
+            .await?
+            .map_err(Error::from)
+            .try_filter_map(async |advisory| {
+                let Some(status) = statuses.get(&advisory.id) else {
+                    return Ok(None);
+                };
+                Ok(Some((
+                    status.clone(),
+                    AdvisoryHead::from_advisory(&advisory, Memo::NotProvided, connection).await?,
+                )))
+            })
+            .try_fold(
+                BTreeMap::<String, Vec<AdvisoryHead>>::new(),
+                async move |mut acc, (status, adv)| {
+                    acc.entry(status.clone()).or_default().push(adv);
+                    Ok(acc)
+                },
+            )
+            .await?;
+
+        Ok((requested_purl, AnalysisDetails { head, status }))
     }
 }
 

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -1,8 +1,11 @@
+#![allow(clippy::expect_used)]
+
 use itertools::Itertools;
+use serde_json::json;
 use test_context::test_context;
 use test_log::test;
 use trustify_module_fundamental::vulnerability::service::VulnerabilityService;
-use trustify_test_context::{Dataset, TrustifyContext};
+use trustify_test_context::{Dataset, TrustifyContext, subset::ContainsSubset};
 
 #[test_context(TrustifyContext)]
 #[test(tokio::test)]
@@ -17,9 +20,15 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 
     println!("{:#?}", result);
 
+    // check number of PURLs
+
     assert_eq!(result.len(), 1);
 
+    // get expected purl
+
     let entry = &result["pkg:rpm/redhat/gnutls@3.7.6-23.el9?arch=aarch64"];
+
+    // test for vulnerability IDs
 
     let ids = entry
         .iter()
@@ -27,16 +36,33 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
         .sorted()
         .collect::<Vec<_>>();
 
-    // TODO: find out why we return four times the same
-    assert_eq!(
-        ids,
-        vec![
-            "CVE-2024-28834",
-            "CVE-2024-28834",
-            "CVE-2024-28834",
-            "CVE-2024-28834"
-        ]
+    assert_eq!(ids, vec!["CVE-2024-28834"]);
+
+    // now check advisories
+
+    let vuln_entry = entry
+        .iter()
+        .find(|e| e.head.identifier == "CVE-2024-28834")
+        .expect("must find entry");
+
+    assert_eq!(vuln_entry.status.len(), 1);
+
+    let status_entry = &vuln_entry.status["affected"];
+
+    assert_eq!(status_entry.len(), 1);
+    let json = serde_json::to_value(status_entry).expect("must serialize");
+    assert!(
+        json.contains_subset(json!([{
+            "document_id": "CVE-2024-28834",
+            "identifier": "https://www.redhat.com/#CVE-2024-28834",
+            "modified": "2025-01-07T01:43:37Z",
+            "published": "2024-03-21T00:00:00Z",
+            "title": "gnutls: vulnerable to Minerva side-channel information leak",
+        }])),
+        "doesn't match: {json:#?}"
     );
+
+    // done
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3424,6 +3424,29 @@ components:
               All CVSS3 scores from the advisory for the given vulnerability.
               May include several, varying by minor version of the CVSS3 vector.
       description: Summary of information from this advisory regarding a single specific vulnerability.
+    AnalysisDetails:
+      allOf:
+      - $ref: '#/components/schemas/VulnerabilityHead'
+      - type: object
+        required:
+        - status
+        properties:
+          status:
+            type: object
+            description: |-
+              Map of status to advisories
+
+              Allowed status values:
+              - `affected`: Advisories that affect the package
+              - `under_investigation`: Advisories that might affect the package, but the investigation is still ongoing
+
+              Additional status values may be added in the future; see API documentation for details.
+            additionalProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdvisoryHead'
+            propertyNames:
+              type: string
     AnalysisRequest:
       type: object
       required:
@@ -3438,7 +3461,7 @@ components:
       additionalProperties:
         type: array
         items:
-          $ref: '#/components/schemas/VulnerabilityDetails'
+          $ref: '#/components/schemas/AnalysisDetails'
       propertyNames:
         type: string
     AnalysisStatus:
@@ -5223,6 +5246,7 @@ components:
             - 'null'
             format: double
             description: Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
+            deprecated: true
           average_severity:
             oneOf:
             - type: 'null'


### PR DESCRIPTION
Skip returning SBOM specific content as the endpoint should return results for this PURL, not related SBOMs.

Remove duplicates in response. Due to the way the SQL query was structured, it returned duplicate entries.

Closes: #1840

## Summary by Sourcery

Change the vulnerabilities analysis endpoint to return a streamlined AnalysisResponse containing AnalysisDetails with advisories grouped by status, remove SBOM-specific content, and eliminate duplicate entries via SQL query aggregation

New Features:
- Introduce AnalysisDetails schema with vulnerabilities and advisories grouped by status
- Add new AnalysisRequest and AnalysisResponse types for the PURL analysis endpoint

Bug Fixes:
- Eliminate duplicate vulnerability entries by aggregating advisories in the SQL query

Enhancements:
- Update SQL query to aggregate advisories into JSONB and filter out SBOM-related statuses
- Deprecate average_score and average_severity fields in vulnerability details
- Refactor row_to_vuln into a unified row_to_vuln method producing AnalysisDetails

Documentation:
- Extend OpenAPI spec with AnalysisDetails schema and deprecate average_severity
- Remove outdated VulnerabilityDetails reference from AnalysisResponse in the API docs

Tests:
- Revise tests to assert single vulnerability result and validate advisories mapped by status

Chores:
- Allow usage of deprecated average_score and average_severity in cve_info tool