### PR TITLE
chore: some alerts for http related metrics

### DIFF
--- a/etc/deploy/compose/compose-otel.yaml
+++ b/etc/deploy/compose/compose-otel.yaml
@@ -1,8 +1,10 @@
 services:
   prometheus:
     image: prom/prometheus:v3.1.0
+    volumes:
+      - ./prometheus/:/etc/prometheus/:z
     command:
-      - --config.file=/etc/prometheus/prometheus.yml
+      - --config.file=/etc/prometheus/prometheus.yaml
       - --web.enable-otlp-receiver
     ports:
       - "9090:9090"

--- a/etc/deploy/compose/prometheus/alerts.yaml
+++ b/etc/deploy/compose/prometheus/alerts.yaml
@@ -1,0 +1,59 @@
+groups:
+- name: http_api_alerts
+  # API success rate (only 2xx and 3xx are considered successful)
+  rules:
+  - alert: APILowSuccessRate
+    expr: |
+      (
+        sum(rate(http_server_duration_seconds_count{job="trustify", http_response_status_code=~"2..|3.."}[10m]))
+        /
+        sum(rate(http_server_duration_seconds_count{job="trustify"}[10m]))
+      ) < 0.99
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      message: "API success rate dropped below 99% in the last 10 minutes"
+  # High 5xx error rate
+  - alert: ApiHigh5xxErrorRate
+    expr: |
+      (
+        sum(rate(http_server_duration_seconds_count{job="trustify", http_response_status_code=~"5.."}[5m]))
+        /
+        sum(rate(http_server_duration_seconds_count{job="trustify"}[5m]))
+      ) > 0.05
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      message: "More than 5% of requests returned 5xx server errors in the last 5 minutes."
+  # High 4xx error rate
+  - alert: ApiHigh4xxErrorRate
+    expr: |
+      (
+        sum(rate(http_server_duration_seconds_count{job="trustify", http_response_status_code=~"4.."}[5m]))
+        /
+        sum(rate(http_server_duration_seconds_count{job="trustify"}[5m]))
+      ) > 0.10
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      message: "More than 10% of requests returned 4xx client errors in the last 5 minutes."
+  # High p95 latency
+  - alert: ApiHighLatencyP95
+    expr: histogram_quantile(0.95, sum(rate(http_server_duration_seconds_bucket{job="trustify"}[5m])) by (le)) > 0.5
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      message: "API p95 latency is higher than 500ms over the last 5 minutes."
+  # High p99 latency
+  - alert: ApiHighLatencyP99
+    expr: histogram_quantile(0.99, sum(rate(http_server_duration_seconds_bucket{job="trustify"}[5m])) by (le)) > 1
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      message: "API p99 latency is higher than 1s over the last 5 minutes."
+

--- a/etc/deploy/compose/prometheus/prometheus.yaml
+++ b/etc/deploy/compose/prometheus/prometheus.yaml
@@ -1,0 +1,3 @@
+rule_files:
+  - alerts.yaml
+


### PR DESCRIPTION
## Summary by Sourcery

Add HTTP-related Prometheus alerts and update Docker Compose to load the new rules

New Features:
- Introduce Prometheus alert rules for API success rate, 4xx/5xx error rates, and p95/p99 latency

Enhancements:
- Rename Prometheus config file from prometheus.yml to prometheus.yaml and mount the config directory in Docker Compose

Deployment:
- Configure Prometheus to load alerts.yaml via rule_files and include it in the Compose setup