### PR TITLE
chore: prepare next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9167,7 +9167,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "serde",
  "test-log",
@@ -9177,7 +9177,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -9203,7 +9203,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9380,7 +9380,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-graphql"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -9545,7 +9545,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -9567,7 +9567,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9589,7 +9589,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9628,7 +9628,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9664,7 +9664,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -10760,7 +10760,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "futures-core",
  "memchr",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -1069,7 +1069,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.26",
+ "h2 0.3.27",
  "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
@@ -1081,7 +1081,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -3841,7 +3841,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3901,7 +3901,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -6286,7 +6286,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -6306,7 +6306,7 @@ dependencies = [
  "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -6588,7 +6588,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -6645,7 +6645,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -7021,15 +7021,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -7089,9 +7089,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7946,9 +7946,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193"
+checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
 dependencies = [
  "smallvec",
 ]
@@ -8049,7 +8049,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "serde",
  "serde_json",
  "sha2",
@@ -8852,7 +8852,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "trustify-ui"
 version = "0.1.0"
-source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#696d12531d186c458dd227f3c97d04253fbd4783"
+source = "git+https://github.com/trustification/trustify-ui.git?branch=publish%2Fmain#330c4ad614b7f2a1d7c52d5768b758cedc416c11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10690,9 +10690,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/modules/fundamental/src/license/endpoints/test.rs
+++ b/modules/fundamental/src/license/endpoints/test.rs
@@ -17,7 +17,7 @@ async fn list_spdx_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
 
     let response: PaginatedResults<SpdxLicenseSummary> = app.call_and_read_body_json(request).await;
 
-    assert_eq!(687, response.total);
+    assert_eq!(706, response.total);
 
     Ok(())
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.3.3
+  version: 0.3.4
 paths:
   /.well-known/trustify:
     get:


### PR DESCRIPTION
## Summary by Sourcery

Prepare next release by bumping project and API spec versions to 0.3.4 and updating the lockfile.

Build:
- Update Cargo.toml version to 0.3.4
- Regenerate Cargo.lock

Documentation:
- Update OpenAPI spec version to 0.3.4