### PR TITLE
feat: delete raw docs from storage when advisory/sbom is deleted

### DIFF
--- a/modules/fundamental/src/advisory/endpoints/mod.rs
+++ b/modules/fundamental/src/advisory/endpoints/mod.rs
@@ -145,6 +145,7 @@ pub async fn get(
 #[delete("/v2/advisory/{key}")]
 /// Delete an advisory
 pub async fn delete(
+    ingestor: web::Data<IngestorService>,
     state: web::Data<AdvisoryService>,
     db: web::Data<Database>,
     purl_service: web::Data<PurlService>,
@@ -163,6 +164,10 @@ pub async fn delete(
             1 => {
                 let _ = purl_service.gc_purls(&tx).await; // ignore gc failure..
                 tx.commit().await?;
+                if let Some(doc) = &fetched.source_document {
+                    let k = doc.try_into()?;
+                    ingestor.storage().delete(k).await.map_err(Error::Storage)?;
+                }
                 Ok(HttpResponse::Ok().json(fetched))
             }
             _ => Err(Error::Internal("Unexpected number of rows affected".into())),
@@ -260,9 +265,7 @@ pub async fn download(
 
     if let Some(doc) = &advisory.source_document {
         let stream = ingestor
-            .get_ref()
             .storage()
-            .clone()
             .retrieve(doc.try_into()?)
             .await
             .map_err(Error::Storage)?

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -316,6 +316,7 @@ all!(GetSbomAdvisories -> ReadSbom, ReadAdvisory);
 )]
 #[delete("/v2/sbom/{id}")]
 pub async fn delete(
+    ingestor: web::Data<IngestorService>,
     service: web::Data<SbomService>,
     db: web::Data<Database>,
     purl_service: web::Data<PurlService>,
@@ -333,6 +334,10 @@ pub async fn delete(
                 1 => {
                     let _ = purl_service.gc_purls(&tx).await; // ignore gc failure..
                     tx.commit().await?;
+                    if let Some(doc) = &v.source_document {
+                        let k = doc.try_into()?;
+                        ingestor.storage().delete(k).await.map_err(Error::Storage)?;
+                    }
                     Ok(HttpResponse::Ok().json(v))
                 }
                 _ => Err(Internal("Unexpected number of rows affected".into())),
@@ -514,7 +519,6 @@ pub async fn download(
 
         let stream = ingestor
             .storage()
-            .clone()
             .retrieve(storage_key)
             .await
             .map_err(Error::Storage)?


### PR DESCRIPTION
Fixes: #1936

If the commit of the database transaction deleting either an advisory or an sbom succeeds, we attempt to delete the raw doc from storage. If that fails, an error will be logged and returned to the user.

The risk of leaving an orphan doc in storage was deemed acceptable relative to the risk of leaving the database in an inconsistent state by deleting the doc from storage prior to commiting the transaction.