### PR TITLE
chore: prepare next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-auth"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-common"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9167,7 +9167,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-cvss"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "serde",
  "test-log",
@@ -9177,7 +9177,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-entity"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -9203,7 +9203,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-infrastructure"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-cors",
  "actix-tls",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-migration"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "sea-orm-migration",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-analysis"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-fundamental"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9380,7 +9380,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-graphql"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-importer"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ingestor"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-storage"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -9545,7 +9545,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-ui"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-web",
  "actix-web-static-files",
@@ -9567,7 +9567,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-module-user"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9589,7 +9589,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-server"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9628,7 +9628,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-test-context"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -9664,7 +9664,7 @@ dependencies = [
 
 [[package]]
 name = "trustify-trustd"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -10760,7 +10760,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,11 +1309,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1498,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "0.0.40"
+version = "0.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288657edd15bfa5a7f30ca3b123c1af2c503eaf218e517fa10bc9063dbc2ad99"
+checksum = "8e232cc6fad4ac9f969bba34440da4d45947a55e60008fbaf5342163f30d6d34"
 dependencies = [
  "bincode",
  "build-info-common",
@@ -1509,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "build-info-build"
-version = "0.0.40"
+version = "0.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3146483d5bc5081ec26f9c4e60232e770980d750b2802d6cc2563cded665cc73"
+checksum = "c095501b4684e681005757c3171fccf3b8a4132a8cf8e5135b6a885068cd413e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1529,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "build-info-common"
-version = "0.0.40"
+version = "0.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8524ad59f5958f37f95e66bf6c9a8fa8440c4f56c069247c44244434cfca3eb1"
+checksum = "6b409ed3b3b89db66e81ed7df221d30a1d78c298e719472cac30b21dfdacf9ce"
 dependencies = [
  "chrono",
  "derive_more 2.0.1",
@@ -1541,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "build-info-proc"
-version = "0.0.40"
+version = "0.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b58fb02636d968e8327d84a5a256df9704ac27a1eda98429c35dbe50a278f69"
+checksum = "3fc6a2f7c956ef2a43081719feb90f90998ad1343c770db43bcdbfbc63894db8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1670,21 +1681,38 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.19.2"
+name = "cargo-util-schemas"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
 dependencies = [
  "camino",
  "cargo-platform",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -2938,6 +2966,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -5720,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "peak_alloc"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c4e8e2dd832fd76346468f822e4e600d30ba4e5aa545a128abf12cfae7ea3e"
+checksum = "ccc90935a8dd139fdf341762773687a1e361d3f54b396a55d9dd1f7001e484bb"
 
 [[package]]
 name = "pem"
@@ -6115,6 +6153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6267,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]
@@ -7215,10 +7259,8 @@ checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 0.9.0",
  "serde",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -7229,8 +7271,10 @@ checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -7247,9 +7291,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7634,6 +7678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7706,6 +7761,15 @@ name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -8885,10 +8949,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -8897,9 +8976,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -9099,7 +9187,7 @@ dependencies = [
  "log",
  "openid",
  "reqwest 0.12.22",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -9142,7 +9230,7 @@ dependencies = [
  "ring",
  "rstest",
  "sbom-walker",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "sea-orm",
  "sea-query",
  "serde",
@@ -9185,7 +9273,7 @@ dependencies = [
  "deepsize",
  "log",
  "rstest",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "sea-orm",
  "serde",
  "serde_json",
@@ -9427,7 +9515,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.22",
  "sbom-walker",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "sea-orm",
  "sea-query",
  "serde",
@@ -9700,6 +9788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9841,6 +9935,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "uriparse"
@@ -10048,6 +10148,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsimd"
@@ -10771,7 +10877,7 @@ dependencies = [
  "postgresql_commands",
  "reedline",
  "reqwest 0.12.22",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -10948,6 +11054,7 @@ dependencies = [
  "liblzma",
  "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
  "time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
 aws-smithy-types = { version = "1" }
 base64 = "0.22"
 biscuit = "0.7"
-build-info = "0.0.40"
-build-info-build = "0.0.40"
-build-info-common = "0.0.40"
+build-info = "0.0.41"
+build-info-build = "0.0.41"
+build-info-common = "0.0.41"
 bytes = "1.5"
 bytesize = "2.0"
 chrono = { version = "0.4.35", default-features = false }
@@ -98,11 +98,11 @@ opentelemetry-instrumentation-actix-web = "0.22.0"
 osv = { version = "0.2.1", default-features = false, features = [] }
 packageurl = "0.3.0"
 parking_lot = "0.12"
-peak_alloc = "0.2.0"
+peak_alloc = "0.3.0"
 pem = "3"
 percent-encoding = "2.3.1"
 petgraph = { version = "0.8.0", features = ["serde-1"] }
-quick-xml = "0.37.0"
+quick-xml = "0.38.0"
 rand = "0.9.0"
 reedline = "0.40.0"
 regex = "1.10.3"
@@ -112,7 +112,7 @@ roxmltree = "0.20.0"
 rstest = "0.25.0"
 sanitize-filename = "=0.6.0"
 sbom-walker = { version = "0.13.0", default-features = false, features = ["crypto-openssl", "serde-cyclonedx", "spdx-rs"] }
-schemars = "0.9"
+schemars = "1.0"
 sea-orm = { version = "1.1.12", features = ["debug-print"] }
 sea-orm-migration = "1"
 sea-query = "0.32.0"
@@ -156,7 +156,7 @@ uuid = "1.7.0"
 walkdir = "2.5"
 walker-common = "0.13.0"
 walker-extras = "0.13.0"
-zip = { version = "4", default-features = false, features = ["aes-crypto", "bzip2", "deflate64", "deflate", "lzma", "time", "zstd"] } # default-features false required due to: https://github.com/zip-rs/zip2/issues/326 # tilde version due to: https://github.com/zip-rs/zip2/issues/328
+zip = "4"
 
 trustify-auth = { path = "common/auth", features = ["actix", "swagger"] }
 trustify-common = { path = "common" }

--- a/common/auth/schema/auth.json
+++ b/common/auth/schema/auth.json
@@ -55,14 +55,14 @@
           }
         },
         "additionalPermissions": {
-          "description": "Additional scopes which get added for client\n\n This can be useful if a client is considered to only provide identities which are supposed\n to have certain scopes, but don't provide them.",
+          "description": "Additional scopes which get added for client\n\nThis can be useful if a client is considered to only provide identities which are supposed\nto have certain scopes, but don't provide them.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "requiredAudience": {
-          "description": "Enforce an audience claim (`aud`) for tokens.\n\n If present, the token must have one matching `aud` claim.",
+          "description": "Enforce an audience claim (`aud`) for tokens.\n\nIf present, the token must have one matching `aud` claim.",
           "type": [
             "string",
             "null"

--- a/modules/importer/schema/importer.json
+++ b/modules/importer/schema/importer.json
@@ -103,13 +103,6 @@
     "SbomImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -118,6 +111,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -188,13 +188,6 @@
     "CsafImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -203,6 +196,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -241,13 +241,6 @@
     "OsvImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -256,6 +249,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -307,13 +307,6 @@
     "CveImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -322,6 +315,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -358,13 +358,6 @@
     "ClearlyDefinedImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -373,6 +366,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -413,13 +413,6 @@
     "ClearlyDefinedCurationImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -428,6 +421,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -452,13 +452,6 @@
     "CweImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -467,6 +460,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -484,13 +484,6 @@
     "QuayImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -499,6 +492,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache License, Version 2.0
     identifier: Apache-2.0
-  version: 0.3.4
+  version: 0.3.5
 paths:
   /.well-known/trustify:
     get:

--- a/xtask/schema/generate-dump.json
+++ b/xtask/schema/generate-dump.json
@@ -117,13 +117,6 @@
     "SbomImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -132,6 +125,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -202,13 +202,6 @@
     "CsafImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -217,6 +210,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -255,13 +255,6 @@
     "OsvImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -270,6 +263,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -321,13 +321,6 @@
     "CveImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -336,6 +329,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -372,13 +372,6 @@
     "ClearlyDefinedImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -387,6 +380,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -427,13 +427,6 @@
     "ClearlyDefinedCurationImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -442,6 +435,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -466,13 +466,6 @@
     "CweImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -481,6 +474,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",
@@ -498,13 +498,6 @@
     "QuayImporter": {
       "type": "object",
       "properties": {
-        "description": {
-          "description": "A description for users.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "disabled": {
           "description": "A flag to disable the importer, without deleting it.",
           "type": "boolean",
@@ -513,6 +506,13 @@
         "period": {
           "description": "The period the importer should be run.",
           "$ref": "#/$defs/HumantimeSerde"
+        },
+        "description": {
+          "description": "A description for users.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "description": "Labels which will be applied to the ingested documents.",


### PR DESCRIPTION
## Summary by Sourcery

Prepare for the 0.3.5 release by bumping the workspace package and OpenAPI versions and upgrading key dependencies.

Enhancements:
- Upgrade build-info, build-info-build, and build-info-common crates to v0.0.41
- Upgrade peak_alloc crate to v0.3.0
- Upgrade quick-xml crate to v0.38.0
- Upgrade schemars crate to v1.0
- Simplify zip dependency to version 4

Documentation:
- Update OpenAPI specification version to 0.3.5

Chores:
- Bump workspace package version to 0.3.5