### PR TITLE
fix: allow cyclonedx to do nested external sboms

### DIFF
--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/54FE396D61CE4E1.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/54FE396D61CE4E1.json
@@ -1,0 +1,161 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "dev"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "3scale-tech-preview/authorino-rhel9",
+      "purl": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+      "type": "container",
+      "description": "Image index manifest of pkg:oci/3scale-tech-preview-authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87"
+    },
+    "timestamp": "2025-05-13T08:15:28Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "149445"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "3scale-tech-preview/authorino-rhel9",
+      "purl": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87"
+        }
+      ],
+      "bom-ref": "authorino-container_image-index",
+      "version": "sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0"
+          }
+        ]
+      },
+      "pedigree": {
+        "variants": [
+          {
+            "name": "3scale-tech-preview/authorino-rhel9",
+            "purl": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792"
+              }
+            ],
+            "bom-ref": "authorino-container_amd64",
+            "version": "sha256:9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "3scale-tech-preview/authorino-rhel9",
+            "purl": "pkg:oci/authorino-rhel9@sha256%3A3d73d6452a2b4d92d967bee392d9c9405791ed4e64f1f49df7fc45d680ca9b60?arch=ppc64le&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "3d73d6452a2b4d92d967bee392d9c9405791ed4e64f1f49df7fc45d680ca9b60"
+              }
+            ],
+            "bom-ref": "authorino-container_ppc64le",
+            "version": "sha256:3d73d6452a2b4d92d967bee392d9c9405791ed4e64f1f49df7fc45d680ca9b60",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          },
+          {
+            "name": "3scale-tech-preview/authorino-rhel9",
+            "purl": "pkg:oci/authorino-rhel9@sha256%3A83cbea23a02963dcd6250585200d0050e925c7dadb3a611ecaf6353565259d45?arch=s390x&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+            "type": "container",
+            "hashes": [
+              {
+                "alg": "SHA-256",
+                "content": "83cbea23a02963dcd6250585200d0050e925c7dadb3a611ecaf6353565259d45"
+              }
+            ],
+            "bom-ref": "authorino-container_s390x",
+            "version": "sha256:83cbea23a02963dcd6250585200d0050e925c7dadb3a611ecaf6353565259d45",
+            "supplier": {
+              "url": [
+                "https://www.redhat.com"
+              ],
+              "name": "Red Hat"
+            },
+            "publisher": "Red Hat"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "authorino-container"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "3scale-tech-preview/authorino-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "1"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.1.3"
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:c687621f-7955-309e-ab6c-bd32b7f96c3f"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/A875C1FFA263483.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/A875C1FFA263483.json
@@ -1,0 +1,180 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "SBOMer",
+          "type": "application",
+          "author": "Red Hat",
+          "version": "dev"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "3scale API Management 2.15 on RHEL 9",
+      "type": "framework",
+      "bom-ref": "3SCALE-2.15-RHEL-9",
+      "version": "3SCALE-2.15-RHEL-9",
+      "evidence": {
+        "identity": [
+          {
+            "field": "cpe",
+            "concludedValue": "cpe:/a:redhat:3scale:2.15::el9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      }
+    },
+    "timestamp": "2025-05-27T20:11:20Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "149445"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "3scale-tech-preview/authorino-rhel9",
+      "purl": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87"
+        }
+      ],
+      "bom-ref": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
+      "version": "sha256:a473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "3scale-tech-preview/authorino-rhel9-operator",
+      "purl": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008"
+        }
+      ],
+      "bom-ref": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008",
+      "version": "sha256:eb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9-operator&tag=3scale2.15.0"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9-operator&tag=3scale2.15"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9-operator&tag=1.1.3-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9-operator&tag=1.1.3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    },
+    {
+      "name": "3scale-tech-preview/authorino-operator-bundle",
+      "purl": "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2"
+        }
+      ],
+      "bom-ref": "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2",
+      "version": "sha256:1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-operator-bundle&tag=3scale2.15.0"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-operator-bundle&tag=3scale2.15"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2?repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-operator-bundle&tag=1.1.3-1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat"
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "3SCALE-2.15-RHEL-9",
+      "provides": [
+        "pkg:oci/authorino-rhel9@sha256%3Aa473dae20e71e3e813ac30ba978f2ab3c5e19d7d39b501ae9103dca892107c87",
+        "pkg:oci/authorino-rhel9-operator@sha256%3Aeb574781cf39917f8f5d9e5c806f520534601f819ee1ebcbb751832da8938008",
+        "pkg:oci/authorino-operator-bundle@sha256%3A1223266b391e1394b9bef70317c7edb813a97c5b7705fd88cee20a2bebf9bec2"
+      ],
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:57334e7f-c34c-3e4e-a565-d83d45fd4399"
+}

