### PR TITLE
Extract DB logic to trustify-db, add read-only mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8324,7 +8324,6 @@ dependencies = [
  "native-tls",
  "packageurl",
  "pem",
- "postgresql_embedded",
  "rand 0.9.1",
  "regex",
  "reqwest",
@@ -8333,6 +8332,7 @@ dependencies = [
  "sbom-walker",
  "schemars 1.0.4",
  "sea-orm",
+ "sea-orm-migration",
  "sea-query",
  "serde",
  "serde_json",
@@ -8340,13 +8340,11 @@ dependencies = [
  "spdx-rs",
  "sqlx",
  "strum 0.27.1",
- "test-context",
  "test-log",
  "thiserror 2.0.12",
  "time",
  "tokio",
  "tracing",
- "trustify-migration",
  "trustify-test-context",
  "urlencoding",
  "utoipa",
@@ -8362,6 +8360,20 @@ dependencies = [
  "test-log",
  "tokio",
  "utoipa",
+]
+
+[[package]]
+name = "trustify-db"
+version = "0.3.5"
+dependencies = [
+ "anyhow",
+ "log",
+ "postgresql_embedded",
+ "sea-orm",
+ "sea-orm-migration",
+ "tracing",
+ "trustify-common",
+ "trustify-migration",
 ]
 
 [[package]]
@@ -8437,6 +8449,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "trustify-common",
+ "trustify-db",
  "trustify-entity",
  "trustify-test-context",
  "uuid",
@@ -8812,6 +8825,7 @@ dependencies = [
  "tokio",
  "trustify-auth",
  "trustify-common",
+ "trustify-db",
  "trustify-infrastructure",
  "trustify-module-analysis",
  "trustify-module-fundamental",
@@ -8857,6 +8871,7 @@ dependencies = [
  "tracing-subscriber",
  "trustify-auth",
  "trustify-common",
+ "trustify-db",
  "trustify-entity",
  "trustify-migration",
  "trustify-module-ingestor",
@@ -8880,6 +8895,7 @@ dependencies = [
  "temp-env",
  "tokio",
  "trustify-common",
+ "trustify-db",
  "trustify-infrastructure",
  "trustify-server",
 ]
@@ -9958,6 +9974,7 @@ dependencies = [
  "tracing-subscriber",
  "trustify-auth",
  "trustify-common",
+ "trustify-db",
  "trustify-module-importer",
  "trustify-module-storage",
  "trustify-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "common",
     "common/auth",
+    "common/db",
     "common/infrastructure",
     "cvss",
     "entity",
@@ -154,6 +155,7 @@ zip = "4"
 trustify-auth = { path = "common/auth", features = ["actix", "swagger"] }
 trustify-common = { path = "common" }
 trustify-cvss = { path = "cvss" }
+trustify-db = { path = "common/db" }
 trustify-entity = { path = "entity" }
 trustify-infrastructure = { path = "common/infrastructure" }
 trustify-migration = { path = "migration" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,8 +6,6 @@ publish.workspace = true
 license.workspace = true
 
 [dependencies]
-trustify-migration = { workspace = true }
-
 actix-web = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
@@ -25,13 +23,13 @@ log = { workspace = true }
 native-tls = { workspace = true }
 packageurl = { workspace = true }
 pem = { workspace = true }
-postgresql_embedded = { workspace = true, features = ["blocking", "tokio"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["native-tls"] }
 ring = { workspace = true }
 sbom-walker = { workspace = true }
 schemars = { workspace = true }
 sea-orm = { workspace = true, features = ["sea-query-binder", "sqlx-postgres", "runtime-tokio-rustls", "macros"] }
+sea-orm-migration = { workspace = true }
 sea-query = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -46,7 +44,7 @@ tracing = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["url"] }
 uuid = { workspace = true, features = ["v5", "serde"] }
-walker-common = { workspace = true, features = ["bzip2", "liblzma", "flate2"]}
+walker-common = { workspace = true, features = ["bzip2", "liblzma", "flate2"] }
 humantime = { workspace = true }
 
 [dev-dependencies]
@@ -54,7 +52,6 @@ chrono = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
-test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 time = { workspace = true, features = ["macros"] }
 tokio = { workspace = true, features = ["full"] }

--- a/common/db/Cargo.toml
+++ b/common/db/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trustify-db"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+trustify-migration = { workspace = true }
+trustify-common = { workspace = true }
+
+anyhow = { workspace = true }
+log = { workspace = true }
+postgresql_embedded = { workspace = true, features = ["blocking", "tokio"] }
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+tracing = { workspace = true }

--- a/common/db/src/embedded.rs
+++ b/common/db/src/embedded.rs
@@ -1,8 +1,8 @@
-use crate::db::Database;
 use anyhow::Context;
 use postgresql_embedded::{PostgreSQL, Settings, VersionReq};
 use std::path::Path;
 use tracing::{Instrument, info_span};
+use trustify_common::db::Database;
 
 /// Create common default settings for the embedded database
 fn default_settings() -> anyhow::Result<Settings> {
@@ -62,7 +62,7 @@ async fn create_for(settings: Settings) -> anyhow::Result<(Database, PostgreSQL)
         port: postgresql.settings().port,
         ..crate::config::Database::from_env()?
     };
-    let db = Database::bootstrap(&config)
+    let db = super::Database::bootstrap(&config)
         .await
         .context("Bootstrapping the test database")?;
 

--- a/common/db/src/lib.rs
+++ b/common/db/src/lib.rs
@@ -1,0 +1,67 @@
+pub mod embedded;
+
+use anyhow::ensure;
+use migration::Migrator;
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::prelude::MigratorTrait;
+use tracing::instrument;
+use trustify_common::{config, db};
+
+pub struct Database<'a>(pub &'a db::Database);
+
+impl<'a> Database<'a> {
+    #[instrument(skip(self), err)]
+    pub async fn migrate(&self) -> Result<(), anyhow::Error> {
+        log::debug!("applying migrations");
+        Migrator::up(self.0, None).await?;
+        log::debug!("applied migrations");
+
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    pub async fn refresh(&self) -> Result<(), anyhow::Error> {
+        log::warn!("refreshing database schema...");
+        Migrator::refresh(self.0).await?;
+        log::warn!("refreshing database schema... done!");
+
+        Ok(())
+    }
+
+    #[instrument(err)]
+    pub async fn bootstrap(database: &config::Database) -> Result<db::Database, anyhow::Error> {
+        ensure!(
+            database.url.is_none(),
+            "Unable to bootstrap database with '--db-url'"
+        );
+
+        let url = crate::config::Database {
+            name: "postgres".into(),
+            ..database.clone()
+        }
+        .to_url();
+
+        log::debug!("bootstrap to {}", url);
+        let db = sea_orm::Database::connect(url).await?;
+
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            format!("DROP DATABASE IF EXISTS \"{}\";", database.name),
+        ))
+        .await?;
+
+        db.execute(Statement::from_string(
+            db.get_database_backend(),
+            format!("CREATE DATABASE \"{}\";", database.name),
+        ))
+        .await?;
+        db.close().await?;
+
+        let db = db::Database::new(database).await?;
+        db.execute_unprepared("CREATE EXTENSION IF NOT EXISTS \"pg_stat_statements\";")
+            .await?;
+        Database(&db).migrate().await?;
+
+        Ok(db)
+    }
+}

--- a/common/src/db/func.rs
+++ b/common/src/db/func.rs
@@ -1,4 +1,4 @@
-use migration::Iden;
+use sea_orm::Iden;
 use sea_orm::{ConnectionTrait, DbErr, ExecResult};
 use sea_query::{Func, SelectStatement};
 use std::fmt::Write;

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { workspace = true, features = ["v5"] }
 
 [dev-dependencies]
 trustify-common = { workspace = true }
+trustify-db  = { workspace = true }
 trustify-entity = { workspace = true }
 trustify-test-context = { workspace = true }
 

--- a/migration/tests/tests.rs
+++ b/migration/tests/tests.rs
@@ -13,7 +13,7 @@ async fn test_migrations(ctx: TrustifyContext) -> Result<(), anyhow::Error> {
     // At this point we already have migrations.
     assert!(!migrations.is_empty());
 
-    db.refresh().await?;
+    trustify_db::Database(&db).refresh().await?;
 
     let rolled_back_and_reapplied_migrations = Migrator::get_applied_migrations(&db).await?;
     assert!(!rolled_back_and_reapplied_migrations.is_empty());

--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -11,7 +11,7 @@ use ::cpe::{
     cpe::{Cpe, CpeType, Language},
     uri::OwnedUri,
 };
-use anyhow::anyhow;
+use actix_http::StatusCode;
 use futures::FutureExt;
 use opentelemetry::KeyValue;
 use petgraph::{Graph, prelude::NodeIndex};
@@ -492,9 +492,11 @@ impl InnerService {
             return Ok(g);
         }
 
-        let distinct_sbom_id = Uuid::parse_str(distinct_sbom_id).map_err(|err| {
-            Error::Database(anyhow!("Unable to parse SBOM ID {distinct_sbom_id}: {err}"))
-        })?;
+        let distinct_sbom_id =
+            Uuid::parse_str(distinct_sbom_id).map_err(|err| Error::BadRequest {
+                msg: format!("Unable to parse SBOM ID {distinct_sbom_id}: {err}"),
+                status: StatusCode::BAD_REQUEST,
+            })?;
 
         // check if there is a loading operation pending
 

--- a/modules/ui/src/error.rs
+++ b/modules/ui/src/error.rs
@@ -37,6 +37,7 @@ impl actix_web::error::ResponseError for Error {
                 message: err.to_string(),
                 details: None,
             }),
+            Self::Ingestor(err) => err.error_response(),
             err => HttpResponse::InternalServerError().json(ErrorInformation {
                 error: "InternalServerError".into(),
                 message: err.to_string(),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,7 @@ graphql = ["trustify-module-graphql"]
 [dependencies]
 trustify-auth = { workspace = true }
 trustify-common = { workspace = true }
+trustify-db = { workspace = true }
 trustify-infrastructure = { workspace = true }
 trustify-module-analysis = { workspace = true }
 trustify-module-fundamental = { workspace = true }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -10,7 +10,7 @@ use utoipa::{
 use utoipa_actix_web::AppExt;
 
 pub async fn create_openapi() -> anyhow::Result<utoipa::openapi::OpenApi> {
-    let (db, postgresql) = db::embedded::create().await?;
+    let (db, postgresql) = trustify_db::embedded::create().await?;
     let (storage, _temp) = FileSystemBackend::for_test().await?;
     let analysis = AnalysisService::new(AnalysisConfig::default(), db.clone());
 

--- a/server/src/profile/api.rs
+++ b/server/src/profile/api.rs
@@ -245,7 +245,7 @@ impl InitData {
         let db = db::Database::new(&run.database).await?;
 
         if run.devmode {
-            db.migrate().await?;
+            trustify_db::Database(&db).migrate().await?;
         }
 
         if run.devmode || run.sample_data {

--- a/server/src/profile/mod.rs
+++ b/server/src/profile/mod.rs
@@ -37,7 +37,7 @@ mod test {
 
     #[test(tokio::test)]
     async fn timeout() {
-        let (db, postgresql) = db::embedded::create().await.expect("must create");
+        let (db, postgresql) = trustify_db::embedded::create().await.expect("must create");
 
         let check = spawn_db_check(db).expect("must create");
 

--- a/server/src/sample_data.rs
+++ b/server/src/sample_data.rs
@@ -24,7 +24,7 @@ async fn add(
         .create(name.into(), config)
         .await
         .or_else(|err| match err {
-            Error::AlreadyExists(_) => Ok(()),
+            Error::AlreadyExists => Ok(()),
             err => Err(err),
         })?)
 }

--- a/test-context/Cargo.toml
+++ b/test-context/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 trustify-auth = { workspace = true }
 trustify-common = { workspace = true }
+trustify-db = { workspace = true }
 trustify-entity = { workspace = true }
 trustify-migration = { workspace = true }
 trustify-module-ingestor = { workspace = true }

--- a/test-context/src/lib.rs
+++ b/test-context/src/lib.rs
@@ -210,7 +210,7 @@ impl AsyncTestContext for TrustifyContext {
                 env::var("EXTERNAL_TEST_DB_BOOTSTRAP").as_deref(),
                 Ok("1" | "true")
             ) {
-                db::Database::bootstrap(&config).await
+                trustify_db::Database::bootstrap(&config).await
             } else {
                 db::Database::new(&config).await
             }
@@ -219,7 +219,7 @@ impl AsyncTestContext for TrustifyContext {
             return TrustifyContext::new(db, None).await;
         }
 
-        let (db, postgresql) = db::embedded::create()
+        let (db, postgresql) = trustify_db::embedded::create()
             .await
             .expect("Create an embedded database");
 

--- a/trustd/Cargo.toml
+++ b/trustd/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 trustify-common = { workspace = true }
+trustify-db = { workspace = true }
 trustify-infrastructure = { workspace = true }
 trustify-server = { workspace = true }
 

--- a/trustd/src/db.rs
+++ b/trustd/src/db.rs
@@ -35,7 +35,7 @@ impl Run {
     }
 
     async fn create(self) -> anyhow::Result<ExitCode> {
-        match db::Database::bootstrap(&self.database).await {
+        match trustify_db::Database::bootstrap(&self.database).await {
             Ok(_) => Ok(ExitCode::SUCCESS),
             Err(e) => Err(e),
         }
@@ -43,7 +43,7 @@ impl Run {
     async fn refresh(self) -> anyhow::Result<ExitCode> {
         match db::Database::new(&self.database).await {
             Ok(db) => {
-                db.refresh().await?;
+                trustify_db::Database(&db).refresh().await?;
                 Ok(ExitCode::SUCCESS)
             }
             Err(e) => Err(e),
@@ -52,7 +52,7 @@ impl Run {
     async fn migrate(self) -> anyhow::Result<ExitCode> {
         match db::Database::new(&self.database).await {
             Ok(db) => {
-                db.migrate().await?;
+                trustify_db::Database(&db).migrate().await?;
                 Ok(ExitCode::SUCCESS)
             }
             Err(e) => Err(e),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "tracing-log"
 
 trustify-auth = { workspace = true }
 trustify-common = { workspace = true }
+trustify-db = { workspace = true }
 trustify-module-importer = { workspace = true }
 trustify-module-storage = { workspace = true }
 trustify-server = { workspace = true }

--- a/xtask/src/dataset.rs
+++ b/xtask/src/dataset.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use postgresql_commands::{CommandBuilder, CommandExecutor, pg_dump::PgDumpBuilder};
 use serde_json::Value;
 use std::{io::BufReader, path::PathBuf, time::Duration};
-use trustify_common::{db, model::BinaryByteSize};
+use trustify_common::model::BinaryByteSize;
 use trustify_module_importer::{
     model::{CommonImporter, CsafImporter, CveImporter, ImporterConfiguration, SbomImporter},
     runner::{
@@ -83,8 +83,8 @@ impl GenerateDump {
 
     pub async fn run(self) -> anyhow::Result<()> {
         let (db, postgres) = match &self.working_dir {
-            Some(wd) => db::embedded::create_in(wd.join("db")).await?,
-            None => db::embedded::create().await?,
+            Some(wd) => trustify_db::embedded::create_in(wd.join("db")).await?,
+            None => trustify_db::embedded::create().await?,
         };
 
         let (storage, _tmp) = match &self.working_dir {


### PR DESCRIPTION
## Summary by Sourcery

Improve database handling by extracting migration/bootstrap logic into a new trustify-db crate, adding a read-only mode to test contexts, classifying read-only errors, and updating services to return 503 for unavailable database operations

New Features:
- Add read-only database mode to TrustifyContext with automatic connection termination and verification
- Provide ReadOnly<T> wrapper for running integration tests against a read-only database

Enhancements:
- Introduce trustify-db crate to centralize database bootstrap, migration and refresh operations
- Implement DatabaseErrors trait for classifying duplicate-key and read-only errors
- Refactor service error handling to map read-only errors to Unavailable and return 503 Service Unavailable responses
- Unify and simplify HTTP error names and logging levels across modules

Chores:
- Update workspace Cargo.toml files and module dependencies to include trustify-db and adjust database crate references
- Replace direct db::Database calls with trustify_db::Database across commands and embedded setups