### PR TITLE
feat: add delete method to Storage trait

### DIFF
--- a/modules/storage/src/service/dispatch.rs
+++ b/modules/storage/src/service/dispatch.rs
@@ -50,6 +50,13 @@ impl StorageBackend for DispatchBackend {
                 .map_err(anyhow::Error::from),
         }
     }
+
+    async fn delete(&self, key: StorageKey) -> Result<(), Self::Error> {
+        match self {
+            Self::Filesystem(backend) => backend.delete(key).await.map_err(anyhow::Error::from),
+            Self::S3(backend) => backend.delete(key).await.map_err(anyhow::Error::from),
+        }
+    }
 }
 
 impl DispatchBackend {

--- a/modules/storage/src/service/fs.rs
+++ b/modules/storage/src/service/fs.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures::Stream;
 use std::{
     fmt::Debug,
-    io::{Error as IoError, ErrorKind, Result as IoResult},
+    io::{ErrorKind, Result as IoResult},
     path::{Path, PathBuf},
 };
 use strum::IntoEnumIterator;
@@ -165,10 +165,7 @@ impl StorageBackend for FileSystemBackend {
     async fn delete(&self, key: StorageKey) -> Result<(), Self::Error> {
         match self.locate(key).await? {
             Some((path, _)) => remove_file(path).await,
-            None => Err(IoError::new(
-                ErrorKind::NotFound,
-                "No document found in storage matching key",
-            )),
+            None => Ok(()),
         }
     }
 }

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -103,6 +103,10 @@ pub trait StorageBackend {
         Output = Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error>,
     >;
 
-    /// Delete the stored content
+    /// Delete the stored content.
+    ///
+    /// This operation MUST be idempotent: deleting a non-existent key should succeed
+    /// (i.e., return `Ok(())`) and not result in an error. This ensures consistent
+    /// behavior across all backends.
     fn delete(&self, key: StorageKey) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/modules/storage/src/service/mod.rs
+++ b/modules/storage/src/service/mod.rs
@@ -102,4 +102,7 @@ pub trait StorageBackend {
     ) -> impl Future<
         Output = Result<Option<impl Stream<Item = Result<Bytes, Self::Error>> + 'a>, Self::Error>,
     >;
+
+    /// Delete the stored content
+    fn delete(&self, key: StorageKey) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/modules/storage/src/service/s3.rs
+++ b/modules/storage/src/service/s3.rs
@@ -194,22 +194,10 @@ impl StorageBackend for S3Backend {
     }
 
     async fn delete(&self, StorageKey(key): StorageKey) -> Result<(), Self::Error> {
-        match self
-            .client
-            .head_object()
-            .bucket(&self.bucket)
-            .key(&key)
-            .send()
-            .await
-        {
+        let req = self.client.delete_object().bucket(&self.bucket).key(&key);
+        match req.send().await {
+            Ok(_) => Ok(()),
             Err(err) => Err(Error::S3(err.into())),
-            _ => {
-                let req = self.client.delete_object().bucket(&self.bucket).key(&key);
-                match req.send().await {
-                    Ok(_) => Ok(()),
-                    Err(err) => Err(Error::S3(err.into())),
-                }
-            }
         }
     }
 }

--- a/modules/storage/src/service/test.rs
+++ b/modules/storage/src/service/test.rs
@@ -29,11 +29,11 @@ pub async fn test_store_read_and_delete<B: StorageBackend>(backend: B) {
         .delete(digest.key())
         .await
         .expect("delete must succeed");
-
-    assert!(
-        backend.delete(digest.key()).await.is_err(),
-        "delete of missing file should fail"
-    );
+    assert!(backend.retrieve(digest.key()).await.unwrap().is_none());
+    backend
+        .delete(digest.key())
+        .await
+        .expect("delete should be idempotent");
 }
 
 pub async fn test_read_not_found<B: StorageBackend>(backend: B) {

--- a/modules/storage/src/service/test.rs
+++ b/modules/storage/src/service/test.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 use futures::TryStreamExt;
 use trustify_common::id::Id;
 
-pub async fn test_store_and_read<B: StorageBackend>(backend: B) {
+pub async fn test_store_read_and_delete<B: StorageBackend>(backend: B) {
     const DIGEST: &str = "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e";
 
     let digest = backend
@@ -24,6 +24,16 @@ pub async fn test_store_and_read<B: StorageBackend>(backend: B) {
     let content = stream.try_collect::<BytesMut>().await.unwrap();
 
     assert_eq!(content.as_ref(), b"Hello World");
+
+    backend
+        .delete(digest.key())
+        .await
+        .expect("delete must succeed");
+
+    assert!(
+        backend.delete(digest.key()).await.is_err(),
+        "delete of missing file should fail"
+    );
 }
 
 pub async fn test_read_not_found<B: StorageBackend>(backend: B) {


### PR DESCRIPTION
fixes: #1864

## Summary by Sourcery

Implement an idempotent delete operation across all storage backends, refactor filesystem retrieval logic with a locate helper, and extend tests to cover deletion behavior

New Features:
- Add delete method to StorageBackend trait
- Implement delete for FileSystemBackend, S3Backend, and DispatchBackend

Enhancements:
- Extract locate helper in FileSystemBackend to unify file lookup across retrieve and delete
- Refactor FileSystemBackend retrieve method to use the new locate helper

Tests:
- Introduce test_store_read_and_delete to verify delete functionality and idempotency
- Update existing storage backend tests to use the new delete-aware test helper