### PR TITLE
feat: add scores and severities to response

### DIFF
--- a/cvss/src/cvss3/score.rs
+++ b/cvss/src/cvss3/score.rs
@@ -37,13 +37,7 @@ impl Score {
 
     /// Convert the numeric score into a `Severity`
     pub fn severity(self) -> Severity {
-        match self.0 {
-            x if x < 0.1 => Severity::None,
-            x if x < 4.0 => Severity::Low,
-            x if x < 7.0 => Severity::Medium,
-            x if x < 9.0 => Severity::High,
-            _ => Severity::Critical,
-        }
+        Severity::from(self.0)
     }
 }
 

--- a/cvss/src/cvss3/severity.rs
+++ b/cvss/src/cvss3/severity.rs
@@ -41,6 +41,22 @@ impl Severity {
             Severity::Critical => "critical",
         }
     }
+
+    pub fn from_f64(value: f64) -> Severity {
+        match value {
+            x if x < 0.1 => Severity::None,
+            x if x < 4.0 => Severity::Low,
+            x if x < 7.0 => Severity::Medium,
+            x if x < 9.0 => Severity::High,
+            _ => Severity::Critical,
+        }
+    }
+}
+
+impl From<f64> for Severity {
+    fn from(value: f64) -> Self {
+        Self::from_f64(value)
+    }
 }
 
 impl FromStr for Severity {
@@ -65,9 +81,7 @@ impl fmt::Display for Severity {
 }
 
 impl<'de> Deserialize<'de> for Severity {
-    fn deserialize<D: de::Deserializer<'de>>(
-        deserializer: D,
-    ) -> core::result::Result<Self, D::Error> {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         String::deserialize(deserializer)?
             .parse()
             .map_err(de::Error::custom)
@@ -75,10 +89,7 @@ impl<'de> Deserialize<'de> for Severity {
 }
 
 impl Serialize for Severity {
-    fn serialize<S: ser::Serializer>(
-        &self,
-        serializer: S,
-    ) -> core::result::Result<S::Ok, S::Error> {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.as_str().serialize(serializer)
     }
 }

--- a/modules/fundamental/src/vulnerability/model/analyze.rs
+++ b/modules/fundamental/src/vulnerability/model/analyze.rs
@@ -1,7 +1,14 @@
 use crate::{advisory::model::AdvisoryHead, vulnerability::model::VulnerabilityHead};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::{collections::BTreeMap, ops::Deref};
-use utoipa::ToSchema;
+use trustify_cvss::cvss3::severity::Severity;
+use utoipa::{
+    PartialSchema, ToSchema,
+    openapi::{
+        ObjectBuilder, RefOr, Schema, Type, extensions::ExtensionsBuilder, schema::SchemaType,
+    },
+};
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct AnalysisRequest {
@@ -20,7 +27,73 @@ pub struct AnalysisDetails {
     /// - `under_investigation`: Advisories that might affect the package, but the investigation is still ongoing
     ///
     /// Additional status values may be added in the future; see API documentation for details.
-    pub status: BTreeMap<String, Vec<AdvisoryHead>>,
+    pub status: BTreeMap<String, Vec<AnalysisAdvisory>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct AnalysisAdvisory {
+    #[serde(flatten)]
+    pub advisory: AdvisoryHead,
+
+    /// CVSS scores
+    pub scores: Vec<Score>,
+}
+
+/// The type of score, indicating the scoring system and version used.
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, strum::VariantArray)]
+pub enum ScoreType {
+    /// CVSS v2.0 score
+    #[serde(rename = "2.0")]
+    V2,
+    /// CVSS v3.0 score
+    #[serde(rename = "3.0")]
+    V3,
+    /// CVSS v3.1 score
+    #[serde(rename = "3.1")]
+    V3_1,
+    /// CVSS v4.0 score
+    #[serde(rename = "4.0")]
+    V4,
+}
+
+impl PartialSchema for ScoreType {
+    fn schema() -> RefOr<Schema> {
+        Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::Type(Type::String))
+                .description(Some(
+                    "The type of score, indicating the scoring system and version used.",
+                ))
+                .enum_values(Some(["2.0", "3.0", "3.1", "4.0"]))
+                .extensions(Some(
+                    ExtensionsBuilder::new()
+                        .add(
+                            "x-enum-descriptions",
+                            json!([
+                                "CVSS v2.0 score",
+                                "CVSS v3.0 score",
+                                "CVSS v3.1 score",
+                                "CVSS v4.0 score",
+                            ]),
+                        )
+                        .build(),
+                ))
+                .build(),
+        )
+        .into()
+    }
+}
+
+impl ToSchema for ScoreType {}
+
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, ToSchema, PartialEq)]
+pub struct Score {
+    /// The score type
+    pub r#type: ScoreType,
+    /// The actual value
+    pub value: f64,
+    /// The derived severity
+    pub severity: Severity,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
@@ -31,5 +104,53 @@ impl Deref for AnalysisResponse {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use strum::VariantArray;
+
+    #[test]
+    fn ensure_schema_variants() {
+        let RefOr::T(Schema::Object(schema)) = ScoreType::schema() else {
+            panic!("must but a concrete object");
+        };
+
+        // ensure the base type is a string
+
+        assert!(matches!(schema.schema_type, SchemaType::Type(Type::String)));
+
+        // ensure we have as many enum variants as in our Rust type, and that they match
+
+        assert_eq!(
+            schema.enum_values,
+            Some(
+                ScoreType::VARIANTS
+                    .iter()
+                    .map(|v| json!(v))
+                    .collect::<Vec<_>>()
+            )
+        );
+
+        // ensure that we have the same entries in the extension description
+
+        let ext = &schema.extensions.unwrap()["x-enum-descriptions"];
+        let serde_json::Value::Array(items) = ext else {
+            panic!("must be an array")
+        };
+
+        assert_eq!(
+            items,
+            &ScoreType::VARIANTS
+                .iter()
+                .map(|v| {
+                    let v = json!(v).to_string();
+                    let v = v.trim_matches('\"');
+                    format!("CVSS v{v} score")
+                })
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/modules/fundamental/src/vulnerability/service/mod.rs
+++ b/modules/fundamental/src/vulnerability/service/mod.rs
@@ -1,9 +1,12 @@
+#[cfg(test)]
+mod test;
+
 use crate::{
     Error,
     advisory::model::AdvisoryHead,
     vulnerability::model::{
-        AnalysisDetails, AnalysisResponse, VulnerabilityDetails, VulnerabilityHead,
-        VulnerabilitySummary,
+        AnalysisAdvisory, AnalysisDetails, AnalysisResponse, Score, ScoreType,
+        VulnerabilityDetails, VulnerabilityHead, VulnerabilitySummary,
     },
 };
 use futures_util::{TryFutureExt, TryStreamExt};
@@ -24,7 +27,7 @@ use trustify_common::{
     model::{Paginated, PaginatedResults},
     purl::{Purl, PurlErr},
 };
-use trustify_entity::{advisory, vulnerability};
+use trustify_entity::{advisory, cvss3, vulnerability};
 use trustify_module_ingestor::common::Deprecation;
 
 #[derive(Default)]
@@ -257,11 +260,46 @@ GROUP BY
             .collect::<Vec<_>>();
 
         // create a map for looking up the status once we resolved the ID to a struct
+
         let statuses = advisories
             .into_iter()
             .flatten()
             .map(|e| (e.id, e.status))
             .collect::<HashMap<_, _>>();
+
+        // query for all the scores
+
+        let scores = cvss3::Entity::find()
+            .filter(cvss3::Column::AdvisoryId.is_in(ids.clone()))
+            .filter(cvss3::Column::VulnerabilityId.eq(vulnerability.id))
+            .stream(connection)
+            .await?
+            .map_err(Error::from)
+            .try_filter_map(async |row| {
+                // map to V3* type
+                let r#type = match row.minor_version {
+                    0 => ScoreType::V3,
+                    1 => ScoreType::V3_1,
+                    _ => return Ok(None),
+                };
+
+                Ok(Some((
+                    row.advisory_id,
+                    Score {
+                        r#type,
+                        value: row.score,
+                        severity: row.score.into(),
+                    },
+                )))
+            })
+            .try_fold(
+                HashMap::<Uuid, Vec<Score>>::new(),
+                async move |mut acc, (advisory_id, entry)| {
+                    acc.entry(advisory_id).or_default().push(entry);
+                    Ok(acc)
+                },
+            )
+            .await?;
 
         // query for all advisories and translate into map
 
@@ -276,11 +314,25 @@ GROUP BY
                 };
                 Ok(Some((
                     status.clone(),
-                    AdvisoryHead::from_advisory(&advisory, Memo::NotProvided, connection).await?,
+                    AnalysisAdvisory {
+                        advisory: AdvisoryHead::from_advisory(
+                            &advisory,
+                            Memo::NotProvided,
+                            connection,
+                        )
+                        .await?,
+                        // fetch scores from pre-loaded map
+                        scores: scores
+                            .get(&advisory.id)
+                            .into_iter()
+                            .flatten()
+                            .copied()
+                            .collect(),
+                    },
                 )))
             })
             .try_fold(
-                BTreeMap::<String, Vec<AdvisoryHead>>::new(),
+                BTreeMap::<String, Vec<AnalysisAdvisory>>::new(),
                 async move |mut acc, (status, adv)| {
                     acc.entry(status.clone()).or_default().push(adv);
                     Ok(acc)
@@ -291,6 +343,3 @@ GROUP BY
         Ok((requested_purl, AnalysisDetails { head, status }))
     }
 }