--- a/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/D52B5B9527D4447.json
+++ b/etc/test-data/cyclonedx/rh/latest_filters/TC-2677/D52B5B9527D4447.json
@@ -1,0 +1,9384 @@
+{
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "name": "syft",
+          "type": "application",
+          "author": "anchore",
+          "version": "1.16.0"
+        }
+      ]
+    },
+    "supplier": {
+      "url": [
+        "https://www.redhat.com"
+      ],
+      "name": "Red Hat"
+    },
+    "component": {
+      "name": "3scale-tech-preview/authorino-rhel9",
+      "purl": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+      "type": "container"
+    },
+    "timestamp": "2025-05-13T08:14:13Z",
+    "properties": [
+      {
+        "name": "redhat:advisory_id",
+        "value": "149445"
+      }
+    ]
+  },
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "3scale-tech-preview/authorino-rhel9",
+      "purl": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0",
+      "type": "container",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792"
+        }
+      ],
+      "bom-ref": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&tag=1.1.3-1",
+      "version": "sha256:9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792",
+      "evidence": {
+        "identity": [
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3-1"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=1.1.3"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15"
+          },
+          {
+            "field": "purl",
+            "concludedValue": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&repository_url=registry.access.redhat.com%2F3scale-tech-preview%2Fauthorino-rhel9&tag=3scale2.15.0"
+          }
+        ]
+      },
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bc9682febfdcd886306e9c7310bc3030cca75552",
+            "url": "https://pkgs.devel.redhat.com/git/containers/authorino#bc9682febfdcd886306e9c7310bc3030cca75552"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:image:labels:architecture",
+          "value": "x86_64"
+        },
+        {
+          "name": "sbomer:image:labels:build-date",
+          "value": "2025-05-12T17:21:45"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.component",
+          "value": "authorino-container"
+        },
+        {
+          "name": "sbomer:image:labels:com.redhat.license_terms",
+          "value": "https://www.redhat.com/agreements"
+        },
+        {
+          "name": "sbomer:image:labels:description",
+          "value": "Kubernetes-native authorization service for tailor-made Zero Trust API security"
+        },
+        {
+          "name": "sbomer:image:labels:distribution-scope",
+          "value": "public"
+        },
+        {
+          "name": "sbomer:image:labels:io.buildah.version",
+          "value": "1.33.12"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.description",
+          "value": "Kubernetes-native authorization service for tailor-made Zero Trust API security"
+        },
+        {
+          "name": "sbomer:image:labels:io.k8s.display-name",
+          "value": "Authorino"
+        },
+        {
+          "name": "sbomer:image:labels:io.openshift.tags",
+          "value": "api, auth,"
+        },
+        {
+          "name": "sbomer:image:labels:maintainer",
+          "value": "mcassola@redhat.com"
+        },
+        {
+          "name": "sbomer:image:labels:name",
+          "value": "3scale-tech-preview/authorino-rhel9"
+        },
+        {
+          "name": "sbomer:image:labels:release",
+          "value": "1"
+        },
+        {
+          "name": "sbomer:image:labels:summary",
+          "value": "Authorino container image"
+        },
+        {
+          "name": "sbomer:image:labels:upstream_ref",
+          "value": "f792cd138891dc1ead99fd089aa757fbca3aace9"
+        },
+        {
+          "name": "sbomer:image:labels:upstream_repo",
+          "value": "https://github.com/kuadrant/authorino"
+        },
+        {
+          "name": "sbomer:image:labels:url",
+          "value": "https://access.redhat.com/containers/#/registry.access.redhat.com/3scale-tech-preview/authorino-rhel9/images/1.1.3-1"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-ref",
+          "value": "bc9682febfdcd886306e9c7310bc3030cca75552"
+        },
+        {
+          "name": "sbomer:image:labels:vcs-type",
+          "value": "git"
+        },
+        {
+          "name": "sbomer:image:labels:vendor",
+          "value": "Red Hat"
+        },
+        {
+          "name": "sbomer:image:labels:version",
+          "value": "1.1.3"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3643175",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "https://pkgs.devel.redhat.com/git/containers/authorino#bc9682febfdcd886306e9c7310bc3030cca75552",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "alternatives",
+      "purl": "pkg:rpm/redhat/alternatives@1.24-1.el9_5.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_5.1?arch=x86_64",
+      "version": "1.24-1.el9_5.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0-only"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c3d4462a6bd156a8650477b5f5148bee88fe83d4",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#c3d4462a6bd156a8650477b5f5148bee88fe83d4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3267214",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/chkconfig#c3d4462a6bd156a8650477b5f5148bee88fe83d4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "audit-libs",
+      "purl": "pkg:rpm/redhat/audit-libs@3.1.5-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/audit-libs@3.1.5-1.el9?arch=x86_64",
+      "version": "3.1.5-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4ed80addfbcd55646148e3f3f10cd74e2e7bcd7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#a4ed80addfbcd55646148e3f3f10cd74e2e7bcd7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3202378",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/audit#a4ed80addfbcd55646148e3f3f10cd74e2e7bcd7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "basesystem",
+      "purl": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "version": "11-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+            "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688850",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/basesystem#9dcb78fb51be1226bf055ed17077be7a0aaa9b9a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bash",
+      "purl": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "version": "5.1.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "80326284a249f523c3e2d14e0eed2dbaece63c4e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2910143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bash#80326284a249f523c3e2d14e0eed2dbaece63c4e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "bzip2-libs",
+      "purl": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "version": "1.0.8-10.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fc546512bf0d59d11d367828d43b5988da3a5d92",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3469717",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/bzip2#fc546512bf0d59d11d367828d43b5988da3a5d92",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates",
+      "purl": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "version": "2024.2.69_v8.0.303-91.4.el9_4",
+      "licenses": [
+        {
+          "expression": "MIT AND GPL-2.0-or-later"
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d46488391f737a6a74113abca1e34835a70c8054",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#d46488391f737a6a74113abca1e34835a70c8054"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3233446",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/ca-certificates#d46488391f737a6a74113abca1e34835a70c8054",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "coreutils-single",
+      "purl": "pkg:rpm/redhat/coreutils-single@8.32-36.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/coreutils-single@8.32-36.el9?arch=x86_64",
+      "version": "8.32-36.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "050cd3e9685e5eb03cd04ea7a82c2c83c4719f68",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#050cd3e9685e5eb03cd04ea7a82c2c83c4719f68"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3229124",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/coreutils#050cd3e9685e5eb03cd04ea7a82c2c83c4719f68",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "crypto-policies",
+      "purl": "pkg:rpm/redhat/crypto-policies@20240828-2.git626aa59.el9_5?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/crypto-policies@20240828-2.git626aa59.el9_5?arch=noarch",
+      "version": "20240828-2.git626aa59.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1-or-later"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cff876574a46ea6492a17e0296cdae965a266374",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#cff876574a46ea6492a17e0296cdae965a266374"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3292963",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/crypto-policies#cff876574a46ea6492a17e0296cdae965a266374",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "curl-minimal",
+      "purl": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64",
+      "version": "7.76.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36c10becf42f5173a562543d8006ad15c125ac2c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#36c10becf42f5173a562543d8006ad15c125ac2c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3243256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#36c10becf42f5173a562543d8006ad15c125ac2c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "cyrus-sasl-lib",
+      "purl": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "version": "2.1.27-21.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD with advertising"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+            "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2162423",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/cyrus-sasl#d3ea93ab95c8ae3c287443b6a565b33bd83e39ee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dejavu-sans-fonts",
+      "purl": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "version": "2.37-18.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bitstream Vera and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1479ec5203df4c3e577d1992b22c6976c142afa9",
+            "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688969",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/dejavu-fonts#1479ec5203df4c3e577d1992b22c6976c142afa9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "dnf-data",
+      "purl": "pkg:rpm/redhat/dnf-data@4.14.0-17.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/dnf-data@4.14.0-17.el9?arch=noarch",
+      "version": "4.14.0-17.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "181173a1c81b1ffedf6afe96d7d044bba1f235e6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#181173a1c81b1ffedf6afe96d7d044bba1f235e6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3209396",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/dnf#181173a1c81b1ffedf6afe96d7d044bba1f235e6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "file-libs",
+      "purl": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "version": "5.39-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2800051",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/file#ff838f9ddc71672e2cc28c34d9c9ee3bb71a786c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "filesystem",
+      "purl": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "version": "3.16-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a5b75452255bee32dd79cb51dea804d566ac9e30",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3134118",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/filesystem#a5b75452255bee32dd79cb51dea804d566ac9e30",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "fonts-filesystem",
+      "purl": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "version": "1:2.0.5-7.el9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ac288ee82aa9655c3784dd2f59cedb3562638129",
+            "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1732053",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/fonts-rpm-macros#ac288ee82aa9655c3784dd2f59cedb3562638129",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gawk",
+      "purl": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "version": "5.1.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv2+ and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3830530bfc524ab9b89fafe76d58a388675ecc11",
+            "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1891122",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gawk#3830530bfc524ab9b89fafe76d58a388675ecc11",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gdbm-libs",
+      "purl": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "version": "1:1.23-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1a66bb7ed77701afec99503ce9602021bc24092b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995292",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gdbm#1a66bb7ed77701afec99503ce9602021bc24092b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "github.com/OneOfOne/xxhash",
+      "purl": "pkg:golang/github.com/OneOfOne/xxhash@v1.2.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/OneOfOne/xxhash@v1.2.8",
+      "version": "v1.2.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/XiaoMi/pegasus-go-client",
+      "purl": "pkg:golang/github.com/XiaoMi/pegasus-go-client@v0.0.0-20210427083443-f3b6b08bc4c2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/XiaoMi/pegasus-go-client@v0.0.0-20210427083443-f3b6b08bc4c2",
+      "version": "v0.0.0-20210427083443-f3b6b08bc4c2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/agnivade/levenshtein",
+      "purl": "pkg:golang/github.com/agnivade/levenshtein@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/agnivade/levenshtein@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/authzed/authzed-go",
+      "purl": "pkg:golang/github.com/authzed/authzed-go@v0.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/authzed/authzed-go@v0.7.0",
+      "version": "v0.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/authzed/grpcutil",
+      "purl": "pkg:golang/github.com/authzed/grpcutil@v0.0.0-20230908193239-4286bb1d6403",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/authzed/grpcutil@v0.0.0-20230908193239-4286bb1d6403",
+      "version": "v0.0.0-20230908193239-4286bb1d6403",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/beorn7/perks",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "version": "v1.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/bradfitz/gomemcache",
+      "purl": "pkg:golang/github.com/bradfitz/gomemcache@v0.0.0-20190913173617-a41fca850d0b",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/bradfitz/gomemcache@v0.0.0-20190913173617-a41fca850d0b",
+      "version": "v0.0.0-20190913173617-a41fca850d0b",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cenkalti/backoff/v4",
+      "purl": "pkg:golang/github.com/cenkalti/backoff@v4.2.1#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cenkalti/backoff@v4.2.1#v4",
+      "version": "v4.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/certifi/gocertifi",
+      "purl": "pkg:golang/github.com/certifi/gocertifi@v0.0.0-20210507211836-431795d63e8d",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/certifi/gocertifi@v0.0.0-20210507211836-431795d63e8d",
+      "version": "v0.0.0-20210507211836-431795d63e8d",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cespare/xxhash/v2",
+      "purl": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "version": "v2.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cncf/xds/go",
+      "purl": "pkg:golang/github.com/cncf/xds@v0.0.0-20231128003011-0fa0005c9caa#go",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cncf/xds@v0.0.0-20231128003011-0fa0005c9caa#go",
+      "version": "v0.0.0-20231128003011-0fa0005c9caa",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coocood/freecache",
+      "purl": "pkg:golang/github.com/coocood/freecache@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coocood/freecache@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/coreos/go-oidc",
+      "purl": "pkg:golang/github.com/coreos/go-oidc@v2.2.1%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-oidc@v2.2.1%2Bincompatible",
+      "version": "v2.2.1+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/dgryski/go-rendezvous",
+      "purl": "pkg:golang/github.com/dgryski/go-rendezvous@v0.0.0-20200823014737-9f7001d12a5f",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgryski/go-rendezvous@v0.0.0-20200823014737-9f7001d12a5f",
+      "version": "v0.0.0-20200823014737-9f7001d12a5f",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/eko/gocache",
+      "purl": "pkg:golang/github.com/eko/gocache@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/eko/gocache@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/emicklei/go-restful/v3",
+      "purl": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "version": "v3.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/envoyproxy/go-control-plane",
+      "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/envoyproxy/protoc-gen-validate",
+      "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "version": "v5.6.0+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/evanphx/json-patch/v5",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v5.6.0#v5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0#v5",
+      "version": "v5.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/felixge/httpsnoop",
+      "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+      "version": "v1.0.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fsnotify/fsnotify",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "version": "v1.7.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-ini/ini",
+      "purl": "pkg:golang/github.com/go-ini/ini@v1.67.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-ini/ini@v1.67.0",
+      "version": "v1.67.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-jose/go-jose/v4",
+      "purl": "pkg:golang/github.com/go-jose/go-jose@v4.0.2#v4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-jose/go-jose@v4.0.2#v4",
+      "version": "v4.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/logr",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "version": "v1.4.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/stdr",
+      "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+      "version": "v1.2.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-logr/zapr",
+      "purl": "pkg:golang/github.com/go-logr/zapr@v1.2.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/zapr@v1.2.4",
+      "version": "v1.2.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonpointer",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+      "version": "v0.19.6",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/jsonreference",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "version": "v0.20.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-openapi/swag",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.22.3",
+      "version": "v0.22.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-redis/redis/v8",
+      "purl": "pkg:golang/github.com/go-redis/redis@v8.11.5#v8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-redis/redis@v8.11.5#v8",
+      "version": "v8.11.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gobwas/glob",
+      "purl": "pkg:golang/github.com/gobwas/glob@v0.2.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gobwas/glob@v0.2.3",
+      "version": "v0.2.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/googleapis",
+      "purl": "pkg:golang/github.com/gogo/googleapis@v1.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/googleapis@v1.4.0",
+      "version": "v1.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gogo/protobuf",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "version": "v1.3.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang-jwt/jwt",
+      "purl": "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible",
+      "version": "v3.2.2+incompatible",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/groupcache",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/mock",
+      "purl": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/golang/protobuf",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "version": "v1.5.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gnostic-models",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "version": "v0.6.8",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "version": "v0.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/gofuzz",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/gorilla/mux",
+      "purl": "pkg:golang/github.com/gorilla/mux@v1.8.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/mux@v1.8.1",
+      "version": "v1.8.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grpc-ecosystem/go-grpc-middleware",
+      "purl": "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0",
+      "version": "v1.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grpc-ecosystem/go-grpc-prometheus",
+      "purl": "pkg:golang/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/grpc-ecosystem/grpc-gateway/v2",
+      "purl": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.16.0#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.16.0#v2",
+      "version": "v2.16.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/errwrap",
+      "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+      "version": "v1.1.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/hashicorp/go-multierror",
+      "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/imdario/mergo",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.12",
+      "version": "v0.3.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/josharian/intern",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/json-iterator/go",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "version": "v1.1.12",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/jzelinskie/stringz",
+      "purl": "pkg:golang/github.com/jzelinskie/stringz@v0.0.0-20210414224931-d6a8ce844a70",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jzelinskie/stringz@v0.0.0-20210414224931-d6a8ce844a70",
+      "version": "v0.0.0-20210414224931-d6a8ce844a70",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/kuadrant/authorino",
+      "purl": "pkg:golang/github.com/kuadrant/authorino@v0.18.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kuadrant/authorino@v0.18.1",
+      "version": "v0.18.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mailru/easyjson",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "version": "v0.7.7",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/concurrent",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/modern-go/reflect2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "version": "v1.0.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/munnerz/goautoneg",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/open-policy-agent/opa",
+      "purl": "pkg:golang/github.com/open-policy-agent/opa@v0.64.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/open-policy-agent/opa@v0.64.1",
+      "version": "v0.64.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pegasus-kv/thrift",
+      "purl": "pkg:golang/github.com/pegasus-kv/thrift@v0.13.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pegasus-kv/thrift@v0.13.0",
+      "version": "v0.13.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pquerna/cachecontrol",
+      "purl": "pkg:golang/github.com/pquerna/cachecontrol@v0.0.0-20201205024021-ac21108117ac",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pquerna/cachecontrol@v0.0.0-20201205024021-ac21108117ac",
+      "version": "v0.0.0-20201205024021-ac21108117ac",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_golang",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_golang@v1.19.0",
+      "version": "v1.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/client_model",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.6.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.6.1",
+      "version": "v0.6.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/common",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.48.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/common@v0.48.0",
+      "version": "v0.48.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/prometheus/procfs",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.12.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.12.0",
+      "version": "v0.12.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rcrowley/go-metrics",
+      "purl": "pkg:golang/github.com/rcrowley/go-metrics@v0.0.0-20200313005456-10cdbea86bc0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rcrowley/go-metrics@v0.0.0-20200313005456-10cdbea86bc0",
+      "version": "v0.0.0-20200313005456-10cdbea86bc0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/sirupsen/logrus",
+      "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+      "version": "v1.9.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cast",
+      "purl": "pkg:golang/github.com/spf13/cast@v1.6.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cast@v1.6.0",
+      "version": "v1.6.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.8.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.0",
+      "version": "v1.8.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "version": "v1.0.5",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.4",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.4",
+      "version": "v1.8.4",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tchap/go-patricia/v2",
+      "purl": "pkg:golang/github.com/tchap/go-patricia@v2.3.1#v2",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tchap/go-patricia@v2.3.1#v2",
+      "version": "v2.3.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/gjson",
+      "purl": "pkg:golang/github.com/tidwall/gjson@v1.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tidwall/gjson@v1.14.0",
+      "version": "v1.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/match",
+      "purl": "pkg:golang/github.com/tidwall/match@v1.1.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tidwall/match@v1.1.1",
+      "version": "v1.1.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/pretty",
+      "purl": "pkg:golang/github.com/tidwall/pretty@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/tidwall/pretty@v1.2.0",
+      "version": "v1.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/xeipuuv/gojsonpointer",
+      "purl": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20190905194746-02993c407bfb",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20190905194746-02993c407bfb",
+      "version": "v0.0.0-20190905194746-02993c407bfb",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/xeipuuv/gojsonreference",
+      "purl": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+      "version": "v0.0.0-20180127040603-bd5ef7bd5415",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "github.com/yashtewari/glob-intersection",
+      "purl": "pkg:golang/github.com/yashtewari/glob-intersection@v0.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yashtewari/glob-intersection@v0.2.0",
+      "version": "v0.2.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "glib2",
+      "purl": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.1?arch=x86_64",
+      "version": "2.68.4-14.el9_4.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "a4080c6567c27ca88400de0bf1f27a36ca15d532",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#a4080c6567c27ca88400de0bf1f27a36ca15d532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3269928",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glib2#a4080c6567c27ca88400de0bf1f27a36ca15d532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc",
+      "purl": "pkg:rpm/redhat/glibc@2.34-125.el9_5.8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc@2.34-125.el9_5.8?arch=x86_64",
+      "version": "2.34-125.el9_5.8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3588685",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/redhat/glibc-common@2.34-125.el9_5.8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-common@2.34-125.el9_5.8?arch=x86_64",
+      "version": "2.34-125.el9_5.8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3588685",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-125.el9_5.8?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-125.el9_5.8?arch=x86_64",
+      "version": "2.34-125.el9_5.8",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3588685",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/glibc#2f478ae3d4804b26fbb1a980a30eed6903f08d9d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gmp",
+      "purl": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "version": "1:6.2.0-13.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+            "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2625518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gmp#6fdd58bd8d71cbe9e084a57bfe87f0abd4390124",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnupg2",
+      "purl": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "version": "2.3.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+            "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2481337",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gnupg2#fac10d0d25c2f70085c4736552150e0eed4ffb6b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "gnutls",
+      "purl": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=x86_64",
+      "version": "3.8.3-4.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b54e951cdf0ff84604b3276d170ca887da165199",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b54e951cdf0ff84604b3276d170ca887da165199"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2989518",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gnutls#b54e951cdf0ff84604b3276d170ca887da165199",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
+      "purl": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#google.golang.org/grpc/otelgrpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#google.golang.org/grpc/otelgrpc",
+      "version": "v0.46.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+      "purl": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#net/http/otelhttp",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#net/http/otelhttp",
+      "version": "v0.46.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel",
+      "purl": "pkg:golang/go.opentelemetry.io/otel@v1.21.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel@v1.21.0",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracegrpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracegrpc",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracehttp",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracehttp",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/metric",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/metric@v1.21.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/metric@v1.21.0",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/sdk",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.21.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.21.0",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/otel/trace",
+      "purl": "pkg:golang/go.opentelemetry.io/otel/trace@v1.21.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/otel/trace@v1.21.0",
+      "version": "v1.21.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.opentelemetry.io/proto/otlp",
+      "purl": "pkg:golang/go.opentelemetry.io/proto/otlp@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opentelemetry.io/proto/otlp@v1.0.0",
+      "version": "v1.0.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.uber.org/multierr",
+      "purl": "pkg:golang/go.uber.org/multierr@v1.11.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.uber.org/multierr@v1.11.0",
+      "version": "v1.11.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "go.uber.org/zap",
+      "purl": "pkg:golang/go.uber.org/zap@v1.25.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/go.uber.org/zap@v1.25.0",
+      "version": "v1.25.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gobject-introspection",
+      "purl": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "version": "1.68.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5fa3808a6c90b0da8da9a85fad983244c13640ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2248264",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gobject-introspection#5fa3808a6c90b0da8da9a85fad983244c13640ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.22.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.22.0",
+      "version": "v0.22.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/exp",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230905200255-921286631fa9",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230905200255-921286631fa9",
+      "version": "v0.0.0-20230905200255-921286631fa9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/net",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "version": "v0.24.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.17.0",
+      "version": "v0.17.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/term",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "version": "v0.19.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "version": "v0.14.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/time",
+      "purl": "pkg:golang/golang.org/x/time@v0.5.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.5.0",
+      "version": "v0.5.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gomodules.xyz/jsonpatch/v2",
+      "purl": "pkg:golang/gomodules.xyz/jsonpatch/v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gomodules.xyz/jsonpatch/v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/api",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#api",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#api",
+      "version": "v0.0.0-20240227224415-6ceb2ff114de",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/genproto/googleapis/rpc",
+      "purl": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#rpc",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#rpc",
+      "version": "v0.0.0-20240227224415-6ceb2ff114de",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/grpc",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.63.2",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.63.2",
+      "version": "v1.63.2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "google.golang.org/protobuf",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "version": "v1.33.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/inf.v0",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "version": "v0.9.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/natefinch/lumberjack.v2",
+      "purl": "pkg:golang/gopkg.in/natefinch/lumberjack.v2@v2.2.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/natefinch/lumberjack.v2@v2.2.1",
+      "version": "v2.2.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/square/go-jose.v2",
+      "purl": "pkg:golang/gopkg.in/square/go-jose.v2@v2.5.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/square/go-jose.v2@v2.5.1",
+      "version": "v2.5.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/tomb.v2",
+      "purl": "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
+      "version": "v2.0.0-20161208151619-d5d1b5820637",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "version": "v2.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "version": "v3.0.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "version": "5a6340b3-6229229e",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpg-pubkey",
+      "purl": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "version": "fd431d51-4ae0493b",
+      "licenses": [
+        {
+          "license": {
+            "name": "pubkey"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ]
+    },
+    {
+      "name": "gpgme",
+      "purl": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "version": "1.15.1-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+            "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1892040",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/gpgme#9fe4c3fa6fa88cbf191b3b05da0fa51a018bd925",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "grep",
+      "purl": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "version": "3.6-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7779e81140d7afaf33d2a97f4afdd682457f9697",
+            "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689607",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/grep#7779e81140d7afaf33d2a97f4afdd682457f9697",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "purl": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "version": "0.14-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "391500fb2a46f72180ba1353136c1b3327d71c55",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1728857",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-c#391500fb2a46f72180ba1353136c1b3327d71c55",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "json-glib",
+      "purl": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "version": "1.6.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d5548792bb86a77330957962541a936d9c391896",
+            "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1707185",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/json-glib#d5548792bb86a77330957962541a936d9c391896",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/api",
+      "purl": "pkg:golang/k8s.io/api@v0.28.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.28.3",
+      "version": "v0.28.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apiextensions-apiserver",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.28.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.28.3",
+      "version": "v0.28.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/apimachinery",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.28.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.28.3",
+      "version": "v0.28.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/client-go",
+      "purl": "pkg:golang/k8s.io/client-go@v0.28.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.28.3",
+      "version": "v0.28.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/component-base",
+      "purl": "pkg:golang/k8s.io/component-base@v0.28.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/component-base@v0.28.3",
+      "version": "v0.28.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/klog/v2",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.100.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.100.1",
+      "version": "v2.100.1",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/kube-openapi",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230717233707-2695361300d9",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230717233707-2695361300d9",
+      "version": "v0.0.0-20230717233707-2695361300d9",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "k8s.io/utils",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20230406110748-d93618cff8a2",
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20230406110748-d93618cff8a2",
+      "version": "v0.0.0-20230406110748-d93618cff8a2",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "keyutils-libs",
+      "purl": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "version": "1.6.3-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+            "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2212253",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/keyutils#8b733aad43e6981c2c0e87ad5aa39f30fcfd6e69",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "krb5-libs",
+      "purl": "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=x86_64",
+      "version": "1.21.1-4.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2b904f4c4adf013b85bdecedff48b2dc440f2d83",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#2b904f4c4adf013b85bdecedff48b2dc440f2d83"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3346321",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/krb5#2b904f4c4adf013b85bdecedff48b2dc440f2d83",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-core-font-en",
+      "purl": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "langpacks-en",
+      "purl": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "version": "3.0-16.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+            "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689786",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/langpacks#2a2f67a911d19f353ac145c4a4c74bd46e470eee",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libacl",
+      "purl": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "version": "2.3.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2709815",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/acl#07e00cdabc3c0506d69462d5541a12f90e5c9d60",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libarchive",
+      "purl": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64",
+      "version": "3.5.3-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "de13b461c631e54afaad91437aa1e35c59d4873d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libarchive#de13b461c631e54afaad91437aa1e35c59d4873d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2293132",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libarchive#de13b461c631e54afaad91437aa1e35c59d4873d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libassuan",
+      "purl": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "version": "2.5.5-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5b185f851a42718727fee9efcf42ba525a59a8bb",
+            "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1689887",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libassuan#5b185f851a42718727fee9efcf42ba525a59a8bb",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libattr",
+      "purl": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "version": "2.5.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+            "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1688838",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/attr#35f2e4ded627fd996de438e461ded8ec9eb4af1b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libblkid",
+      "purl": "pkg:rpm/redhat/libblkid@2.37.4-20.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libblkid@2.37.4-20.el9?arch=x86_64",
+      "version": "2.37.4-20.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045bde2d084eaa0d6075207b24306d202178841c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3242400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap",
+      "purl": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "version": "2.48-9.el9_2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD or GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2590508",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap#579dc340bc85f77708d4c04f72f9cc7c2ad16e27",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcap-ng",
+      "purl": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "version": "0.8.2-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1888632",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libcap-ng#1c0fd873df97a4b29000206bd9b0f6d0ee54a2a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcom_err",
+      "purl": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "version": "1.46.5-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55211469981d94577ec3da753afcdf2cc4d651ab",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820207",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/e2fsprogs#55211469981d94577ec3da753afcdf2cc4d651ab",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libcurl-minimal",
+      "purl": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64",
+      "version": "7.76.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "36c10becf42f5173a562543d8006ad15c125ac2c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#36c10becf42f5173a562543d8006ad15c125ac2c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3243256",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/curl#36c10becf42f5173a562543d8006ad15c125ac2c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libdnf",
+      "purl": "pkg:rpm/redhat/libdnf@0.69.0-12.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libdnf@0.69.0-12.el9?arch=x86_64",
+      "version": "0.69.0-12.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "58d2db3e7dbaa54208dff6025439ad2795ab03cd",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#58d2db3e7dbaa54208dff6025439ad2795ab03cd"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3130069",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libdnf#58d2db3e7dbaa54208dff6025439ad2795ab03cd",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libevent",
+      "purl": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "version": "2.1.12-8.el9_4",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and ISC"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3235991",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libevent#d83a5ab76c1a33ce50cacfd40160e428b7c39221",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libffi",
+      "purl": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "version": "3.4.2-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6f484e5230669fffb71870ce41c386e01ab4e47d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467679",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libffi#6f484e5230669fffb71870ce41c386e01ab4e47d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcc",
+      "purl": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3501765",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "purl": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "version": "1.10.0-11.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3202712",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libgcrypt#6cd6cde2ff10db934bd6b9be9ecdfe75edebb67a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "purl": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "version": "1.42-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "55660568a38dad2e4a858df692830af766ad6532",
+            "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1818836",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libgpg-error#55660568a38dad2e4a858df692830af766ad6532",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libidn2",
+      "purl": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "version": "2.3.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(GPLv2+ or LGPLv3+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c781354177446e1bb6a5b48d2113feaed50cc860",
+            "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690002",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libidn2#c781354177446e1bb6a5b48d2113feaed50cc860",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libksba",
+      "purl": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "version": "1.5.1-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "(LGPLv3+ or GPLv2+) and GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3198143",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libksba#ced1b2ff933b56b33f08882bb4e5ddba997afaa6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmodulemd",
+      "purl": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "version": "2.13.0-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d48969327abbcbfad2ab893639cfb7d22362223d",
+            "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1695462",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libmodulemd#d48969327abbcbfad2ab893639cfb7d22362223d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libmount",
+      "purl": "pkg:rpm/redhat/libmount@2.37.4-20.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libmount@2.37.4-20.el9?arch=x86_64",
+      "version": "2.37.4-20.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045bde2d084eaa0d6075207b24306d202178841c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3242400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libnghttp2",
+      "purl": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "version": "1.43.0-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "79861abb0ea729bcf418eabaf5027b18ba623bf9",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nghttp2#79861abb0ea729bcf418eabaf5027b18ba623bf9",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libpeas",
+      "purl": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "version": "1.30.0-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "14f3f166e32b0592b8a0289de0e7050df985f9a0",
+            "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690090",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libpeas#14f3f166e32b0592b8a0289de0e7050df985f9a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librepo",
+      "purl": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "version": "1.14.5-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "458f8b732e9d31cbe09323c87f796924ac30461c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2797210",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librepo#458f8b732e9d31cbe09323c87f796924ac30461c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libreport-filesystem",
+      "purl": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "version": "2.15.2-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "4690267165817ccc06cb342d8ef955ae10b54c75",
+            "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1852394",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libreport#4690267165817ccc06cb342d8ef955ae10b54c75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "librhsm",
+      "purl": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "version": "0.0.3-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "bf2220747d150d79be10852ee5e990f99d7f2a77",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2996611",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/librhsm#bf2220747d150d79be10852ee5e990f99d7f2a77",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libselinux",
+      "purl": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b604bc7c7288a43b90e0f88226ddff652b945e40",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2821561",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libselinux#b604bc7c7288a43b90e0f88226ddff652b945e40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsemanage",
+      "purl": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_5?arch=x86_64",
+      "version": "3.6-2.1.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "303e790d443c463186a571078fce19f8f89a530e",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#303e790d443c463186a571078fce19f8f89a530e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3418015",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsemanage#303e790d443c463186a571078fce19f8f89a530e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsepol",
+      "purl": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "version": "3.6-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d568b2713a4280fad93a660b66d5047296c3853f",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2820602",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsepol#d568b2713a4280fad93a660b66d5047296c3853f",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsigsegv",
+      "purl": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "version": "2.13-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "b3dee05a0458f11a68b0f9a878aa676670814326",
+            "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690130",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libsigsegv#b3dee05a0458f11a68b0f9a878aa676670814326",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsmartcols",
+      "purl": "pkg:rpm/redhat/libsmartcols@2.37.4-20.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsmartcols@2.37.4-20.el9?arch=x86_64",
+      "version": "2.37.4-20.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045bde2d084eaa0d6075207b24306d202178841c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3242400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libsolv",
+      "purl": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "version": "0.7.24-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "334959330f40393346bb399506b5c5081231109d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2995003",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libsolv#334959330f40393346bb399506b5c5081231109d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libstdc++",
+      "purl": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "version": "11.5.0-5.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ with exceptions and LGPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3501765",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/gcc#94f8d08fea6e2026c7aa2ba346696bed8a1555f6",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libtasn1",
+      "purl": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64",
+      "version": "4.16.0-8.el9_1",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+ and LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "1f4838353e54ba7f401be2e0010bb516f5f8b878",
+            "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#1f4838353e54ba7f401be2e0010bb516f5f8b878"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2286653",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libtasn1#1f4838353e54ba7f401be2e0010bb516f5f8b878",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libunistring",
+      "purl": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "version": "0.9.10-15.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ or LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+            "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690195",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libunistring#3a88a751f026c2b2a316eec8f46d3624eb80d7b1",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libusbx",
+      "purl": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "version": "1.0.26-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "e369f619a0e615f4b86409c454308b316c0a78b7",
+            "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1986004",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libusbx#e369f619a0e615f4b86409c454308b316c0a78b7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libuuid",
+      "purl": "pkg:rpm/redhat/libuuid@2.37.4-20.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libuuid@2.37.4-20.el9?arch=x86_64",
+      "version": "2.37.4-20.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "045bde2d084eaa0d6075207b24306d202178841c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3242400",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/util-linux#045bde2d084eaa0d6075207b24306d202178841c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libverto",
+      "purl": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "version": "0.3.2-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+            "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690209",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libverto#001b0ae5e53da5bbdb9a545f9509d8a6e02f530a",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxcrypt",
+      "purl": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "version": "4.4.18-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and BSD and Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "5ae2c88752320b1d81d70ae38259ce56b1c692de",
+            "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690260",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libxcrypt#5ae2c88752320b1d81d70ae38259ce56b1c692de",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libxml2",
+      "purl": "pkg:rpm/redhat/libxml2@2.9.13-6.el9_5.2?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libxml2@2.9.13-6.el9_5.2?arch=x86_64",
+      "version": "2.9.13-6.el9_5.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "fea643dd547539bba90534e6bb7b7b1f90f5ac3c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#fea643dd547539bba90534e6bb7b7b1f90f5ac3c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3550038",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/libxml2#fea643dd547539bba90534e6bb7b7b1f90f5ac3c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libyaml",
+      "purl": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "version": "0.2.5-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "70e1549fe5e56c95f1e23967e02c657d7af570ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690356",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/libyaml#70e1549fe5e56c95f1e23967e02c657d7af570ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "libzstd",
+      "purl": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "version": "1.5.1-2.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dcda9fe564e51b7222a5efca3b14840bcc341b44",
+            "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1879398",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zstd#dcda9fe564e51b7222a5efca3b14840bcc341b44",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lua-libs",
+      "purl": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "version": "5.4.4-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "8d795270f6d1372b9636433ed1fb08b2439eed16",
+            "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2467503",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lua#8d795270f6d1372b9636433ed1fb08b2439eed16",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "lz4-libs",
+      "purl": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "version": "1.9.3-5.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+            "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690509",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/lz4#7b28c998dab8a99b5fa04e897bfb31deb38ec2ba",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "microdnf",
+      "purl": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "version": "3.9.1-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cc6603992b29365e456f8747a8d17c17b8dc45a4",
+            "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2324298",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/microdnf#cc6603992b29365e456f8747a8d17c17b8dc45a4",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "mpfr",
+      "purl": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "version": "4.1.0-7.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "207ac3816285664c0c73fa4894dbdead53d1ca40",
+            "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690656",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/mpfr#207ac3816285664c0c73fa4894dbdead53d1ca40",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-base",
+      "purl": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch",
+      "version": "6.2-10.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98deb1ab40c22f7f3b7727c23a62fea43946c0c0",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#98deb1ab40c22f7f3b7727c23a62fea43946c0c0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2643605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#98deb1ab40c22f7f3b7727c23a62fea43946c0c0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "ncurses-libs",
+      "purl": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64",
+      "version": "6.2-10.20210508.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "98deb1ab40c22f7f3b7727c23a62fea43946c0c0",
+            "url": "git://pkgs.devel.redhat.com/rpms/ncurses#98deb1ab40c22f7f3b7727c23a62fea43946c0c0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2643605",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/ncurses#98deb1ab40c22f7f3b7727c23a62fea43946c0c0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "nettle",
+      "purl": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "version": "3.9.1-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv3+ or GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2785925",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/nettle#7e4a847c42da5300f4bac05df9a0fb140e0a2ed2",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "npth",
+      "purl": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "version": "1.6-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+            "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1690792",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/npth#00dacd37cfbc19be13be2d910d23e39f5c849fcc",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openldap",
+      "purl": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "version": "2.6.6-3.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "OLDAP-2.8"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "409b72030310df96b296a5dd8cf80f0a211cc038",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2899087",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openldap#409b72030310df96b296a5dd8cf80f0a211cc038",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3378feb4c39482e9191806ec051c29f3e56ffda7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3289267",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-fips-provider-so",
+      "purl": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "version": "3.0.7-6.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3378feb4c39482e9191806ec051c29f3e56ffda7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3289267",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl-fips-provider#3378feb4c39482e9191806ec051c29f3e56ffda7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "openssl-libs",
+      "purl": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "version": "1:3.2.2-6.el9_5.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ASL 2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "2c6e91ce81908f921a235e85391ba3676a6825a7",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3487083",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#2c6e91ce81908f921a235e85391ba3676a6825a7",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit",
+      "purl": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "p11-kit-trust",
+      "purl": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "version": "0.25.3-3.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "3af459e136c2ab22bad5a3577540eae19c51e96c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3361662",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/p11-kit#3af459e136c2ab22bad5a3577540eae19c51e96c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre",
+      "purl": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "version": "8.44-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3009164",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre#d94c9b77e3a4ea15a6f946ef3c050bc09f6742a0",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2",
+      "purl": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "pcre2-syntax",
+      "purl": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "version": "10.40-6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3200608",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/pcre2#0715e9e4f078efd0299ed2dbda1c777a7c65f658",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "popt",
+      "purl": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "version": "1.18-8.el9",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+            "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691597",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/popt#30c0ac9823db95a04ab1dc0f65f4e77ec2c25fa5",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "readline",
+      "purl": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "version": "8.1-4.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "be386f45be1322adf2bd79dd94c9904c4efa3d22",
+            "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691921",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/readline#be386f45be1322adf2bd79dd94c9904c4efa3d22",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "redhat-release",
+      "purl": "pkg:rpm/redhat/redhat-release@9.5-0.6.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/redhat-release@9.5-0.6.el9?arch=x86_64",
+      "version": "9.5-0.6.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "db981623382b242d5d7eb70628aafc5a61f6a09c",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#db981623382b242d5d7eb70628aafc5a61f6a09c"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3303934",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/redhat-release#db981623382b242d5d7eb70628aafc5a61f6a09c",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rootfiles",
+      "purl": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "version": "8.1-31.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "30d4e6354acbcb23c1f2485151e08cc352871e75",
+            "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1691770",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/rootfiles#30d4e6354acbcb23c1f2485151e08cc352871e75",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm",
+      "purl": "pkg:rpm/redhat/rpm@4.16.1.3-34.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm@4.16.1.3-34.el9?arch=x86_64",
+      "version": "4.16.1.3-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad0cd9e4d222c4f0cea35c6e0d55e41882741880",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#ad0cd9e4d222c4f0cea35c6e0d55e41882741880"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3226609",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#ad0cd9e4d222c4f0cea35c6e0d55e41882741880",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "rpm-libs",
+      "purl": "pkg:rpm/redhat/rpm-libs@4.16.1.3-34.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-34.el9?arch=x86_64",
+      "version": "4.16.1.3-34.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv2+ and LGPLv2+ with exceptions"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ad0cd9e4d222c4f0cea35c6e0d55e41882741880",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#ad0cd9e4d222c4f0cea35c6e0d55e41882741880"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3226609",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/rpm#ad0cd9e4d222c4f0cea35c6e0d55e41882741880",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sed",
+      "purl": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "version": "4.8-9.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "GPLv3+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "dad14ff8a62e967c0afb23d1d237a927d847e86e",
+            "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1692031",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/sed#dad14ff8a62e967c0afb23d1d237a927d847e86e",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "setup",
+      "purl": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "version": "2.13.7-10.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2892761",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/setup#0715e1fecad7542c1b9fdffa2d072f802b2b173b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "shadow-utils",
+      "purl": "pkg:rpm/redhat/shadow-utils@4.9-10.el9_5?arch=x86_64&epoch=2",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/shadow-utils@4.9-10.el9_5?arch=x86_64&epoch=2",
+      "version": "2:4.9-10.el9_5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD and GPLv2+"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cbd5dd541f26e6af94277b44944023b75d67bdb3",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#cbd5dd541f26e6af94277b44944023b75d67bdb3"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3285706",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/shadow-utils#cbd5dd541f26e6af94277b44944023b75d67bdb3",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/controller-runtime",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.16.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.16.3",
+      "version": "v0.16.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/json",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "version": "v4.2.3",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "version": "v1.4.0",
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "sqlite-libs",
+      "purl": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64",
+      "version": "3.34.1-7.el9_3",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "cfe68a6673a1d114d101ba724f82fb4f6947a08d",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#cfe68a6673a1d114d101ba724f82fb4f6947a08d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2838018",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/sqlite#cfe68a6673a1d114d101ba724f82fb4f6947a08d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "stdlib",
+      "purl": "pkg:golang/stdlib@1.22.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/stdlib@1.22.7",
+      "version": "go1.22.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sbomer:package:language",
+          "value": "go"
+        },
+        {
+          "name": "sbomer:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/home/authorino/bin/authorino"
+        }
+      ]
+    },
+    {
+      "name": "systemd-libs",
+      "purl": "pkg:rpm/redhat/systemd-libs@252-46.el9_5.3?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/systemd-libs@252-46.el9_5.3?arch=x86_64",
+      "version": "252-46.el9_5.3",
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPLv2+ and MIT"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "6e369d16c0a0994f4c7576bbfa53f4d754c26e3b",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#6e369d16c0a0994f4c7576bbfa53f4d754c26e3b"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3491956",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/systemd#6e369d16c0a0994f4c7576bbfa53f4d754c26e3b",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "tzdata",
+      "purl": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "version": "2025b-1.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "ff671e79a03e80cf1c432e92fa02aff95d597a97",
+            "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3572007",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git+https://pkgs.devel.redhat.com/git/rpms/tzdata#ff671e79a03e80cf1c432e92fa02aff95d597a97",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "xz-libs",
+      "purl": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "version": "5.2.5-8.el9_0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Public Domain"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+            "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2032531",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/xz#eb3e0ec613440600e9e6afa2cfc4738d3bc78458",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "purl": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "version": "1.2.11-40.el9",
+      "licenses": [
+        {
+          "license": {
+            "name": "zlib and Boost"
+          }
+        }
+      ],
+      "pedigree": {
+        "commits": [
+          {
+            "uid": "c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+            "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d"
+          }
+        ]
+      },
+      "supplier": {
+        "url": [
+          "https://www.redhat.com"
+        ],
+        "name": "Red Hat"
+      },
+      "publisher": "Red Hat",
+      "properties": [
+        {
+          "name": "sbomer:package:type",
+          "value": "rpm"
+        },
+        {
+          "name": "sbomer:location:0:path",
+          "value": "/var/lib/rpm/rpmdb.sqlite"
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2495976",
+          "type": "build-system",
+          "comment": "brew-build-id"
+        },
+        {
+          "url": "git://pkgs.devel.redhat.com/rpms/zlib#c10ee2a909da9fb42ae05a9fc897a1a1101f422d",
+          "type": "vcs",
+          "comment": ""
+        }
+      ]
+    }
+  ],
+  "specVersion": "1.6",
+  "dependencies": [
+    {
+      "ref": "pkg:oci/authorino-rhel9@sha256%3A9b5e51705afe32370d90820d498c29b442cde0b12d07953c9bee9d1f1467f792?arch=amd64&os=linux&tag=1.1.3-1",
+      "dependsOn": [
+        "pkg:rpm/redhat/alternatives@1.24-1.el9_5.1?arch=x86_64",
+        "pkg:rpm/redhat/audit-libs@3.1.5-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+        "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+        "pkg:rpm/redhat/coreutils-single@8.32-36.el9?arch=x86_64",
+        "pkg:rpm/redhat/crypto-policies@20240828-2.git626aa59.el9_5?arch=noarch",
+        "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64",
+        "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+        "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+        "pkg:rpm/redhat/dnf-data@4.14.0-17.el9?arch=noarch",
+        "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+        "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+        "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+        "pkg:golang/github.com/OneOfOne/xxhash@v1.2.8",
+        "pkg:golang/github.com/XiaoMi/pegasus-go-client@v0.0.0-20210427083443-f3b6b08bc4c2",
+        "pkg:golang/github.com/agnivade/levenshtein@v1.1.1",
+        "pkg:golang/github.com/authzed/authzed-go@v0.7.0",
+        "pkg:golang/github.com/authzed/grpcutil@v0.0.0-20230908193239-4286bb1d6403",
+        "pkg:golang/github.com/beorn7/perks@v1.0.1",
+        "pkg:golang/github.com/bradfitz/gomemcache@v0.0.0-20190913173617-a41fca850d0b",
+        "pkg:golang/github.com/cenkalti/backoff@v4.2.1#v4",
+        "pkg:golang/github.com/certifi/gocertifi@v0.0.0-20210507211836-431795d63e8d",
+        "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+        "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+        "pkg:golang/github.com/cncf/xds@v0.0.0-20231128003011-0fa0005c9caa#go",
+        "pkg:golang/github.com/coocood/freecache@v1.1.1",
+        "pkg:golang/github.com/coreos/go-oidc@v2.2.1%2Bincompatible",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+        "pkg:golang/github.com/dgryski/go-rendezvous@v0.0.0-20200823014737-9f7001d12a5f",
+        "pkg:golang/github.com/eko/gocache@v1.2.0",
+        "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+        "pkg:golang/github.com/envoyproxy/go-control-plane@v0.12.0",
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v1.0.4",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+        "pkg:golang/github.com/evanphx/json-patch@v5.6.0#v5",
+        "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+        "pkg:golang/github.com/go-ini/ini@v1.67.0",
+        "pkg:golang/github.com/go-jose/go-jose@v4.0.2#v4",
+        "pkg:golang/github.com/go-logr/logr@v1.4.1",
+        "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+        "pkg:golang/github.com/go-logr/zapr@v1.2.4",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+        "pkg:golang/github.com/go-openapi/swag@v0.22.3",
+        "pkg:golang/github.com/go-redis/redis@v8.11.5#v8",
+        "pkg:golang/github.com/gobwas/glob@v0.2.3",
+        "pkg:golang/github.com/gogo/googleapis@v1.4.0",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/golang/mock@v1.6.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.4",
+        "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "pkg:golang/github.com/google/gofuzz@v1.2.0",
+        "pkg:golang/github.com/google/uuid@v1.6.0",
+        "pkg:golang/github.com/gorilla/mux@v1.8.1",
+        "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0",
+        "pkg:golang/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0",
+        "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.16.0#v2",
+        "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+        "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+        "pkg:golang/github.com/imdario/mergo@v0.3.12",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/jzelinskie/stringz@v0.0.0-20210414224931-d6a8ce844a70",
+        "pkg:golang/github.com/kuadrant/authorino@v0.18.1",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/open-policy-agent/opa@v0.64.1",
+        "pkg:golang/github.com/pegasus-kv/thrift@v0.13.0",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+        "pkg:golang/github.com/pquerna/cachecontrol@v0.0.0-20201205024021-ac21108117ac",
+        "pkg:golang/github.com/prometheus/client_golang@v1.19.0",
+        "pkg:golang/github.com/prometheus/client_model@v0.6.1",
+        "pkg:golang/github.com/prometheus/common@v0.48.0",
+        "pkg:golang/github.com/prometheus/procfs@v0.12.0",
+        "pkg:golang/github.com/rcrowley/go-metrics@v0.0.0-20200313005456-10cdbea86bc0",
+        "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+        "pkg:golang/github.com/spf13/cast@v1.6.0",
+        "pkg:golang/github.com/spf13/cobra@v1.8.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.4",
+        "pkg:golang/github.com/tchap/go-patricia@v2.3.1#v2",
+        "pkg:golang/github.com/tidwall/gjson@v1.14.0",
+        "pkg:golang/github.com/tidwall/match@v1.1.1",
+        "pkg:golang/github.com/tidwall/pretty@v1.2.0",
+        "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20190905194746-02993c407bfb",
+        "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+        "pkg:golang/github.com/yashtewari/glob-intersection@v0.2.0",
+        "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.1?arch=x86_64",
+        "pkg:rpm/redhat/glibc@2.34-125.el9_5.8?arch=x86_64",
+        "pkg:rpm/redhat/glibc-common@2.34-125.el9_5.8?arch=x86_64",
+        "pkg:rpm/redhat/glibc-minimal-langpack@2.34-125.el9_5.8?arch=x86_64",
+        "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=x86_64",
+        "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#google.golang.org/grpc/otelgrpc",
+        "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#net/http/otelhttp",
+        "pkg:golang/go.opentelemetry.io/otel@v1.21.0",
+        "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace",
+        "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracegrpc",
+        "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracehttp",
+        "pkg:golang/go.opentelemetry.io/otel/metric@v1.21.0",
+        "pkg:golang/go.opentelemetry.io/otel/sdk@v1.21.0",
+        "pkg:golang/go.opentelemetry.io/otel/trace@v1.21.0",
+        "pkg:golang/go.opentelemetry.io/proto/otlp@v1.0.0",
+        "pkg:golang/go.uber.org/multierr@v1.11.0",
+        "pkg:golang/go.uber.org/zap@v1.25.0",
+        "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+        "pkg:golang/golang.org/x/crypto@v0.22.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20230905200255-921286631fa9",
+        "pkg:golang/golang.org/x/net@v0.24.0",
+        "pkg:golang/golang.org/x/oauth2@v0.17.0",
+        "pkg:golang/golang.org/x/sys@v0.19.0",
+        "pkg:golang/golang.org/x/term@v0.19.0",
+        "pkg:golang/golang.org/x/text@v0.14.0",
+        "pkg:golang/golang.org/x/time@v0.5.0",
+        "pkg:golang/gomodules.xyz/jsonpatch/v2@v2.4.0",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#api",
+        "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#rpc",
+        "pkg:golang/google.golang.org/grpc@v1.63.2",
+        "pkg:golang/google.golang.org/protobuf@v1.33.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/natefinch/lumberjack.v2@v2.2.1",
+        "pkg:golang/gopkg.in/square/go-jose.v2@v2.5.1",
+        "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+        "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+        "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+        "pkg:golang/k8s.io/api@v0.28.3",
+        "pkg:golang/k8s.io/apiextensions-apiserver@v0.28.3",
+        "pkg:golang/k8s.io/apimachinery@v0.28.3",
+        "pkg:golang/k8s.io/client-go@v0.28.3",
+        "pkg:golang/k8s.io/component-base@v0.28.3",
+        "pkg:golang/k8s.io/klog/v2@v2.100.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230717233707-2695361300d9",
+        "pkg:golang/k8s.io/utils@v0.0.0-20230406110748-d93618cff8a2",
+        "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+        "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libblkid@2.37.4-20.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+        "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64",
+        "pkg:rpm/redhat/libdnf@0.69.0-12.el9?arch=x86_64",
+        "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+        "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+        "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libmount@2.37.4-20.el9?arch=x86_64",
+        "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+        "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsmartcols@2.37.4-20.el9?arch=x86_64",
+        "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64",
+        "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+        "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/libuuid@2.37.4-20.el9?arch=x86_64",
+        "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/libxml2@2.9.13-6.el9_5.2?arch=x86_64",
+        "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+        "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+        "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+        "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch",
+        "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64",
+        "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+        "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+        "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+        "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+        "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+        "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+        "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+        "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+        "pkg:rpm/redhat/redhat-release@9.5-0.6.el9?arch=x86_64",
+        "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+        "pkg:rpm/redhat/rpm@4.16.1.3-34.el9?arch=x86_64",
+        "pkg:rpm/redhat/rpm-libs@4.16.1.3-34.el9?arch=x86_64",
+        "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+        "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+        "pkg:rpm/redhat/shadow-utils@4.9-10.el9_5?arch=x86_64&epoch=2",
+        "pkg:golang/sigs.k8s.io/controller-runtime@v0.16.3",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+        "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64",
+        "pkg:golang/stdlib@1.22.7",
+        "pkg:rpm/redhat/systemd-libs@252-46.el9_5.3?arch=x86_64",
+        "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+        "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+        "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64"
+      ]
+    },
+    {
+      "ref": "pkg:rpm/redhat/alternatives@1.24-1.el9_5.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/audit-libs@3.1.5-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/basesystem@11-13.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bash@5.1.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/bzip2-libs@1.0.8-10.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ca-certificates@2024.2.69_v8.0.303-91.4.el9_4?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/coreutils-single@8.32-36.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/crypto-policies@20240828-2.git626aa59.el9_5?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/curl-minimal@7.76.1-31.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/cyrus-sasl-lib@2.1.27-21.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dejavu-sans-fonts@2.37-18.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/dnf-data@4.14.0-17.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/file-libs@5.39-16.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/filesystem@3.16-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/fonts-filesystem@2.0.5-7.el9.1?arch=noarch&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gawk@5.1.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gdbm-libs@1.23-1.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/OneOfOne/xxhash@v1.2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/XiaoMi/pegasus-go-client@v0.0.0-20210427083443-f3b6b08bc4c2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/agnivade/levenshtein@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/authzed/authzed-go@v0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/authzed/grpcutil@v0.0.0-20230908193239-4286bb1d6403",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/bradfitz/gomemcache@v0.0.0-20190913173617-a41fca850d0b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cenkalti/backoff@v4.2.1#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/certifi/gocertifi@v0.0.0-20210507211836-431795d63e8d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cespare/xxhash@v2.2.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cncf/xds@v0.0.0-20231128003011-0fa0005c9caa#go",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coocood/freecache@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-oidc@v2.2.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgryski/go-rendezvous@v0.0.0-20200823014737-9f7001d12a5f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/eko/gocache@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful@v3.11.0#v3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v5.6.0#v5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-ini/ini@v1.67.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-jose/go-jose@v4.0.2#v4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/zapr@v1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.22.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-redis/redis@v8.11.5#v8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gobwas/glob@v0.2.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/googleapis@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/mux@v1.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway@v2.16.0#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jzelinskie/stringz@v0.0.0-20210414224931-d6a8ce844a70",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kuadrant/authorino@v0.18.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/open-policy-agent/opa@v0.64.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pegasus-kv/thrift@v0.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pquerna/cachecontrol@v0.0.0-20201205024021-ac21108117ac",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_golang@v1.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.6.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/common@v0.48.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rcrowley/go-metrics@v0.0.0-20200313005456-10cdbea86bc0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cast@v1.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.8.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/tchap/go-patricia@v2.3.1#v2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/tidwall/gjson@v1.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/tidwall/match@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/tidwall/pretty@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20190905194746-02993c407bfb",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yashtewari/glob-intersection@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glib2@2.68.4-14.el9_4.1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc@2.34-125.el9_5.8?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-common@2.34-125.el9_5.8?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/glibc-minimal-langpack@2.34-125.el9_5.8?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gmp@6.2.0-13.el9?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnupg2@2.3.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gnutls@3.8.3-4.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#google.golang.org/grpc/otelgrpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/contrib/instrumentation@v0.46.1#net/http/otelhttp",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel@v1.21.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracegrpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/exporters@v1.21.0#otlp/otlptrace/otlptracehttp",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/metric@v1.21.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.21.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/otel/trace@v1.21.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.opentelemetry.io/proto/otlp@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.uber.org/multierr@v1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/go.uber.org/zap@v1.25.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gobject-introspection@1.68.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.22.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20230905200255-921286631fa9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.19.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gomodules.xyz/jsonpatch/v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#api",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto/googleapis@v0.0.0-20240227224415-6ceb2ff114de#rpc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.63.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/natefinch/lumberjack.v2@v2.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/square/go-jose.v2@v2.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@5a6340b3-6229229e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpg-pubkey@fd431d51-4ae0493b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/gpgme@1.15.1-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/grep@3.6-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-c@0.14-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/json-glib@1.6.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.28.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apiextensions-apiserver@v0.28.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.28.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.28.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/component-base@v0.28.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.100.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20230717233707-2695361300d9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20230406110748-d93618cff8a2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/keyutils-libs@1.6.3-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/krb5-libs@1.21.1-4.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-core-font-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/langpacks-en@3.0-16.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libacl@2.3.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libarchive@3.5.3-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libassuan@2.5.5-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libattr@2.5.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libblkid@2.37.4-20.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap@2.48-9.el9_2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcap-ng@0.8.2-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcom_err@1.46.5-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libcurl-minimal@7.76.1-31.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libdnf@0.69.0-12.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libevent@2.1.12-8.el9_4?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libffi@3.4.2-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcc@11.5.0-5.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgcrypt@1.10.0-11.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libgpg-error@1.42-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libidn2@2.3.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libksba@1.5.1-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmodulemd@2.13.0-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libmount@2.37.4-20.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libnghttp2@1.43.0-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libpeas@1.30.0-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librepo@1.14.5-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libreport-filesystem@2.15.2-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/librhsm@0.0.3-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libselinux@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsemanage@3.6-2.1.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsepol@3.6-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsigsegv@2.13-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsmartcols@2.37.4-20.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libsolv@0.7.24-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libstdc%2B%2B@11.5.0-5.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libtasn1@4.16.0-8.el9_1?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libunistring@0.9.10-15.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libusbx@1.0.26-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libuuid@2.37.4-20.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libverto@0.3.2-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxcrypt@4.4.18-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libxml2@2.9.13-6.el9_5.2?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libyaml@0.2.5-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/libzstd@1.5.1-2.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lua-libs@5.4.4-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/lz4-libs@1.9.3-5.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/microdnf@3.9.1-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/mpfr@4.1.0-7.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/ncurses-libs@6.2-10.20210508.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/nettle@3.9.1-1.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/npth@1.6-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openldap@2.6.6-3.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider@3.0.7-6.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-fips-provider-so@3.0.7-6.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/openssl-libs@3.2.2-6.el9_5.1?arch=x86_64&epoch=1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/p11-kit-trust@0.25.3-3.el9_5?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre@8.44-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2@10.40-6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/popt@1.18-8.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/readline@8.1-4.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/redhat-release@9.5-0.6.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rootfiles@8.1-31.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm@4.16.1.3-34.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/rpm-libs@4.16.1.3-34.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sed@4.8-9.el9?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/setup@2.13.7-10.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/shadow-utils@4.9-10.el9_5?arch=x86_64&epoch=2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/controller-runtime@v0.16.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/sqlite-libs@3.34.1-7.el9_3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/stdlib@1.22.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/systemd-libs@252-46.el9_5.3?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/tzdata@2025b-1.el9?arch=noarch",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/xz-libs@5.2.5-8.el9_0?arch=x86_64",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64",
+      "dependsOn": []
+    }
+  ],
+  "serialNumber": "urn:uuid:0615294c-50a0-40fc-b429-eb059db828c7"
+}

