### PR TITLE
fix: partition latest query groups by sbom id when cpes are not available

### DIFF
--- a/modules/analysis/src/service/load.rs
+++ b/modules/analysis/src/service/load.rs
@@ -347,8 +347,7 @@ impl InnerService {
         }
 
         fn find(sbom_package_relation: sbom_node::Relation) -> Select<sbom_node::Entity> {
-            const RANK_SQL: &str =
-                "RANK() OVER (PARTITION BY sbom_node.name,cpe.id ORDER BY sbom.published DESC)";
+            const RANK_SQL: &str = "RANK() OVER (PARTITION BY sbom_node.name, COALESCE(cpe.id, sbom.sbom_id) ORDER BY sbom.published DESC)";
 
             sbom_node::Entity::find()
                 .select_only()


### PR DESCRIPTION
Just one observation by looking at some examples is that SBOMs get "missed" in the latest query when there are multiple ones without CPEs defined. The partition in the query will rank them all as a single group. The change in this draft PR is not a fix, but just a start of the discussion.

## Summary by Sourcery

Bug Fixes:
- Partition latest SBOM query results by SBOM ID when CPE ID is unavailable