-
-#[cfg(test)]
-mod test;

--- a/modules/fundamental/src/vulnerability/service/test.rs
+++ b/modules/fundamental/src/vulnerability/service/test.rs
@@ -1,18 +1,20 @@
+use crate::{
+    purl::service::PurlService, sbom::service::SbomService,
+    vulnerability::service::VulnerabilityService,
+};
 use std::str::FromStr;
-
-use crate::purl::service::PurlService;
-use crate::sbom::service::SbomService;
-use crate::vulnerability::service::VulnerabilityService;
 use test_context::test_context;
 use test_log::test;
-use trustify_common::db::query::{Query, q};
-use trustify_common::model::Paginated;
-use trustify_common::purl::Purl;
+use trustify_common::{
+    db::query::{Query, q},
+    model::Paginated,
+    purl::Purl,
+};
 use trustify_cvss::cvss3::severity::Severity;
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -43,7 +45,7 @@ async fn all_vulnerabilities(ctx: &TrustifyContext) -> Result<(), anyhow::Error>
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -89,7 +91,7 @@ async fn statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -117,7 +119,7 @@ async fn statuses_too(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let vuln_service = VulnerabilityService::new();
     let sbom_service = SbomService::new(ctx.db.clone());
@@ -216,7 +218,7 @@ async fn commons_compress(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let vuln_service = VulnerabilityService::new();
     let sbom_service = SbomService::new(ctx.db.clone());
@@ -322,7 +324,7 @@ async fn product_statuses(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -354,7 +356,7 @@ async fn delete_vulnerability(ctx: &TrustifyContext) -> Result<(), anyhow::Error
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -459,7 +461,7 @@ async fn vulnerability_queries(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
 }
 
 #[test_context(TrustifyContext)]
-#[test(actix_web::test)]
+#[test(tokio::test)]
 async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let service = VulnerabilityService::new();
 
@@ -509,5 +511,30 @@ async fn analyze_purls(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             "Unexpected key '{item}' found in result"
         )
     });
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(tokio::test)]
+#[ignore = "Requires #1873"]
+async fn analyze_purls_no_score(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let service = VulnerabilityService::new();
+
+    ctx.ingest_documents(["osv/RUSTSEC-2022-0022.json"]).await?;
+
+    let result = service
+        .analyze_purls(["pkg:cargo/hyper@0.14.9"], &ctx.db)
+        .await?;
+
+    // ensure we get an entry
+
+    assert_eq!(result.len(), 1);
+    let advisory = &result["pkg:cargo/hyper@0.14.9"][0];
+    let status = &advisory.status["affected"][0];
+
+    // the scores must be empty
+
+    assert!(status.scores.is_empty());
+
     Ok(())
 }

