### PR TITLE
fix: 'analysis/latest/component/' with PURL key

### DIFF
--- a/modules/analysis/src/service/mod.rs
+++ b/modules/analysis/src/service/mod.rs
@@ -596,7 +596,9 @@ impl AnalysisService {
                 .is_some_and(|node| node.name.eq(component_name)),
             GraphQuery::Component(ComponentReference::Purl(purl)) => {
                 graph.node_weight(i).is_some_and(|node| match node {
-                    graph::Node::Package(package) => package.purl.contains(purl),
+                    graph::Node::Package(package) => package.purl.iter().any(|package_purl| {
+                        package_purl.to_string().starts_with(&purl.to_string())
+                    }),
                     _ => false,
                 })
             }


### PR DESCRIPTION
As reported in https://issues.redhat.com/browse/TC-2717, calling the `/api/v2/analysis/latest/component/{key}` with PURL value for `key` generates a `HTTP error 500: {"error":"Internal Server Error"}`.

The error is reported also in the server log as `ERROR trustify_module_analysis::error: Query Error: error returned from database: missing FROM-clause entry for table "sbom_node"`.

It turned out the `fn find<E>() -> Select<E>` function has an hardcoded part, i.e. `sbom_node.name,cpe.id ORDER BY sbom.published`, that relies upon having always some entities involved for the `find` method to work properly.
In the case of the PURL key, the generic used was `sbom_package_purl_ref::Entity`, without having `sbom_node::Entity` involved at all and so causing the `missing FROM-clause entry for table "sbom_node"` error.

Once fixed the query (and added the `test_tc2717` test to reproduce the issue), it turned out also the `filter` condition was too restrictive because based on the assumption that the provided PURL key represented a qualified PURL which is not always the case based on usage reported in the TC-2717 issue itself.
So I've added more condition to find the SBOMs to be loaded, letting the provided PURL key to eventually match the versioned PURL or the base one. This might not cover every use case but it's for sure improving the previous condition.

The next issue was related to this one: the graph nodes filter was simply checking for PURLs fully matching the provided PURL key and also in this case I've relaxed the check to work with partial matches, i.e. `starts_with`.

I've kept in a second commit a further "nice to have" refactoring: basically the source of the issue comes from the `find` method with generics while this won't work with every entity but with just the ones providing the table involved in the hardcoded rank evaluation.
Hence I've refactored the `find` method to make it safer to be used.


