### PR TITLE
fix: Improve error handling within Quay Importer

### DIFF
--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -298,18 +298,13 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
     log::debug!("After: {analysis_graph:#?}");
 
     assert_root_traces(&analysis_graph.items, |traces| {
-        assert!(
-            matches!(
-                traces,
-                [
-                    [..],
-                    [
+        assert!(traces.contains(&[
                         Node {
                             id: "SPDXRef-e24fec28-1001-499c-827f-2e2e5f2671b5",
                             name: "quarkus-bom",
                             version: "3.2.12.Final-redhat-00002",
-                            cpes: ["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
-                            purls: [
+                            cpes: &["cpe:/a:redhat:quarkus:3.2:*:el8:*",],
+                            purls: &[
                                 "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@3.2.12.Final-redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
                             ],
                         },
@@ -317,10 +312,10 @@ async fn test_quarkus_analysis_service(ctx: &TrustifyContext) -> Result<(), anyh
                             id: "SPDXRef-DOCUMENT",
                             name: "quarkus-bom-3.2.12.Final-redhat-00002",
                             version: "",
-                            ..
+                            cpes: &[],
+                            purls: &[],
                         },
-                    ]
-                ]
+                    ].as_slice()
             ),
             "doesn't match: {traces:#?}"
         );

--- a/modules/importer/schema/importer.json
+++ b/modules/importer/schema/importer.json
@@ -533,6 +533,15 @@
               "type": "null"
             }
           ]
+        },
+        "concurrency": {
+          "description": "The maximum concurrent repository fetches",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
         }
       },
       "required": [

--- a/modules/importer/src/model/quay.rs
+++ b/modules/importer/src/model/quay.rs
@@ -33,6 +33,10 @@ pub struct QuayImporter {
     /// The max size of the ingested SBOM's (None is unlimited)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_limit: Option<BinaryByteSize>,
+
+    /// The maximum concurrent repository fetches
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<usize>,
 }
 
 pub const DEFAULT_SOURCE_QUAY: &str = "quay.io";

--- a/modules/importer/src/runner/quay/walker.rs
+++ b/modules/importer/src/runner/quay/walker.rs
@@ -5,7 +5,7 @@ use crate::runner::context::RunContext;
 use crate::runner::progress::{Progress, ProgressInstance};
 use crate::runner::quay::oci;
 use crate::runner::report::{Message, Phase, ReportBuilder};
-use futures::{StreamExt, TryStreamExt, future, stream};
+use futures::{Stream, StreamExt, TryStreamExt, future, stream};
 use reqwest::header;
 use serde::Deserialize;
 use std::{collections::HashMap, sync::Arc};
@@ -140,20 +140,22 @@ impl<C: RunContext> QuayWalker<C> {
     }
 
     async fn sboms(&self) -> Result<Vec<Reference>, Error> {
-        let tags: Vec<(Reference, u64)> =
-            stream::iter(self.repositories(Some(String::new())).await?)
-                .filter(|repo| {
-                    future::ready(repo.is_public && self.modified_since(repo.last_modified))
-                })
-                .map(|repo| self.repository(repo.namespace, repo.name))
-                .buffer_unordered(32) // TODO: make configurable
-                .filter_map(|repo| {
-                    future::ready(repo.unwrap_or_default().sboms(&self.importer.source))
-                })
-                .map(stream::iter)
-                .flatten()
-                .collect()
-                .await;
+        let repositories = self
+            .repositories(Some(String::new()))
+            .try_fold(vec![], |mut acc, repo| async move {
+                if repo.is_public && self.modified_since(repo.last_modified) {
+                    acc.push(self.repository(repo.namespace, repo.name));
+                }
+                Ok(acc)
+            })
+            .await?;
+        let tags: Vec<(Reference, u64)> = stream::iter(repositories)
+            .buffer_unordered(32) // TODO: make configurable
+            .filter_map(|repo| future::ready(repo.unwrap_or_default().sboms(&self.importer.source)))
+            .map(stream::iter)
+            .flatten()
+            .collect()
+            .await;
         Ok(tags
             .into_iter()
             .filter_map(|(reference, size)| {
@@ -166,7 +168,7 @@ impl<C: RunContext> QuayWalker<C> {
             .collect())
     }
 
-    async fn repositories(&self, page: Option<String>) -> Result<Vec<Repository>, Error> {
+    fn repositories(&self, page: Option<String>) -> impl Stream<Item = Result<Repository, Error>> {
         stream::try_unfold(page, async |state| match state {
             Some(page) => {
                 if self.context.is_canceled().await {
@@ -187,8 +189,6 @@ impl<C: RunContext> QuayWalker<C> {
             None => Ok(None),
         })
         .try_flatten()
-        .try_collect()
-        .await
     }
 
     async fn repository(&self, namespace: String, name: String) -> Result<Repository, Error> {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4738,6 +4738,12 @@ components:
             - string
             - 'null'
             description: The API token authorizing access to the quay registry
+          concurrency:
+            type:
+            - integer
+            - 'null'
+            description: The maximum concurrent repository fetches
+            minimum: 0
           namespace:
             type:
             - string

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -165,7 +165,7 @@ async fn add_quay(
             source: DEFAULT_SOURCE_QUAY.into(),
             namespace: Some(namespace.into()),
             size_limit: Some(ByteSize::mib(1).into()),
-            api_token: None,
+            ..Default::default()
         }),
     )
     .await

--- a/xtask/schema/generate-dump.json
+++ b/xtask/schema/generate-dump.json
@@ -547,6 +547,15 @@
               "type": "null"
             }
           ]
+        },
+        "concurrency": {
+          "description": "The maximum concurrent repository fetches",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
         }
       },
       "required": [


### PR DESCRIPTION
Fixes: #1892

Invalid sources will show a proper error.

Disabling importer runs will show a "canceled" message.

Errors occurring after the list of SBOM's to be fetched is created, e.g. an expired tag, could stop an importer run. This has been fixed, and any errors should be included in the report after the run completes.

## Summary by Sourcery

Improve error handling in the Quay importer by capturing non-fatal errors in the report, propagating cancellation and invalid source errors, and ensuring the run completes even when individual SBOM fetches or uploads fail.

Bug Fixes:
- Invalid import sources now return an immediate error.
- Importer cancellation returns a canceled error instead of silently breaking the loop.
- SBOM retrieval and upload failures are logged and included in the report without aborting the entire run.

Enhancements:
- Extract fetch and store logic into dedicated methods that handle and report errors gracefully.
- Refactor SBOM enumeration to use fallible streams with size validation and robust error propagation.
- Maintain a single OCI client instance in QuayWalker and introduce an SBOM struct to encapsulate reference and size.
- Remove unnecessary Default derives from Repository and Batch for stricter deserialization.

Tests:
- Add a test to verify error handling for invalid sources.
- Update existing size limit tests to align with new validation logic.