--- a/modules/fundamental/tests/vuln/mod.rs
+++ b/modules/fundamental/tests/vuln/mod.rs
@@ -58,6 +58,13 @@ async fn issue_1840(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
             "modified": "2025-01-07T01:43:37Z",
             "published": "2024-03-21T00:00:00Z",
             "title": "gnutls: vulnerable to Minerva side-channel information leak",
+            "scores": [
+                {
+                    "type": "3.1",
+                    "value": 5.3,
+                    "severity": "medium",
+                }
+            ]
         }])),
         "doesn't match: {json:#?}"
     );

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3424,6 +3424,18 @@ components:
               All CVSS3 scores from the advisory for the given vulnerability.
               May include several, varying by minor version of the CVSS3 vector.
       description: Summary of information from this advisory regarding a single specific vulnerability.
+    AnalysisAdvisory:
+      allOf:
+      - $ref: '#/components/schemas/AdvisoryHead'
+      - type: object
+        required:
+        - scores
+        properties:
+          scores:
+            type: array
+            items:
+              $ref: '#/components/schemas/Score'
+            description: CVSS scores
     AnalysisDetails:
       allOf:
       - $ref: '#/components/schemas/VulnerabilityHead'
@@ -3444,7 +3456,7 @@ components:
             additionalProperties:
               type: array
               items:
