### PR TITLE
ci: give cargo llvm-cov a chance

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -54,20 +54,17 @@ jobs:
         run: |
           docker compose -f etc/deploy/compose/compose-minio.yaml up -d --wait
 
-      - name: Setup cargo-binstall (Linux)
-        if: runner.os != 'Windows'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
-      - name: Install cargo-tarpaulin
-        run:
-          cargo binstall cargo-tarpaulin -y --force
+      - name: Install llvm-tools-preview
+        run: |
+          rustup component add llvm-tools-preview
 
       - name: Test
         # use only one job, trying to reduce memory usage
-        run: cargo tarpaulin --jobs 1 --timeout 300 --out xml --skip-clean --features _test-s3
+        run: cargo llvm-cov --codecov --jobs 1 --features _test-s3 --output-path codecov.json
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # for embedded postgresql
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Codecov GitHub Actions workflow to switch from cargo-tarpaulin to cargo-llvm-cov and install required LLVM tools

CI:
- Use taiki-e/install-action@v2 to install cargo-llvm-cov
- Add llvm-tools-preview via rustup
- Replace cargo tarpaulin coverage step with cargo llvm-cov generating codecov JSON output