### PR TITLE
fix(bench): Make benchmark document titles unique

### DIFF
--- a/modules/fundamental/benches/common.rs
+++ b/modules/fundamental/benches/common.rs
@@ -13,6 +13,7 @@ use csaf::vulnerability::Vulnerability;
 use packageurl::PackageUrl;
 use std::io::Error;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use std::str::FromStr;
 
@@ -97,6 +98,10 @@ pub async fn document_generated_from(path: &str, rev: u64) -> Result<Bytes, Erro
             rev_vulnerability(vulnerability, rev);
         }
     }
+
+    //NOTE: Generating a random title to make the bench pass avoiding `document vanished` error.
+    let uuid = Uuid::new_v4();
+    doc.document.title = format!("random_title-{rev}-{uuid}");
 
     let data = serde_json::to_vec_pretty(&doc).expect("serialize ok");
     Ok(Bytes::from(data))


### PR DESCRIPTION
`cargo bench --bench bench` and `cargo bench --bench bench-otel` 
fixes https://github.com/trustification/trustify/issues/1497

<img width="702" height="672" alt="2025-08-19_12-35" src="https://github.com/user-attachments/assets/afe8f578-1b1b-426d-9480-798c916d1243" />

## Summary by Sourcery

Bug Fixes:
- Assign a random UUID-based title in benches/common to avoid document collision errors during Criterion benchmarking