-                $ref: '#/components/schemas/AdvisoryHead'
+                $ref: '#/components/schemas/AnalysisAdvisory'
             propertyNames:
               type: string
     AnalysisRequest:
@@ -5043,6 +5055,36 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/SbomPackage'
+    Score:
+      type: object
+      required:
+      - type
+      - value
+      - severity
+      properties:
+        severity:
+          $ref: '#/components/schemas/Severity'
+          description: The derived severity
+        type:
+          $ref: '#/components/schemas/ScoreType'
+          description: The score type
+        value:
+          type: number
+          format: double
+          description: The actual value
+    ScoreType:
+      type: string
+      description: The type of score, indicating the scoring system and version used.
+      enum:
+      - '2.0'
+      - '3.0'
+      - '3.1'
+      - '4.0'
+      x-enum-descriptions:
+      - CVSS v2.0 score
+      - CVSS v3.0 score
+      - CVSS v3.1 score
+      - CVSS v4.0 score
     Severity:
       type: string
       description: |-


### PR DESCRIPTION
## Summary by Sourcery

Attach CVSS score values and derived severities to vulnerability analysis responses by extending the data model, service logic, and API schema, and enhancing the cvss library.

New Features:
- Include CVSS scores and derived severities in vulnerability analysis responses.

Enhancements:
- Introduce ScoreType enum and Score struct with OpenAPI schema annotations.
- Enhance VulnerabilityService to query and attach CVSS scores per advisory.
- Add Severity::from_f64 method and From<f64> conversion in the cvss3 library.

Documentation:
- Extend OpenAPI specification with AnalysisAdvisory, Score, and ScoreType schemas.

Tests:
- Add schema validation test for ScoreType variants.
- Add integration test for analysis behavior when no CVSS scores are present.
- Migrate vulnerability service tests to use tokio runtime instead of actix_web.