### PR TITLE
perf(analysis): Parallelize graph query execution

### DIFF
--- a/modules/analysis/src/config.rs
+++ b/modules/analysis/src/config.rs
@@ -1,5 +1,16 @@
 use bytesize::ByteSize;
+use std::num::NonZeroUsize;
 use trustify_common::model::BinaryByteSize;
+
+fn parse_concurrency(s: &str) -> Result<NonZeroUsize, String> {
+    let value: usize = s.parse().map_err(|e| format!("Invalid number: {e}"))?;
+    NonZeroUsize::new(value).ok_or_else(|| "Concurrency must be greater than zero".to_string())
+}
+
+const DEFAULT_CONCURRENCY: NonZeroUsize = match NonZeroUsize::new(10) {
+    Some(val) => val,
+    None => panic!("Default concurrency must be non-zero integer"),
+};
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct AnalysisConfig {
@@ -11,12 +22,22 @@ pub struct AnalysisConfig {
         help = "Maximum size of the graph cache."
     )]
     pub max_cache_size: BinaryByteSize,
+
+    #[arg(
+        long,
+        env = "TRUSTIFY_ANALYSIS_CONCURRENCY",
+        default_value = "10",
+        value_parser = parse_concurrency,
+        help = "The number of concurrent tasks for analysis (must be > 0)."
+    )]
+    pub concurrency: NonZeroUsize,
 }
 
 impl Default for AnalysisConfig {
     fn default() -> Self {
         Self {
             max_cache_size: BinaryByteSize(ByteSize::mib(200)),
+            concurrency: DEFAULT_CONCURRENCY,
         }
     }
 }

--- a/modules/analysis/src/service/test.rs
+++ b/modules/analysis/src/service/test.rs
@@ -395,6 +395,7 @@ async fn test_cache_size_used(ctx: &TrustifyContext) -> Result<(), anyhow::Error
     let service = AnalysisService::new(
         AnalysisConfig {
             max_cache_size: BinaryByteSize::from(small_sbom_size * 2),
+            ..Default::default()
         },
         ctx.db.clone(),
     );


### PR DESCRIPTION
This commit significantly improves the performance of graph analysis by applying parallelization techniques to the run_graph_query and collect_graph functions.

  Previously, the collection of ancestors and descendants for a given node was performed sequentially. By refactoring run_graph_query to use futures::join!, we now process both directions concurrently, reducing the overall
  execution time.

  Building on this, the collect_graph function was optimized to process all discovered nodes in parallel using join_all. This ensures that we leverage available resources more efficiently when analyzing multiple entry points in
  the graph.

Assisted-by: Gemini

## Summary by Sourcery

Optimize graph analysis performance by refactoring query and collection routines to execute traversals and node processing in parallel using futures::join! and join_all.

Enhancements:
- Parallelize run_graph_query to concurrently collect ancestors and descendants using futures::join!
- Process all candidate nodes in collect_graph concurrently across graphs with join_all instead of sequential iteration
- Refactor DiscoveredTracker to use tokio::sync::Mutex and make visit asynchronous for non-blocking locking
- Modify collector.collect_graph to traverse edges in parallel with join_all and concurrent futures
- Update collect_graph signature to accept async closure factories for node creation