### PR TITLE
refactor(common): avoid unnecessary ping info spans

### DIFF
--- a/etc/telemetry/config-collector.yaml
+++ b/etc/telemetry/config-collector.yaml
@@ -14,13 +14,9 @@ exporters:
     tls:
       insecure: true
   debug:
-    verbosity: basic
+    verbosity: detailed
 
 processors:
-  filter/duration:
-    traces:
-      span:
-        - (end_time - start_time) < Duration("1ms")
   batch: {}
 
 service:
@@ -35,7 +31,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [filter/duration,batch]
+      processors: [batch]
       exporters: [debug, otlp]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
* This commit uses tracing-subscriber directive to filter info spans from the ping function that is being used by infrastructure health check.
* Also refactor the ping function to directly use try_acquire method avoiding the side effect caused by sqlx when tries to check for idle connection.
* Also it removes the OTELCOL custom span processor for two reasons:
  * We are going to follow instrumentation spec
  * I make hard to find issues like this related to the ping

* https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html?search=directive

## Summary by Sourcery

Use tracing-subscriber EnvFilter to suppress unnecessary ping spans, refactor the database ping logic to directly acquire a connection without SQLx side effects, remove the custom OTELCOL span processor, and simplify the OTEL collector configuration (increase debug verbosity and drop the duration filter).

Enhancements:
- Filter out ping_info spans by adding a tracing-subscriber EnvFilter directive.
- Increase the telemetry debug exporter verbosity to detailed.
- Remove the duration-based filter processor from the OTEL collector traces pipeline.

Chores:
- Remove the custom OTELCOL span processor to align with the instrumentation spec.