--- a/modules/analysis/src/endpoints/tests/latest_filters.rs
+++ b/modules/analysis/src/endpoints/tests/latest_filters.rs
@@ -58,7 +58,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     );
     let request: Request = TestRequest::get().uri(&uri).to_request();
     let response: Value = app.call_and_read_body_json(request).await;
-    assert_eq!(8, response["total"]);
+    assert_eq!(18, response["total"]);
 
     // purl partial search latest
     let uri: String = format!(
@@ -69,7 +69,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":6
+      "total":16
     })));
 
     // purl partial search latest
@@ -81,7 +81,7 @@ async fn resolve_rh_variant_latest_filter_container_cdx(
     let response: Value = app.call_and_read_body_json(request).await;
     log::warn!("{:?}", response.get("total"));
     assert!(response.contains_subset(json!({
-      "total":5
+      "total":7
     })));
     Ok(())
 }

--- a/modules/analysis/src/service/collector.rs
+++ b/modules/analysis/src/service/collector.rs
@@ -134,8 +134,9 @@ impl<'a, C: ConnectionTrait> Collector<'a, C> {
                 let Some(external_graph) = self.graph_cache.get(&external_sbom_id.to_string())
                 else {
                     log::warn!(
-                        "external sbom graph {:?} not found.",
-                        &external_sbom_id.to_string()
+                        "external sbom graph {:?} for {:?} not found during collection.",
+                        &external_sbom_id.to_string(),
+                        &external_node_id.to_string()
                     );
                     return None;
                 };

--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -196,43 +196,20 @@ async fn resolve_rh_external_sbom_descendants<C: ConnectionTrait>(
     {
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
-
-            // TODO: Resolution of external sbom is different between spdx/cdx so we need to have
-            //       slightly different heuristics - depending on if encoded from rh cdx or rh spdx.
-            //       no doubt there are probably better ways to achieve this then what we have here.
-            if sbom_external_node_ref.starts_with("SPDXRef") {
-                match sbom_node_checksum::Entity::find()
-                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                    .all(connection)
-                    .await
-                {
-                    Ok(matches) => matches
-                        .into_iter()
-                        .next() // just return the first
-                        .map(|matched_model| ResolvedSbom {
-                            sbom_id: matched_model.sbom_id,
-                            node_id: matched_model.node_id,
-                        }),
-                    _ => None,
-                }
-            } else {
-                match sbom_node_checksum::Entity::find()
-                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                    .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-                    .all(connection)
-                    .await
-                {
-                    Ok(matches) => matches
-                        .into_iter()
-                        .next() // just return the first
-                        .map(|matched_model| ResolvedSbom {
-                            sbom_id: matched_model.sbom_id,
-                            node_id: matched_model.node_id,
-                        }),
-                    _ => None,
-                }
+            match sbom_node_checksum::Entity::find()
+                .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                .all(connection)
+                .await
+            {
+                Ok(matches) => matches
+                    .into_iter()
+                    .next() // just return the first
+                    .map(|matched_model| ResolvedSbom {
+                        sbom_id: matched_model.sbom_id,
+                        node_id: matched_model.node_id,
+                    }),
+                _ => None,
             }
         }
         _ => None,
@@ -254,45 +231,20 @@ async fn resolve_rh_external_sbom_ancestors<C: ConnectionTrait>(
     {
         Ok(Some(entity)) => {
             // now find if there are any other nodes with the same checksums
-
-            // TODO: Resolution of external sbom is different between spdx/cdx so we need to have
-            //       slightly different heuristics - depending on if encoded from rh cdx or rh spdx.
-            //       no doubt there are probably better ways to achieve this then what we have here.
-            if sbom_external_node_ref.starts_with("SPDXRef") {
-                match sbom_node_checksum::Entity::find()
-                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                    .all(connection)
-                    .await
-                {
-                    Ok(matches) => matches
-                        .into_iter()
-                        .map(|matched| ResolvedSbom {
-                            sbom_id: matched.sbom_id,
-                            node_id: matched.node_id,
-                        })
-                        .collect(),
-
-                    _ => vec![],
-                }
-            } else {
-                match sbom_node_checksum::Entity::find()
-                    .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
-                    .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
-                    .filter(sbom_node_checksum::Column::NodeId.eq(sbom_external_node_ref.clone()))
-                    .all(connection)
-                    .await
-                {
-                    Ok(matches) => matches
-                        .into_iter()
-                        .map(|matched| ResolvedSbom {
-                            sbom_id: matched.sbom_id,
-                            node_id: matched.node_id,
-                        })
-                        .collect(),
-
-                    _ => vec![],
-                }
+            match sbom_node_checksum::Entity::find()
+                .filter(sbom_node_checksum::Column::Value.eq(entity.value.to_string()))
+                .filter(sbom_node_checksum::Column::SbomId.ne(entity.sbom_id))
+                .all(connection)
+                .await
+            {
+                Ok(matches) => matches
+                    .into_iter()
+                    .map(|matched| ResolvedSbom {
+                        sbom_id: matched.sbom_id,
+                        node_id: matched.node_id,
+                    })
+                    .collect(),
+                _ => vec![],
             }
         }
         _ => {


### PR DESCRIPTION
## Summary by Sourcery

Enable and test nested CycloneDX external SBOM resolution by unifying checksum matching logic and introducing recursive graph loading.

New Features:
- Support nested external SBOM resolution via recursive graph loading

Bug Fixes:
- Unify external SBOM checksum matching to remove SPDX/CycloneDX special cases

Enhancements:
- Refactor SBOM graph loader to recursive load_graphs_inner for nested external SBOMs
- Improve collector warning to include external node ID
- Update logging messages for SBOM loading

Tests:
- Update latest_filters test expectations for new totals
- Add new integration test for nested external SBOMs (TC-2677)